### PR TITLE
feat: add .bak file backup mechanism and improve content preservation

### DIFF
--- a/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
@@ -894,8 +894,13 @@ public class AIGuardrailProcessor extends AbstractProcessor {
                     int start = existing.indexOf(markerStart);
                     int end = existing.indexOf(markerEnd);
                     if (end == -1) {
-                        messager.printMessage(Diagnostic.Kind.WARNING, "VibeTags: malformed markers in " + path + " (no end marker). Overwriting completely.");
-                        Files.writeString(filePath, (frontMatter.isEmpty() ? "" : frontMatter + "\n\n") + wrappedBody + "\n", java.nio.charset.StandardCharsets.UTF_8);
+                        messager.printMessage(Diagnostic.Kind.WARNING, "VibeTags: malformed markers in " + path + " (no end marker). Preserving content before start marker.");
+                        String before = existing.substring(0, start).stripTrailing();
+                        String finalContent = (!before.isEmpty() ? before + "\n\n" : "") + wrappedBody + "\n";
+                        if (existing.strip().equals(finalContent.strip())) {
+                            return false;
+                        }
+                        writeContentWithBackup(filePath, finalContent);
                         return true;
                     }
                     end += markerEnd.length();
@@ -911,7 +916,7 @@ public class AIGuardrailProcessor extends AbstractProcessor {
                     if (existing.strip().equals(finalContent.strip())) {
                         return false;
                     }
-                    Files.writeString(filePath, finalContent, java.nio.charset.StandardCharsets.UTF_8);
+                    writeContentWithBackup(filePath, finalContent);
                     getSafeMessager().printMessage(Diagnostic.Kind.NOTE, "VibeTags: Updated " + fileName);
                     System.out.println("VibeTags: Updated " + fileName);
                     return true;
@@ -921,7 +926,7 @@ public class AIGuardrailProcessor extends AbstractProcessor {
                     if (existing.strip().equals(finalContent.strip())) {
                         return false;
                     }
-                    Files.writeString(filePath, finalContent, java.nio.charset.StandardCharsets.UTF_8);
+                    writeContentWithBackup(filePath, finalContent);
                     getSafeMessager().printMessage(Diagnostic.Kind.NOTE, "VibeTags: Updated legacy file " + fileName);
                     System.out.println("VibeTags: Updated legacy file " + fileName);
                     return true;
@@ -930,7 +935,10 @@ public class AIGuardrailProcessor extends AbstractProcessor {
                     String updated = existing.isEmpty()
                         ? (frontMatter.isEmpty() ? "" : frontMatter + "\n\n") + wrappedBody + "\n"
                         : existing.stripTrailing() + "\n\n" + wrappedBody + "\n";
-                    Files.writeString(filePath, updated, java.nio.charset.StandardCharsets.UTF_8);
+                    if (existing.strip().equals(updated.strip())) {
+                        return false;
+                    }
+                    writeContentWithBackup(filePath, updated);
                     String action = existing.isEmpty() ? "wrote" : "appended";
                     getSafeMessager().printMessage(Diagnostic.Kind.NOTE, "VibeTags: " + action + " " + fileName);
                     System.out.println("VibeTags: " + action + " " + fileName);
@@ -941,7 +949,7 @@ public class AIGuardrailProcessor extends AbstractProcessor {
                 if (existing.strip().equals(content.strip())) {
                     return false;
                 }
-                Files.writeString(filePath, content, java.nio.charset.StandardCharsets.UTF_8);
+                writeContentWithBackup(filePath, content);
                 getSafeMessager().printMessage(Diagnostic.Kind.NOTE, "VibeTags: Updated " + fileName);
                 System.out.println("VibeTags: Updated " + fileName);
                 return true;
@@ -950,5 +958,13 @@ public class AIGuardrailProcessor extends AbstractProcessor {
             getSafeMessager().printMessage(Diagnostic.Kind.WARNING, "VibeTags: Failed to write AI rules file: " + path + " - " + e.getMessage());
             return false;
         }
+    }
+
+    private void writeContentWithBackup(Path filePath, String finalContent) throws IOException {
+        if (Files.exists(filePath)) {
+            Path backupPath = Paths.get(filePath.toString() + ".bak");
+            Files.copy(filePath, backupPath, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        }
+        Files.writeString(filePath, finalContent, java.nio.charset.StandardCharsets.UTF_8);
     }
 }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/AIGuardrailProcessorUnitTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/AIGuardrailProcessorUnitTest.java
@@ -299,6 +299,51 @@ class AIGuardrailProcessorUnitTest {
     }
 
     @Test
+    void testWriteFileIfChanged_createsBackup_whenFileModified(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("test.md");
+        Files.writeString(file, "<!-- VIBETAGS-START -->\nold content\n<!-- VIBETAGS-END -->");
+        Path backupFile = tempDir.resolve("test.md.bak");
+
+        AIGuardrailProcessor processor = new AIGuardrailProcessor();
+        boolean changed = processor.writeFileIfChanged(file.toString(), "new content");
+
+        assertTrue(changed);
+        assertTrue(Files.exists(backupFile), "Backup file should be created");
+        assertTrue(Files.readString(backupFile).contains("old content"), "Backup should contain original content");
+    }
+
+    @Test
+    void testWriteFileIfChanged_doesNotCreateBackup_whenContentIdentical(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("test.md");
+        String content = "<!-- VIBETAGS-START -->\nsame content\n<!-- VIBETAGS-END -->\n";
+        Files.writeString(file, content);
+        Path backupFile = tempDir.resolve("test.md.bak");
+
+        AIGuardrailProcessor processor = new AIGuardrailProcessor();
+        boolean changed = processor.writeFileIfChanged(file.toString(), "same content");
+
+        assertFalse(changed);
+        assertFalse(Files.exists(backupFile), "Backup file should not be created if no changes were made");
+    }
+
+    @Test
+    void testWriteFileIfChanged_preservesContentBeforeMissingEndMarker(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("test.md");
+        Files.writeString(file, "Before start marker\n<!-- VIBETAGS-START -->\nold content missing end marker");
+
+        AIGuardrailProcessor processor = new AIGuardrailProcessor();
+        boolean changed = processor.writeFileIfChanged(file.toString(), "new content");
+
+        assertTrue(changed);
+        String content = Files.readString(file);
+        assertTrue(content.contains("Before start marker"));
+        assertTrue(content.contains("<!-- VIBETAGS-START -->"));
+        assertTrue(content.contains("new content"));
+        assertTrue(content.contains("<!-- VIBETAGS-END -->"));
+        assertFalse(content.contains("old content missing end marker")); // this is inside/after the start marker and gets replaced.
+    }
+
+    @Test
     void testWriteFileIfChanged_stripsWhitespaceForComparison(@TempDir Path tempDir) throws IOException {
         Path file = tempDir.resolve("test.md");
         // File has markers and content as it would be written by the processor


### PR DESCRIPTION
- Implemented automatic .bak file creation before AIGuardrailProcessor modifies existing config files to prevent accidental data loss.
- Fixed an issue where a missing end marker would cause the processor to completely overwrite the file, now properly preserving manually added content before the start marker.
- Added comprehensive unit tests to verify backup generation, skip logic for identical content, and text preservation for malformed marker regions.