### PR TITLE
chore: release v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-04-19
+
+### Fixed
+- **Qualified field/method paths in all generated output**: `element.toString()` for `FIELD` and `METHOD` elements returned only the simple name (e.g. `username`, `validateToken(java.lang.String)`), making PII guardrails, locked-method entries, and draft tasks ambiguous across the entire codebase. A new `elementPath()` helper now prepends the enclosing type's FQN (e.g. `com.example.database.DatabaseConnector.username`). Falls back to `element.toString()` when no enclosing element is present (test mocks, package elements).
+- **Duplicate draft/task entries eliminated**: Methods annotated with `@AIDraft` on both an interface and its implementation (e.g. `executePayment(double)` on `PaymentStrategy` and `CreditCardStrategy`) previously produced identical lines in the generated files. With full class qualification each entry is now distinct.
+- **Granular rule files recreated on every build**: `cleanupGranularDirectory` ran before writing the new granular files. Files containing only VibeTags markers had empty before/after content and were treated as deletable boilerplate, then immediately re-created by `writeFileIfChanged`. Cleanup now runs after writing, and only removes files whose owning class is no longer annotated.
+- **Spurious `System.out.println` output**: Processor emitted raw stdout lines during every compilation round. All diagnostic output is now routed through `Messager` (for compiler output) and `VibeTagsLogger` (for the file log).
+
+### Changed
+- `llms.txt` link text for FIELD/METHOD elements now uses the compact `EnclosingClass.member` format instead of the bare simple name, matching the fully-qualified path used as the link target.
+
 ## [0.5.3] - 2026-04-17
 
 ### Fixed
@@ -72,7 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v0.5.3...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v0.5.4...HEAD
+[0.5.4]: https://github.com/PIsberg/vibetags/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/PIsberg/vibetags/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/PIsberg/vibetags/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/PIsberg/vibetags/compare/v0.5.0...v0.5.1

--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ Add VibeTags as a compile-time dependency. The annotation processor is automatic
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>0.5.3</version>
+    <version>0.5.4</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:0.5.3'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:0.5.3'
+compileOnly 'se.deversity.vibetags:vibetags-processor:0.5.4'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:0.5.4'
 ```
 
 ### Option 1: Using Maven

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -17,8 +17,8 @@ repositories {
 
 dependencies {
     // VibeTags Annotation Processor
-    compileOnly 'se.deversity.vibetags:vibetags-processor:0.5.3'
-    annotationProcessor 'se.deversity.vibetags:vibetags-processor:0.5.3'
+    compileOnly 'se.deversity.vibetags:vibetags-processor:0.5.4'
+    annotationProcessor 'se.deversity.vibetags:vibetags-processor:0.5.4'
 }
 
 tasks.withType(JavaCompile) {

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.version>0.5.3</vibetags.version>
+        <vibetags.version>0.5.4</vibetags.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
     </properties>
 

--- a/load-tests/pom.xml
+++ b/load-tests/pom.xml
@@ -36,7 +36,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
         <jmh.version>1.37</jmh.version>
-        <processor.version>0.5.3</processor.version>
+        <processor.version>0.5.4</processor.version>
     </properties>
 
     <dependencies>

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '0.5.3'
+version = '0.5.4'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '0.5.3'
+            version = '0.5.4'
             from components.java
 
             pom {

--- a/vibetags/pom.xml
+++ b/vibetags/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>0.5.3</version>
+    <version>0.5.4</version>
     <packaging>jar</packaging>
 
     <name>VibeTags Processor</name>

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
@@ -45,7 +45,7 @@ public class AIGuardrailProcessor extends AbstractProcessor {
     public AIGuardrailProcessor() {}
 
     
-    static final String VERSION = "0.5.3";
+    static final String VERSION = "0.5.4";
     private static final String GITHUB_URL = "https://github.com/PIsberg/vibetags";
 
     /** Header written into every generated file — no version so bumping the dep never creates spurious diffs. */


### PR DESCRIPTION
Bump version from 0.5.3 to 0.5.4 across all build files and update CHANGELOG with the four fixes shipped in this patch:
- Qualified field/method element paths in all generated output
- Duplicate draft entries eliminated via class qualification
- Granular rule files no longer deleted/recreated on every build
- Spurious System.out.println output removed from processor