### PR TITLE
chore: release v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-04-17
+
+### Fixed
+- **Granular directory path resolution**: Removed spurious trailing slash from `.cursor/rules/`, `.roo/rules/`, and `.trae/rules/` paths in `buildServiceFileMap`, which prevented directory opt-in detection on some file systems.
+
+### Changed
+- `cleanupGranularDirectory` is now package-private to allow direct unit testing without going through a full compilation round.
+
+### Tests
+- Added `testPackageKind_GranularRules`: verifies that a `PACKAGE`-kind element annotated with `@AILocked` produces a correctly-scoped `.mdc` file (glob `**/pkg/**/*.java`) in the Cursor granular rules directory.
+- Added `testCleanupGranularDirectory_NonExistent` and `testCleanupGranularDirectory_IOException`: cover the early-return guard and file-as-directory edge case in `cleanupGranularDirectory`.
+- Added `testWriteFileIfChanged_IOException`: exercises the read-only file path through `writeFileIfChanged`.
+- Added `testMessager_MiscellaneousOverloads`: covers the three extra `printMessage` overloads on the inner `Messager` proxy.
+- Added `testOptions_ComplexPaths`: verifies `init()` accepts a custom root path, project name, and log path without crashing.
+- Added `forRootInvalidLevel_fallbacksToInfo` and `forRootPathIsDirectory_triggersCatchAndReturnsStandardLogger` to `VibeTagsLoggerUnitTest` for logger error-handling branches.
+- Added `@AfterEach VibeTagsLogger.shutdown()` teardown to prevent logger state leaking between tests.
+
 ## [0.5.2] - 2026-04-16
 
 ### Fixed
@@ -55,7 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v0.5.3...HEAD
+[0.5.3]: https://github.com/PIsberg/vibetags/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/PIsberg/vibetags/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/PIsberg/vibetags/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/PIsberg/vibetags/releases/tag/v0.5.0

--- a/README.md
+++ b/README.md
@@ -82,15 +82,15 @@ Add VibeTags as a compile-time dependency. The annotation processor is automatic
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>0.5.2</version>
+    <version>0.5.3</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:0.5.2'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:0.5.2'
+compileOnly 'se.deversity.vibetags:vibetags-processor:0.5.3'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:0.5.3'
 ```
 
 ### Option 1: Using Maven

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -17,8 +17,8 @@ repositories {
 
 dependencies {
     // VibeTags Annotation Processor
-    compileOnly 'se.deversity.vibetags:vibetags-processor:0.5.2'
-    annotationProcessor 'se.deversity.vibetags:vibetags-processor:0.5.2'
+    compileOnly 'se.deversity.vibetags:vibetags-processor:0.5.3'
+    annotationProcessor 'se.deversity.vibetags:vibetags-processor:0.5.3'
 }
 
 tasks.withType(JavaCompile) {

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.version>0.5.2</vibetags.version>
+        <vibetags.version>0.5.3</vibetags.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
     </properties>
 

--- a/load-tests/pom.xml
+++ b/load-tests/pom.xml
@@ -36,7 +36,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
         <jmh.version>1.37</jmh.version>
-        <processor.version>0.5.2</processor.version>
+        <processor.version>0.5.3</processor.version>
     </properties>
 
     <dependencies>

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '0.5.2'
+version = '0.5.3'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '0.5.2'
+            version = '0.5.3'
             from components.java
 
             pom {

--- a/vibetags/pom.xml
+++ b/vibetags/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>0.5.2</version>
+    <version>0.5.3</version>
     <packaging>jar</packaging>
 
     <name>VibeTags Processor</name>

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
@@ -45,7 +45,7 @@ public class AIGuardrailProcessor extends AbstractProcessor {
     public AIGuardrailProcessor() {}
 
     
-    static final String VERSION = "0.5.2";
+    static final String VERSION = "0.5.3";
     private static final String GITHUB_URL = "https://github.com/PIsberg/vibetags";
 
     /** Header written into every generated file — no version so bumping the dep never creates spurious diffs. */


### PR DESCRIPTION
## Summary
- Bump version to 0.5.3 across all modules (`vibetags/`, `example/`, `load-tests/`, `README.md`)
- Update `CHANGELOG.md` with v0.5.3 release notes
- Fix granular directory path resolution (trailing slash removed from `.cursor/rules`, `.roo/rules`, `.trae/rules`)
- Improve test coverage: 7 new unit tests, `@AfterEach` teardown, `AIContext` import

## Test plan
- [x] 240/240 tests pass locally (`mvn test`)
- [x] All version strings updated to 0.5.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)