### PR TITLE
feat: add Codecov coverage reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,15 @@ jobs:
           grep -q "SECURITY GUARDRAILS" chatgpt_instructions.md && echo "✓ ChatGPT audit guardrails exist" || (echo "✗ ChatGPT audit guardrails missing" && exit 1)
           echo "All @AIAudit content verified ✓"
 
+      - name: Upload coverage to Codecov
+        if: matrix.java == '21'
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: vibetags/target/site/jacoco/jacoco.xml
+          flags: unittests
+          fail_ci_if_error: true
+
   build-gradle:
     name: Gradle Build (JDK ${{ matrix.java }})
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/PIsberg/vibetags/badge)](https://securityscorecards.dev/viewer/?uri=github.com/PIsberg/vibetags)
+[![codecov](https://codecov.io/gh/PIsberg/vibetags/branch/main/graph/badge.svg)](https://codecov.io/gh/PIsberg/vibetags)
 
 **VibeTags** is a Java annotation processor that acts as AI guardrails for code generation tools like Cursor, Claude, Gemini, and ChatGPT. It allows developers to control AI behavior through simple annotations, protecting critical code and guiding AI implementations.
 

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java-library'
     id 'maven-publish'
+    id 'jacoco'
 }
 
 publishing {
@@ -39,4 +40,12 @@ tasks.withType(JavaCompile) {
 
 test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+    }
 }

--- a/vibetags/pom.xml
+++ b/vibetags/pom.xml
@@ -40,6 +40,25 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.5</version>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.11</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
- Add JaCoCo plugin to pom.xml (prepare-agent + report goals)
- Add jacoco plugin + jacocoTestReport task to build.gradle
- Upload jacoco.xml to Codecov in the Maven JDK 21 build only
- Add Codecov badge to README

Requires CODECOV_TOKEN secret to be set in the repository settings.