### PR TITLE
chore: release v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5] - 2026-05-02
+
+### Security
+- Bumped `step-security/harden-runner` from 2.18.0 to 2.19.0
+
 ## [0.5.4] - 2026-04-19
 
 ### Fixed
@@ -83,7 +88,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v0.5.4...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v0.5.5...HEAD
+[0.5.5]: https://github.com/PIsberg/vibetags/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/PIsberg/vibetags/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/PIsberg/vibetags/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/PIsberg/vibetags/compare/v0.5.1...v0.5.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,10 +53,10 @@ gradle clean build    # Gradle
 
 `AIGuardrailProcessor.process()` runs during `javac` compilation of the **consumer** project (not the library itself — the library disables annotation processing with `-proc:none`):
 
-1. Collects all `@AILocked`, `@AIContext`, `@AIDraft`, `@AIAudit`, `@AIIgnore`, `@AIPrivacy` elements from the round environment
-2. Accumulates content into `StringBuilder`s (one per output format)
-3. Calls `resolveActiveServices()` — only files that already exist on disk are regenerated (file presence = opt-in)
-4. Writes to `Paths.get("").toAbsolutePath()` (project root of the consumer)
+1. Collects all annotation elements across **all compilation rounds** into `LinkedHashSet`s (one per annotation type)
+2. Returns `false` from `process()` so other processors can still see the annotations
+3. On `processingOver() == true`, calls `resolveActiveServices()` — only files that already exist on disk are regenerated (file presence = opt-in)
+4. Writes to `Paths.get("").toAbsolutePath()` (project root of the consumer), or to `vibetags.root` if set
 
 ### File-existence opt-in
 
@@ -69,19 +69,44 @@ mvn compile
 
 To deactivate, delete the file — it will never come back.
 
+### Marker-based updates
+
+Generated content is written between markers so the file can contain hand-authored content alongside generated guardrails:
+
+- **HTML comments** (CLAUDE.md, llms.txt, llms-full.txt): `<!-- VIBETAGS-START -->` / `<!-- VIBETAGS-END -->`
+- **Hash comments** (.cursorrules, .aiexclude, ignore files): `# VIBETAGS-START` / `# VIBETAGS-END`
+- **No markers** (JSON/TOML config files): complete overwrite of the file
+
+YAML front-matter in `.mdc` and `.md` files (Cursor, Trae, Roo granular rules) is preserved — markers are placed after the front-matter block.
+
+Files written by an older version of VibeTags (without markers) are automatically migrated to the marker format on the next compile.
+
 ### Output files
 
 | File | Platform | Format |
 |---|---|---|
 | `.cursorrules` | Cursor IDE | Markdown |
+| `.cursor/rules/*.mdc` | Cursor IDE (granular) | YAML front-matter + Markdown |
 | `CLAUDE.md` | Claude | XML + Markdown |
 | `.aiexclude` | Gemini | Glob patterns |
 | `AGENTS.md` | Codex CLI | Markdown |
 | `.codex/` | Codex CLI | Config + Starlark |
 | `gemini_instructions.md` | Gemini | Markdown |
 | `.github/copilot-instructions.md` | GitHub Copilot | Markdown |
+| `CONVENTIONS.md` | Aider | Markdown |
+| `.aiderignore` | Aider | Glob patterns |
+| `QWEN.md` | Qwen | Markdown |
+| `.qwenignore` | Qwen | Glob patterns |
+| `.qwen/settings.json` | Qwen | JSON config |
+| `.qwen/commands/refactor.md` | Qwen | Markdown command template |
+| `.trae/rules/*.md` | Trae IDE (granular) | YAML front-matter + Markdown |
+| `.roo/rules/*.md` | Roo Code (granular) | Markdown |
 | `llms.txt` | Windsurf Cascade, all LLM agents | Markdown (concise map/directory) |
 | `llms-full.txt` | Windsurf Cascade, large-context LLMs | Markdown (full reference book) |
+
+#### Granular rules
+
+Cursor, Trae, and Roo Code support per-class rule files. When a class or method is annotated, the processor writes one rule file per annotated class (filename derived from the class simple name). Orphaned granular files — for classes that have had annotations removed — are cleaned up **after** new files are written to prevent delete-then-recreate cycles.
 
 #### llms.txt vs llms-full.txt
 
@@ -92,7 +117,16 @@ VibeTags follows the [llms.txt standard](https://llmstxt.org/) for LLM agent dis
 
 Both files follow the llms.txt format hierarchy: `# Title`, `> Summary blockquote`, informational text, and `## H2` resource sections.
 
-The optional `vibetags.project` processor option sets the `# H1` project name in both files (defaults to `"This Project"`).
+### Processor options
+
+Passed via `<compilerArg>-A...</compilerArg>` in Maven or `compilerArgs` in Gradle:
+
+| Option | Default | Description |
+|---|---|---|
+| `vibetags.project` | `"This Project"` | Sets the `# H1` project name in llms.txt and llms-full.txt |
+| `vibetags.root` | JVM working directory | Override the output directory for all generated files |
+| `vibetags.log.path` | `vibetags.log` in root | Custom log file path (relative to root, or absolute) |
+| `vibetags.log.level` | `INFO` | Log level: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `OFF` |
 
 ### Annotations (all `RetentionPolicy.SOURCE`)
 
@@ -104,27 +138,52 @@ The optional `vibetags.project` processor option sets the `# H1` project name in
 | `@AIAudit` | TYPE, METHOD | `checkFor: String[]` |
 | `@AIIgnore` | TYPE, METHOD, FIELD | `reason: String` |
 | `@AIPrivacy` | TYPE, METHOD, FIELD | `reason: String` |
+| `@AICore` | TYPE, METHOD, FIELD | `sensitivity: String`, `note: String` |
+| `@AIPerformance` | TYPE, METHOD | `constraint: String` |
 
-`@AIIgnore` differs from `@AILocked`: locked code is visible but immutable; ignored code is excluded from AI context entirely (treat as non-existent). Common uses: auto-generated files, deprecated scaffolding.
+**Annotation semantics:**
 
-`@AIPrivacy` marks elements that handle PII (Personally Identifiable Information). Unlike `@AIIgnore`, the element remains visible for code assistance — the AI is instructed to never include its runtime values in logs, console output, external API suggestions, test fixtures, or mock data. Use it for fields/methods subject to GDPR, HIPAA, PCI-DSS, or similar data-protection rules. Using `@AIPrivacy` together with `@AIIgnore` on the same element triggers a compile-time warning (redundant).
+- `@AILocked` — code is visible but must not be modified by AI
+- `@AIIgnore` — code is excluded from AI context entirely (treat as non-existent); unlike `@AILocked`, the AI should not even be aware of it
+- `@AIPrivacy` — element handles PII; AI must never include its runtime values in logs, test fixtures, mock data, or API suggestions (GDPR/HIPAA/PCI-DSS use cases)
+- `@AICore` — marks well-tested, sensitive core logic (e.g., months to stabilize); AI is instructed to treat changes with extreme care
+- `@AIPerformance` — enforces strict time/space complexity on hot-path code; AI must not introduce O(n²) or worse solutions
+
+**Compile-time validation warnings:**
+
+- `@AIDraft` + `@AILocked` on the same element — contradictory (locked but needs drafting)
+- `@AIAudit` with empty `checkFor[]` — no-op; nothing to audit
+- `@AIPrivacy` + `@AIIgnore` on the same element — redundant; ignore already excludes
+- `@AIIgnore` present but no `.cursorignore` / `.claudeignore` / `.copilotignore` / `.qwenignore` / `.aiexclude` exists — orphaned ignore annotation
+- `@AILocked` present but no `.aiexclude` — Gemini/Codex lock not active
+
+### Multi-module safety
+
+In multi-module builds, if a module has **no new annotations**, the processor skips updating shared files (`.cursorrules`, `llms.txt`, etc.) to avoid overwriting annotations contributed by sibling modules.
 
 ### SPI registration
 
-The processor is discovered via `META-INF/services/javax.annotation.processing.Processor`. The wildcard `@SupportedAnnotationTypes("se.deversity.vibetags.annotations.*")` means new annotations are picked up automatically.
+The processor is discovered via `META-INF/services/javax.annotation.processing.Processor`. The wildcard `@SupportedAnnotationTypes("se.deversity.vibetags.annotations.*")` means new annotations are picked up automatically without touching the processor configuration.
 
 ## Test Structure
 
-| Class | Location | Coverage |
-|---|---|---|
-| `AnnotationDefinitionsTest` | `vibetags/src/test` | Annotation structure and defaults |
-| `AIGuardrailProcessorTest` | `vibetags/src/test` | Processor configuration |
-| `AIGuardrailProcessorUnitTest` | `vibetags/src/test` | Processor logic, opt-in, warning emission |
-| `AIIgnoreProcessorUnitTest` | `vibetags/src/test` | `@AIIgnore` annotation definition and opt-in behaviour |
-| `AIPrivacyProcessorTest` | `vibetags/src/test` | `@AIPrivacy` annotation definition, validation, and per-platform output |
-| `AIGuardrailProcessorProcessTest` | `vibetags/src/test` | `process()` method, `checkOrphanedAnnotations()`, `buildServiceFileMap()`, `writeFileIfChanged()` |
-| `AnnotationProcessorEndToEndTest` | `vibetags/src/test` | Generated file content |
-| `AIGuardrailProcessorIntegrationTest` | `vibetags/src/test` | Full workflow (requires `-Drun.integration.tests=true`) |
+All tests live in `vibetags/src/test`.
+
+| Class | Coverage |
+|---|---|
+| `AnnotationDefinitionsTest` | Annotation structure and defaults |
+| `AIGuardrailProcessorTest` | Processor configuration |
+| `AIGuardrailProcessorUnitTest` | Processor logic, opt-in, warning emission |
+| `AIIgnoreProcessorUnitTest` | `@AIIgnore` annotation definition and opt-in behaviour |
+| `AIPrivacyProcessorTest` | `@AIPrivacy` annotation definition, validation, and per-platform output |
+| `AIGuardrailProcessorProcessTest` | `process()` method, `checkOrphanedAnnotations()`, `buildServiceFileMap()`, `writeFileIfChanged()` |
+| `AnnotationProcessorEndToEndTest` | Generated file content |
+| `GranularRulesEndToEndTest` | Cursor/Trae/Roo granular rule file generation |
+| `QwenEndToEndTest` | Qwen-specific output |
+| `QwenProcessorUnitTest` | Qwen processor options |
+| `VibeTagsLoggerUnitTest` | File logging |
+| `MultiModuleStabilityTest` | Multi-module safety (no-annotation module doesn't wipe shared files) |
+| `AIGuardrailProcessorIntegrationTest` | Full workflow (requires `-Drun.integration.tests=true`) |
 
 ## Pre-commit Hooks
 

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.version>0.5.4</vibetags.version>
+        <vibetags.version>0.5.5</vibetags.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
     </properties>
 

--- a/vibetags/pom.xml
+++ b/vibetags/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>0.5.4</version>
+    <version>0.5.5</version>
     <packaging>jar</packaging>
 
     <name>VibeTags Processor</name>


### PR DESCRIPTION
## Summary
- Bump `step-security/harden-runner` from 2.18.0 to 2.19.0
- Update version to 0.5.5 in `vibetags/pom.xml` and `example/pom.xml`
- Update `CHANGELOG.md` and comparison links
- Expand `CLAUDE.md` with missing annotations (`@AICore`, `@AIPerformance`), processor options, new platforms, granular rules, and architectural details

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, push tag: `git push origin v0.5.5`
- [ ] Create GitHub Release for `v0.5.5` to trigger Maven Central publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)