### PR TITLE
Add clickable tables of contents to README and architecture docs\n\nA…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 
 # VibeTags - AI Guardrails for Java Development
 
+## Table of Contents
+
+- [What is VibeTags?](#-what-is-vibetags)
+- [Project Structure](#-project-structure)
+- [Quick Start](#-quick-start)
+- [How It Works](#-how-it-works)
+- [Documentation](#-documentation)
+- [Building Both Projects](#-building-both-projects)
+- [Performance & Load Tests](#-performance--load-tests)
+- [When to Use VibeTags](#-when-to-use-vibetags)
+- [Advanced Features](#-advanced-features)
+- [Contributing](#-contributing)
+- [Project Components](#-project-components)
+- [License](#-license)
+- [Why VibeTags?](#-why-vibetags)
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Maven Central](https://img.shields.io/maven-central/v/se.deversity.vibetags/vibetags-processor.svg)](https://central.sonatype.com/artifact/se.deversity.vibetags/vibetags-processor)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/PIsberg/vibetags/badge)](https://securityscorecards.dev/viewer/?uri=github.com/PIsberg/vibetags)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,23 @@
 # VibeTags Architecture - Technical Deep Dive
 
+## Table of Contents
+
+- [Overview](#overview)
+- [System Architecture](#system-architecture)
+- [Build Sequence](#build-sequence)
+- [Data Flow](#data-flow)
+- [Platform Output Formats](#platform-output-formats)
+- [Core Components](#core-components)
+- [Build Flow](#build-flow)
+- [Directory Structure](#directory-structure)
+- [Design Decisions](#design-decisions)
+- [Testing Strategy](#testing-strategy)
+- [Limitations](#limitations)
+- [Future Architecture](#future-architecture)
+- [Dependencies](#dependencies)
+- [Build Commands](#build-commands)
+- [AI Platform Integration](#ai-platform-integration)
+
 ## Overview
 
 VibeTags is a **Java annotation processor** (JSR 269 compliant) that generates AI platform-specific configuration files from Java source code annotations. It operates at **compile-time only**, with zero runtime overhead.


### PR DESCRIPTION
…dded comprehensive TOC to README.md with links to all major sections.\nAdded comprehensive TOC to ARCHITECTURE.md with links to all technical sections.\nImproves documentation navigation for users exploring VibeTags features and internals.\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>