### PR TITLE
feat: @AITestDriven — enforce Red-Green-Refactor discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 VibeTags is a **compile-time Java annotation processor** (`se.deversity.vibetags.processor.AIGuardrailProcessor`) that generates AI platform-specific guardrail configuration files from Java annotations. Zero runtime overhead — all annotations use `RetentionPolicy.SOURCE`.
 
 The repo has these independent Maven (and where noted, Gradle) subprojects:
-- `vibetags-annotations/` — the 8 `@interface` classes, zero deps. Goes on the consumer's compile classpath. **Build first** — `vibetags/` depends on it.
+- `vibetags-annotations/` — the 10 `@interface` classes, zero deps. Goes on the consumer's compile classpath. **Build first** — `vibetags/` depends on it.
 - `vibetags/` — the annotation processor itself (`AIGuardrailProcessor` + `VibeTagsLogger`). Pulls in slf4j/logback. Goes on the consumer's annotation-processor path only.
 - `vibetags-bom/` — pom-only BOM that manages `vibetags-annotations` + `vibetags-processor` versions. Maven only; Gradle consumers read it via `mavenLocal()` / `platform(...)`.
 - `example/` — a demo e-commerce app that consumes the library through the BOM (annotations on compile, processor on AP path).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 - [Performance & Load Tests](#-performance--load-tests)
 - [When to Use VibeTags](#-when-to-use-vibetags)
 - [Advanced Features](#-advanced-features)
+  - [@AIAudit - Continuous Security Auditing](#-aiaudit---continuous-security-auditing)
+  - [@AIDraft - Requesting AI Implementations](#-aidraft---requesting-ai-implementations)
+  - [Smart Validation Warnings](#-smart-validation-warnings)
+  - [@AIContract - Freezing Public API Signatures](#-aicontract---freezing-public-api-signatures)
+  - [@AITestDriven - Test-Driven AI Requirements](#-aitestdriven---test-driven-ai-requirements)
 - [Contributing](#-contributing)
 - [Project Components](#-project-components)
 - [License](#-license)
@@ -49,6 +54,7 @@ VibeTags provides Java annotations that serve as instructions for AI code genera
 - **🚫 @AIIgnore** - Exclude classes, methods, or fields from AI context entirely (auto-generated code, deprecated scaffolding)
 - **🔐 @AIPrivacy** - Mark fields and methods that handle PII — AI must never include their values in logs, suggestions, test fixtures, or external API calls
 - **📜 @AIContract** - Freeze the public signature of an interface or method — AI may change internal logic but must not alter method names, parameter types, parameter order, return types, or checked exceptions
+- **🧪 @AITestDriven** - Enforce Red-Green-Refactor discipline — AI must provide matching test updates alongside any logic changes (configurable coverage goal, framework, and mock policy)
 
 ### Supported AI Platforms
 
@@ -91,10 +97,10 @@ vibetags/
 │   ├── build.gradle      # Gradle build configuration
 │   ├── README.md         # Detailed usage guide and best practices
 │   └── src/              # Example source code with annotations
-├── vibetags-annotations/ # The 9 @interface classes (zero deps, RetentionPolicy.SOURCE)
+├── vibetags-annotations/ # The 10 @interface classes (zero deps, RetentionPolicy.SOURCE)
 │   ├── pom.xml
 │   ├── build.gradle
-│   └── src/main/java/    # AILocked, AIContext, AIDraft, AIAudit, AIIgnore, AIPrivacy, AICore, AIPerformance, AIContract
+│   └── src/main/java/    # AILocked, AIContext, AIDraft, AIAudit, AIIgnore, AIPrivacy, AICore, AIPerformance, AIContract, AITestDriven
 ├── vibetags-bom/         # Bill of Materials (versions only, no source)
 │   └── pom.xml           # Imported by consumers to manage vibetags-* versions in one place
 ├── load-tests/           # Performance & safety test harness (standalone)
@@ -746,6 +752,17 @@ If you use `@AIContract` (signature frozen but logic can change) alongside `@AID
 If you use `@AIContract` alongside `@AILocked` (no changes at all), VibeTags will warn about the overlapping intent:
 `[WARNING] VibeTags: com.example.LegacyApi.process is annotated with both @AIContract and @AILocked. @AILocked prohibits all modifications; @AIContract permits internal-logic changes. Consider using only @AILocked if no changes at all are intended.`
 
+#### Contradictory Test-Driven Annotations
+If you use `@AITestDriven` on an element that is also annotated with `@AIIgnore`, VibeTags will warn you — an ignored element is excluded from AI context entirely, so test enforcement cannot apply:
+`[WARNING] VibeTags: com.example.OrderService.processPayment is annotated with both @AITestDriven and @AIIgnore. @AIIgnore excludes the element from AI context entirely; @AITestDriven cannot enforce test coverage on an ignored element. Remove one of the two annotations.`
+
+If you use `@AITestDriven` on an element that is also annotated with `@AILocked`, VibeTags will warn about the conflicting intent — `@AILocked` prohibits all changes while `@AITestDriven` permits changes when tests are provided:
+`[WARNING] VibeTags: com.example.LegacyService.compute is annotated with both @AITestDriven and @AILocked. @AILocked prohibits all modifications; @AITestDriven permits changes only when tests are updated. Consider using only @AILocked if no changes at all are intended.`
+
+#### Invalid Coverage Goal
+If you use `@AITestDriven` with a `coverageGoal` outside the valid 0-100 range, VibeTags will warn you:
+`[WARNING] VibeTags: @AITestDriven on com.example.Service.method has an invalid coverageGoal (150). Value must be between 0 and 100 (inclusive).`
+
 ### 📜 @AIContract - Freezing Public API Signatures
 
 The `@AIContract` annotation draws a hard line between **interface** and **implementation**. It tells AI assistants: *"You're welcome to change what happens inside this method — replace the algorithm, swap the data source, optimize the logic — but you must leave the method name, parameter types, parameter order, return type, and checked exceptions exactly as they are."*
@@ -821,6 +838,115 @@ The following elements have contract-frozen public signatures. You MAY change in
 - **Legacy bridges** — where modern code talks to older systems that expect exact data shapes
 - **Framework-wired methods** — where Spring, Dagger, or another framework locates methods by exact signature
 
+### 🧪 @AITestDriven - Test-Driven AI Requirements
+
+The `@AITestDriven` annotation is the **accountability officer** of the VibeTags suite. It transforms the AI from a simple code generator into a disciplined engineer that follows a strict Red-Green-Refactor workflow.
+
+When an AI tool scans a project and encounters this tag, it must treat the test suite as an immutable part of the "Definition of Done." Changes without tests are considered incomplete and must not be proposed.
+
+#### How It Works: The Enforcement Loop
+
+1. **Context Mapping** — The AI identifies the associated test class (via naming convention or explicit `testLocation`).
+2. **Requirement Analysis** — Before implementing, the AI reads the existing tests to understand expected behavior.
+3. **Synchronous Update** — New logic and new test cases are generated in a single pass. If the logic changes, the tests must reflect the new expected behavior.
+4. **Regression Check** — The AI verifies its changes do not break existing tests; if they do, it must fix the logic or explain why the test contract needs to evolve.
+
+#### Annotation Attributes
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `testLocation` | `String` | `""` | Explicit path to the test file when it doesn't follow standard naming (e.g. `src/test/integration/ProcTest.java`). Leave empty for convention-based resolution. |
+| `coverageGoal` | `int` | `100` | Minimum statement-coverage percentage the AI must achieve in generated or updated tests. |
+| `framework` | `Framework[]` | `{JUNIT_5}` | Testing frameworks the AI must use. Multiple values may be combined (e.g. `{JUNIT_5, MOCKITO}`). |
+| `mockPolicy` | `String` | `""` | Instruction describing how external dependencies should be handled (e.g. `"Always mock external APIs"`, `"Use H2 for database tests"`). |
+
+**Available frameworks:** `JUNIT_5`, `JUNIT_4`, `TESTNG`, `MOCKITO`, `ASSERTJ`, `SPOCK`, `NONE`
+
+#### Example Usage
+
+```java
+public class OrderService {
+
+    /**
+     * Discount engine — the logic here evolves frequently as business rules change.
+     * Every change MUST be accompanied by a full test update.
+     */
+    @AIDraft(instructions = "Implement discount calculation: percentage, fixed amount, BOGO, tiered.")
+    @AITestDriven(
+        coverageGoal = 100,
+        framework = {AITestDriven.Framework.JUNIT_5, AITestDriven.Framework.ASSERTJ},
+        mockPolicy = "Use fixed prices — no external pricing calls in unit tests"
+    )
+    public double calculateDiscount(String orderId, String discountCode) {
+        return 0.0; // AI implements this, but must also provide the tests
+    }
+
+    /**
+     * Order status state machine — complex workflow that must stay fully tested.
+     */
+    @AITestDriven(
+        coverageGoal = 95,
+        framework = {AITestDriven.Framework.JUNIT_5, AITestDriven.Framework.MOCKITO},
+        testLocation = "src/test/java/com/example/service/OrderServiceTest.java",
+        mockPolicy = "Mock OrderRepository and EventPublisher; use real state machine logic"
+    )
+    public String updateOrderStatus(String orderId, String newStatus) {
+        return "CREATED";
+    }
+}
+```
+
+#### Generated Output by Platform
+
+**Cursor (.cursorrules):**
+```markdown
+## 🧪 TEST-DRIVEN REQUIREMENTS
+The following elements require a corresponding test update whenever their logic is modified.
+AI MUST NOT propose changes to these elements without also providing the matching test code.
+
+* `com.example.service.OrderService.calculateDiscount` - Coverage goal: 100%. Framework: JUNIT_5, ASSERTJ. Mock policy: Use fixed prices — no external pricing calls in unit tests.
+* `com.example.service.OrderService.updateOrderStatus` - Coverage goal: 95%. Framework: JUNIT_5, MOCKITO. Test file: src/test/java/com/example/service/OrderServiceTest.java.
+```
+
+**Claude (CLAUDE.md):**
+```xml
+<test_driven_requirements>
+  <element path="com.example.service.OrderService.calculateDiscount">
+    <coverage_goal>100</coverage_goal>
+    <frameworks>JUNIT_5, ASSERTJ</frameworks>
+    <mock_policy>Use fixed prices — no external pricing calls in unit tests</mock_policy>
+  </element>
+  <element path="com.example.service.OrderService.updateOrderStatus">
+    <coverage_goal>95</coverage_goal>
+    <frameworks>JUNIT_5, MOCKITO</frameworks>
+    <test_location>src/test/java/com/example/service/OrderServiceTest.java</test_location>
+    <mock_policy>Mock OrderRepository and EventPublisher; use real state machine logic</mock_policy>
+  </element>
+</test_driven_requirements>
+<rule>For any element listed in <test_driven_requirements>, you MUST provide both the implementation change AND the corresponding test code update in a single response. Changes without tests are incomplete and must not be proposed.</rule>
+```
+
+#### Compile-time Validation
+
+`@AITestDriven` has three dedicated compile-time checks:
+
+- **`@AITestDriven` + `@AIIgnore`** — contradictory. The element is excluded from AI context, so enforcing test coverage on it is impossible. Remove one of the two.
+  `[WARNING] VibeTags: com.example.OrderService.processPayment is annotated with both @AITestDriven and @AIIgnore. @AIIgnore excludes the element from AI context entirely; @AITestDriven cannot enforce test coverage on an ignored element. Remove one of the two annotations.`
+
+- **`@AITestDriven` + `@AILocked`** — contradictory. `@AILocked` prohibits all changes; `@AITestDriven` permits changes when tests are provided. Use only `@AILocked` if no changes are intended.
+  `[WARNING] VibeTags: com.example.LegacyService.compute is annotated with both @AITestDriven and @AILocked. @AILocked prohibits all modifications; @AITestDriven permits changes only when tests are updated. Consider using only @AILocked if no changes at all are intended.`
+
+- **`@AITestDriven` with invalid `coverageGoal`** — `coverageGoal` must be between 0 and 100 inclusive.
+  `[WARNING] VibeTags: @AITestDriven on com.example.Service.method has an invalid coverageGoal (150). Value must be between 0 and 100 (inclusive).`
+
+#### Best Use Cases
+
+- **Business logic** — discount engines, pricing algorithms, order state machines that change often
+- **Security-sensitive operations** — payment processing, authentication flows where regressions are costly
+- **Draft implementations** — combine with `@AIDraft` to ensure the AI writes both the implementation and its tests in one shot
+- **Core algorithms** — pair with `@AICore` when well-tested stability is critical
+- **API surface evolution** — ensure any behavioral change is validated by tests before it reaches production
+
 ## 🤝 Contributing
 
 VibeTags is designed to evolve based on community needs. Future extensions could include:
@@ -832,7 +958,7 @@ VibeTags is designed to evolve based on community needs. Future extensions could
 ## 📊 Project Components
 
 ### vibetags/
-The core annotation processor library. Contains all 8 Java annotations and the annotation processor that generates AI configuration files at compile time.
+The core annotation processor library. Contains all 10 Java annotations and the annotation processor that generates AI configuration files at compile time.
 
 ### [example/](example/README.md)
 A practical e-commerce application demonstrating real-world usage of all 8 VibeTags annotations. Shows how to protect legacy payment processors, guide AI on security configurations, request AI implementations for notification services, enforce continuous security auditing for database infrastructure, mark PII fields, identify core business logic, and enforce hot-path performance constraints.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -102,6 +102,7 @@ The split keeps `slf4j` / `logback` (the processor's internal logging deps) off 
 - `@AICore` - Marks sensitive core logic; AI must change with extreme caution (sensitivity: String, note: String)
 - `@AIPerformance` - Hot-path constraint; AI must not introduce O(n²) complexity (constraint: String)
 - `@AIContract` - Freezes the public signature; AI may change internal logic but must not alter method name, parameter types/order, return type, or checked exceptions (reason: String)
+- `@AITestDriven` - Enforces Red-Green-Refactor; AI must provide matching test updates alongside any logic changes (testLocation: String, coverageGoal: int, framework: Framework[], mockPolicy: String)
 
 **Processor** — package `se.deversity.vibetags.processor`, jar `vibetags-processor`:
 - `AIGuardrailProcessor` — extends `AbstractProcessor` (JSR 269); thin orchestrator (~230 lines) that wires the helpers below into the JSR 269 lifecycle
@@ -111,8 +112,8 @@ The split keeps `slf4j` / `logback` (the processor's internal logging deps) off 
 - Compile-scope dependency on `vibetags-annotations` so the processor code can reference annotation classes (e.g. `roundEnv.getElementsAnnotatedWith(AILocked.class)`) and so legacy single-coordinate consumers still get the annotations transitively.
 
 **Internal helpers** — package `se.deversity.vibetags.processor.internal` (single-responsibility classes that do the actual work, since 0.6.0):
-- `AnnotationCollector` — owns the nine `LinkedHashSet<Element>` accumulators that aggregate annotated elements across all `javac` rounds; also tracks the `anyAnnotationsFound` flag used for the multi-module preservation check
-- `AnnotationValidator` — emits five compile-time consistency warnings (`@AIDraft`+`@AILocked` contradiction, empty `@AIAudit.checkFor`, redundant `@AIPrivacy`+`@AIIgnore`, `@AIContract`+`@AIDraft` contradiction, `@AIContract`+`@AILocked` overlap)
+- `AnnotationCollector` — owns the ten `LinkedHashSet<Element>` accumulators that aggregate annotated elements across all `javac` rounds; also tracks the `anyAnnotationsFound` flag used for the multi-module preservation check
+- `AnnotationValidator` — emits compile-time consistency warnings (`@AIDraft`+`@AILocked` contradiction, empty `@AIAudit.checkFor`, redundant `@AIPrivacy`+`@AIIgnore`, `@AIContract`+`@AIDraft` contradiction, `@AIContract`+`@AILocked` overlap, `@AITestDriven`+`@AIIgnore` contradiction, `@AITestDriven`+`@AILocked` contradiction, invalid `@AITestDriven.coverageGoal`)
 - `OrphanWarner` — emits warnings when annotations are used but the corresponding ignore-file isn't present (e.g. `@AIIgnore` without `.cursorignore`)
 - `ServiceRegistry` — maps logical service keys to file paths and resolves which services are "active" via the file-existence opt-in
 - `ElementNaming` — pure helpers for `elementPath`, `elementDisplayName`, `owningElement`
@@ -383,6 +384,7 @@ All annotations use `@Retention(RetentionPolicy.SOURCE)` — they exist only at 
 | **`@AICore`** | TYPE, METHOD, FIELD | `sensitivity: String`, `note: String` | Marks well-tested core logic; AI must change with extreme caution |
 | **`@AIPerformance`** | TYPE, METHOD, FIELD | `constraint: String` | Hot-path constraint; AI must not introduce O(n²) or worse complexity |
 | **`@AIContract`** | TYPE, METHOD | `reason: String` | Freezes public signature; AI may change internal logic but must not alter method name, parameter types/order, return type, or checked exceptions |
+| **`@AITestDriven`** | TYPE, METHOD | `testLocation: String`, `coverageGoal: int`, `framework: Framework[]`, `mockPolicy: String` | Enforces Red-Green-Refactor: AI must not propose changes without also providing the matching test update |
 
 **Annotation semantics compared:**
 - `@AILocked` — visible to AI but must not be modified
@@ -391,11 +393,15 @@ All annotations use `@Retention(RetentionPolicy.SOURCE)` — they exist only at 
 - `@AICore` — visible, modifiable, but AI must treat changes with extreme caution and verify test coverage
 - `@AIPerformance` — visible, modifiable, but AI must never introduce O(n²) or worse complexity
 - `@AIContract` — visible, modifiable internally, but the public signature (name, param types/order, return type, checked exceptions) is immutable
+- `@AITestDriven` — visible, modifiable, but any change must be accompanied by a matching test update in the same response; the AI is the "accountability officer" that enforces the test suite
 
 **Invalid combinations that trigger compiler WARNINGs:**
 - `@AIPrivacy` + `@AIIgnore` — redundant; `@AIIgnore` already hides the element from AI entirely
 - `@AIContract` + `@AIDraft` — contradictory; a frozen signature that also needs drafting is logically inconsistent
 - `@AIContract` + `@AILocked` — overlapping; `@AILocked` already prohibits all modifications, making `@AIContract`'s "logic is changeable" carve-out meaningless
+- `@AITestDriven` + `@AIIgnore` — contradictory; enforcing test coverage on an ignored element is logically inconsistent
+- `@AITestDriven` + `@AILocked` — contradictory; `@AILocked` prohibits all modifications while `@AITestDriven` permits changes when tests are provided
+- `@AITestDriven` with `coverageGoal` outside 0–100 — invalid; must be a valid percentage
 
 ### Annotation Processor
 

--- a/example/.ai/rules/com-example-service-OrderService.md
+++ b/example/.ai/rules/com-example-service-OrderService.md
@@ -29,4 +29,17 @@
 ### Rules for method generateOrderConfirmation
 - **Rule**: Never log or expose runtime values of this element.
 - **Reason**: Output contains customer shipping address and contact details (PII)
+
+### Rules for method calculateDiscount
+- **Rule**: Changes MUST be accompanied by a matching test update.
+- **Coverage Goal**: 100%
+- **Frameworks**: JUNIT_5, ASSERTJ
+- **Mock Policy**: Use fixed prices — no external pricing calls in unit tests
+
+### Rules for method updateOrderStatus
+- **Rule**: Changes MUST be accompanied by a matching test update.
+- **Coverage Goal**: 95%
+- **Frameworks**: JUNIT_5, MOCKITO
+- **Test Location**: src/test/java/com/example/service/OrderServiceTest.java
+- **Mock Policy**: Mock OrderRepository and EventPublisher; use real state machine logic
 <!-- VIBETAGS-END -->

--- a/example/.amazonq/rules/com-example-service-OrderService.md
+++ b/example/.amazonq/rules/com-example-service-OrderService.md
@@ -29,4 +29,17 @@
 ### Rules for method generateOrderConfirmation
 - **Rule**: Never log or expose runtime values of this element.
 - **Reason**: Output contains customer shipping address and contact details (PII)
+
+### Rules for method calculateDiscount
+- **Rule**: Changes MUST be accompanied by a matching test update.
+- **Coverage Goal**: 100%
+- **Frameworks**: JUNIT_5, ASSERTJ
+- **Mock Policy**: Use fixed prices — no external pricing calls in unit tests
+
+### Rules for method updateOrderStatus
+- **Rule**: Changes MUST be accompanied by a matching test update.
+- **Coverage Goal**: 95%
+- **Frameworks**: JUNIT_5, MOCKITO
+- **Test Location**: src/test/java/com/example/service/OrderServiceTest.java
+- **Mock Policy**: Mock OrderRepository and EventPublisher; use real state machine logic
 <!-- VIBETAGS-END -->

--- a/example/.continue/rules/com-example-service-OrderService.md
+++ b/example/.continue/rules/com-example-service-OrderService.md
@@ -35,4 +35,17 @@ alwaysApply: false
 ### Rules for method generateOrderConfirmation
 - **Rule**: Never log or expose runtime values of this element.
 - **Reason**: Output contains customer shipping address and contact details (PII)
+
+### Rules for method calculateDiscount
+- **Rule**: Changes MUST be accompanied by a matching test update.
+- **Coverage Goal**: 100%
+- **Frameworks**: JUNIT_5, ASSERTJ
+- **Mock Policy**: Use fixed prices — no external pricing calls in unit tests
+
+### Rules for method updateOrderStatus
+- **Rule**: Changes MUST be accompanied by a matching test update.
+- **Coverage Goal**: 95%
+- **Frameworks**: JUNIT_5, MOCKITO
+- **Test Location**: src/test/java/com/example/service/OrderServiceTest.java
+- **Mock Policy**: Mock OrderRepository and EventPublisher; use real state machine logic
 <!-- VIBETAGS-END -->

--- a/example/.cursor/rules/com-example-service-OrderService.mdc
+++ b/example/.cursor/rules/com-example-service-OrderService.mdc
@@ -35,4 +35,17 @@ alwaysApply: false
 ### Rules for method generateOrderConfirmation
 - **Rule**: Never log or expose runtime values of this element.
 - **Reason**: Output contains customer shipping address and contact details (PII)
+
+### Rules for method calculateDiscount
+- **Rule**: Changes MUST be accompanied by a matching test update.
+- **Coverage Goal**: 100%
+- **Frameworks**: JUNIT_5, ASSERTJ
+- **Mock Policy**: Use fixed prices — no external pricing calls in unit tests
+
+### Rules for method updateOrderStatus
+- **Rule**: Changes MUST be accompanied by a matching test update.
+- **Coverage Goal**: 95%
+- **Frameworks**: JUNIT_5, MOCKITO
+- **Test Location**: src/test/java/com/example/service/OrderServiceTest.java
+- **Mock Policy**: Mock OrderRepository and EventPublisher; use real state machine logic
 <!-- VIBETAGS-END -->

--- a/example/.cursorrules
+++ b/example/.cursorrules
@@ -103,4 +103,11 @@ The following elements have contract-frozen public signatures. You MAY change in
 * `com.example.service.PricingService.calculatePrice(java.lang.String,int,java.lang.String)` - Signature locked by OpenAPI v2 contract. checkout-service and mobile-app bind to this exact signature. A type change is a breaking API change.
 * `com.example.service.PricingService.applyPromoCode(java.lang.String,double,java.lang.String)` - Promotions-service depends on this exact method signature for its async price-adjustment events. Changing parameter types would break the event deserialization.
 * `com.example.service.PricingService.getBulkPricing(java.util.List<java.lang.String>,int)` - B2B portal contract v1.2 — the List<Map<String,Object>> structure is serialized directly to JSON. Changing the return type breaks portal parsing.
+
+## 🧪 TEST-DRIVEN REQUIREMENTS
+The following elements require a corresponding test update whenever their logic is modified.
+AI MUST NOT propose changes to these elements without also providing the matching test code.
+
+* `com.example.service.OrderService.calculateDiscount(java.lang.String,java.lang.String)` - Coverage goal: 100%. Framework: JUNIT_5, ASSERTJ. Mock policy: Use fixed prices — no external pricing calls in unit tests.
+* `com.example.service.OrderService.updateOrderStatus(java.lang.String,java.lang.String)` - Coverage goal: 95%. Framework: JUNIT_5, MOCKITO. Test file: src/test/java/com/example/service/OrderServiceTest.java. Mock policy: Mock OrderRepository and EventPublisher; use real state machine logic.
 # VIBETAGS-END

--- a/example/.github/copilot-instructions.md
+++ b/example/.github/copilot-instructions.md
@@ -103,4 +103,10 @@ Do not modify the public signatures of the following elements. Internal implemen
 - `com.example.service.PricingService.calculatePrice(java.lang.String,int,java.lang.String)` - Signature locked by OpenAPI v2 contract. checkout-service and mobile-app bind to this exact signature. A type change is a breaking API change.
 - `com.example.service.PricingService.applyPromoCode(java.lang.String,double,java.lang.String)` - Promotions-service depends on this exact method signature for its async price-adjustment events. Changing parameter types would break the event deserialization.
 - `com.example.service.PricingService.getBulkPricing(java.util.List<java.lang.String>,int)` - B2B portal contract v1.2 — the List<Map<String,Object>> structure is serialized directly to JSON. Changing the return type breaks portal parsing.
+
+## Test-Driven Requirements
+Do not suggest changes to the following elements without also providing the corresponding test update:
+
+- `com.example.service.OrderService.calculateDiscount(java.lang.String,java.lang.String)` - Coverage goal: 100%. Framework: JUNIT_5, ASSERTJ. Mock policy: Use fixed prices — no external pricing calls in unit tests.
+- `com.example.service.OrderService.updateOrderStatus(java.lang.String,java.lang.String)` - Coverage goal: 95%. Framework: JUNIT_5, MOCKITO. Test file: src/test/java/com/example/service/OrderServiceTest.java. Mock policy: Mock OrderRepository and EventPublisher; use real state machine logic.
 <!-- VIBETAGS-END -->

--- a/example/.roo/rules/com-example-service-OrderService.md
+++ b/example/.roo/rules/com-example-service-OrderService.md
@@ -29,4 +29,17 @@
 ### Rules for method generateOrderConfirmation
 - **Rule**: Never log or expose runtime values of this element.
 - **Reason**: Output contains customer shipping address and contact details (PII)
+
+### Rules for method calculateDiscount
+- **Rule**: Changes MUST be accompanied by a matching test update.
+- **Coverage Goal**: 100%
+- **Frameworks**: JUNIT_5, ASSERTJ
+- **Mock Policy**: Use fixed prices — no external pricing calls in unit tests
+
+### Rules for method updateOrderStatus
+- **Rule**: Changes MUST be accompanied by a matching test update.
+- **Coverage Goal**: 95%
+- **Frameworks**: JUNIT_5, MOCKITO
+- **Test Location**: src/test/java/com/example/service/OrderServiceTest.java
+- **Mock Policy**: Mock OrderRepository and EventPublisher; use real state machine logic
 <!-- VIBETAGS-END -->

--- a/example/.rules
+++ b/example/.rules
@@ -86,4 +86,10 @@ Internal logic may be changed; never alter method names, parameter types, order,
 - `com.example.service.PricingService.calculatePrice(java.lang.String,int,java.lang.String)`: Signature locked by OpenAPI v2 contract. checkout-service and mobile-app bind to this exact signature. A type change is a breaking API change.
 - `com.example.service.PricingService.applyPromoCode(java.lang.String,double,java.lang.String)`: Promotions-service depends on this exact method signature for its async price-adjustment events. Changing parameter types would break the event deserialization.
 - `com.example.service.PricingService.getBulkPricing(java.util.List<java.lang.String>,int)`: B2B portal contract v1.2 — the List<Map<String,Object>> structure is serialized directly to JSON. Changing the return type breaks portal parsing.
+
+## Test-Driven Requirements
+Changes to the following elements must be accompanied by matching test code:
+
+- `com.example.service.OrderService.calculateDiscount(java.lang.String,java.lang.String)`: Coverage goal: 100%. Framework: JUNIT_5, ASSERTJ. Mock policy: Use fixed prices — no external pricing calls in unit tests.
+- `com.example.service.OrderService.updateOrderStatus(java.lang.String,java.lang.String)`: Coverage goal: 95%. Framework: JUNIT_5, MOCKITO. Test file: src/test/java/com/example/service/OrderServiceTest.java. Mock policy: Mock OrderRepository and EventPublisher; use real state machine logic.
 # VIBETAGS-END

--- a/example/.tabnine/guidelines/com-example-service-OrderService.md
+++ b/example/.tabnine/guidelines/com-example-service-OrderService.md
@@ -29,4 +29,17 @@
 ### Rules for method generateOrderConfirmation
 - **Rule**: Never log or expose runtime values of this element.
 - **Reason**: Output contains customer shipping address and contact details (PII)
+
+### Rules for method calculateDiscount
+- **Rule**: Changes MUST be accompanied by a matching test update.
+- **Coverage Goal**: 100%
+- **Frameworks**: JUNIT_5, ASSERTJ
+- **Mock Policy**: Use fixed prices — no external pricing calls in unit tests
+
+### Rules for method updateOrderStatus
+- **Rule**: Changes MUST be accompanied by a matching test update.
+- **Coverage Goal**: 95%
+- **Frameworks**: JUNIT_5, MOCKITO
+- **Test Location**: src/test/java/com/example/service/OrderServiceTest.java
+- **Mock Policy**: Mock OrderRepository and EventPublisher; use real state machine logic
 <!-- VIBETAGS-END -->

--- a/example/.trae/rules/com-example-service-OrderService.md
+++ b/example/.trae/rules/com-example-service-OrderService.md
@@ -35,4 +35,17 @@ description: "AI rules for com.example.service.OrderService"
 ### Rules for method generateOrderConfirmation
 - **Rule**: Never log or expose runtime values of this element.
 - **Reason**: Output contains customer shipping address and contact details (PII)
+
+### Rules for method calculateDiscount
+- **Rule**: Changes MUST be accompanied by a matching test update.
+- **Coverage Goal**: 100%
+- **Frameworks**: JUNIT_5, ASSERTJ
+- **Mock Policy**: Use fixed prices — no external pricing calls in unit tests
+
+### Rules for method updateOrderStatus
+- **Rule**: Changes MUST be accompanied by a matching test update.
+- **Coverage Goal**: 95%
+- **Frameworks**: JUNIT_5, MOCKITO
+- **Test Location**: src/test/java/com/example/service/OrderServiceTest.java
+- **Mock Policy**: Mock OrderRepository and EventPublisher; use real state machine logic
 <!-- VIBETAGS-END -->

--- a/example/.windsurf/rules/com-example-service-OrderService.md
+++ b/example/.windsurf/rules/com-example-service-OrderService.md
@@ -35,4 +35,17 @@ alwaysApply: false
 ### Rules for method generateOrderConfirmation
 - **Rule**: Never log or expose runtime values of this element.
 - **Reason**: Output contains customer shipping address and contact details (PII)
+
+### Rules for method calculateDiscount
+- **Rule**: Changes MUST be accompanied by a matching test update.
+- **Coverage Goal**: 100%
+- **Frameworks**: JUNIT_5, ASSERTJ
+- **Mock Policy**: Use fixed prices — no external pricing calls in unit tests
+
+### Rules for method updateOrderStatus
+- **Rule**: Changes MUST be accompanied by a matching test update.
+- **Coverage Goal**: 95%
+- **Frameworks**: JUNIT_5, MOCKITO
+- **Test Location**: src/test/java/com/example/service/OrderServiceTest.java
+- **Mock Policy**: Mock OrderRepository and EventPublisher; use real state machine logic
 <!-- VIBETAGS-END -->

--- a/example/.windsurfrules
+++ b/example/.windsurfrules
@@ -101,4 +101,10 @@ Internal implementation may be changed, but MUST NOT alter method names, paramet
 * `com.example.service.PricingService.calculatePrice(java.lang.String,int,java.lang.String)` - Signature locked by OpenAPI v2 contract. checkout-service and mobile-app bind to this exact signature. A type change is a breaking API change.
 * `com.example.service.PricingService.applyPromoCode(java.lang.String,double,java.lang.String)` - Promotions-service depends on this exact method signature for its async price-adjustment events. Changing parameter types would break the event deserialization.
 * `com.example.service.PricingService.getBulkPricing(java.util.List<java.lang.String>,int)` - B2B portal contract v1.2 — the List<Map<String,Object>> structure is serialized directly to JSON. Changing the return type breaks portal parsing.
+
+## 🧪 TEST-DRIVEN REQUIREMENTS
+AI MUST NOT propose changes to the following elements without also providing the matching test code.
+
+* `com.example.service.OrderService.calculateDiscount(java.lang.String,java.lang.String)` - Coverage goal: 100%. Framework: JUNIT_5, ASSERTJ. Mock policy: Use fixed prices — no external pricing calls in unit tests.
+* `com.example.service.OrderService.updateOrderStatus(java.lang.String,java.lang.String)` - Coverage goal: 95%. Framework: JUNIT_5, MOCKITO. Test file: src/test/java/com/example/service/OrderServiceTest.java. Mock policy: Mock OrderRepository and EventPublisher; use real state machine logic.
 # VIBETAGS-END

--- a/example/AGENTS.md
+++ b/example/AGENTS.md
@@ -88,4 +88,10 @@ Internal logic may be modified, but never change method names, parameter types, 
 - **com.example.service.PricingService.calculatePrice(java.lang.String,int,java.lang.String)**: Signature locked by OpenAPI v2 contract. checkout-service and mobile-app bind to this exact signature. A type change is a breaking API change.
 - **com.example.service.PricingService.applyPromoCode(java.lang.String,double,java.lang.String)**: Promotions-service depends on this exact method signature for its async price-adjustment events. Changing parameter types would break the event deserialization.
 - **com.example.service.PricingService.getBulkPricing(java.util.List<java.lang.String>,int)**: B2B portal contract v1.2 — the List<Map<String,Object>> structure is serialized directly to JSON. Changing the return type breaks portal parsing.
+
+## 🧪 TEST-DRIVEN REQUIREMENTS
+Changes to the following elements MUST be accompanied by a matching test update in the same response.
+
+- **com.example.service.OrderService.calculateDiscount(java.lang.String,java.lang.String)**: Coverage goal: 100%. Framework: JUNIT_5, ASSERTJ. Mock policy: Use fixed prices — no external pricing calls in unit tests.
+- **com.example.service.OrderService.updateOrderStatus(java.lang.String,java.lang.String)**: Coverage goal: 95%. Framework: JUNIT_5, MOCKITO. Test file: src/test/java/com/example/service/OrderServiceTest.java. Mock policy: Mock OrderRepository and EventPublisher; use real state machine logic.
 <!-- VIBETAGS-END -->

--- a/example/CLAUDE.md
+++ b/example/CLAUDE.md
@@ -201,6 +201,21 @@
   </contract_signatures>
 
 <rule>You may refactor the internal logic of elements listed in <contract_signatures>, but you MUST NOT change their public signatures: method names, parameter types, parameter order, return types, or checked exceptions.</rule>
+  <test_driven_requirements>
+    <element path="com.example.service.OrderService.calculateDiscount(java.lang.String,java.lang.String)">
+      <coverage_goal>100</coverage_goal>
+      <frameworks>JUNIT_5, ASSERTJ</frameworks>
+      <mock_policy>Use fixed prices — no external pricing calls in unit tests</mock_policy>
+    </element>
+    <element path="com.example.service.OrderService.updateOrderStatus(java.lang.String,java.lang.String)">
+      <coverage_goal>95</coverage_goal>
+      <frameworks>JUNIT_5, MOCKITO</frameworks>
+      <test_location>src/test/java/com/example/service/OrderServiceTest.java</test_location>
+      <mock_policy>Mock OrderRepository and EventPublisher; use real state machine logic</mock_policy>
+    </element>
+  </test_driven_requirements>
+
+<rule>For any element listed in <test_driven_requirements>, you MUST provide both the implementation change AND the corresponding test code update in a single response. Changes without tests are incomplete and must not be proposed.</rule>
 </project_guardrails>
 
 <rule>Never propose edits to files listed in <locked_files>.</rule>

--- a/example/CONVENTIONS.md
+++ b/example/CONVENTIONS.md
@@ -195,4 +195,13 @@ This file contains project-specific coding conventions and AI guardrails extract
 #### CONTRACT: com.example.service.PricingService.getBulkPricing(java.util.List<java.lang.String>,int)
 - **Constraint**: Signature is frozen. Do not change method names, parameter types, return types, or checked exceptions.
 - **Reason**: B2B portal contract v1.2 — the List<Map<String,Object>> structure is serialized directly to JSON. Changing the return type breaks portal parsing.
+
+#### TEST-DRIVEN: com.example.service.OrderService.calculateDiscount(java.lang.String,java.lang.String)
+- **Rule**: Changes MUST be accompanied by test updates.
+- **Coverage Goal**: 100%
+- **Frameworks**: JUNIT_5, ASSERTJ
+#### TEST-DRIVEN: com.example.service.OrderService.updateOrderStatus(java.lang.String,java.lang.String)
+- **Rule**: Changes MUST be accompanied by test updates.
+- **Coverage Goal**: 95%
+- **Frameworks**: JUNIT_5, MOCKITO
 <!-- VIBETAGS-END -->

--- a/example/QWEN.md
+++ b/example/QWEN.md
@@ -102,4 +102,10 @@ Signatures (method names, parameters, return types, checked exceptions) are immu
 * `com.example.service.PricingService.calculatePrice(java.lang.String,int,java.lang.String)` - Signature locked by OpenAPI v2 contract. checkout-service and mobile-app bind to this exact signature. A type change is a breaking API change.
 * `com.example.service.PricingService.applyPromoCode(java.lang.String,double,java.lang.String)` - Promotions-service depends on this exact method signature for its async price-adjustment events. Changing parameter types would break the event deserialization.
 * `com.example.service.PricingService.getBulkPricing(java.util.List<java.lang.String>,int)` - B2B portal contract v1.2 — the List<Map<String,Object>> structure is serialized directly to JSON. Changing the return type breaks portal parsing.
+
+## 🧪 TEST-DRIVEN REQUIREMENTS
+Changes to the following elements MUST be accompanied by a matching test update in the same response.
+
+* `com.example.service.OrderService.calculateDiscount(java.lang.String,java.lang.String)` - Coverage goal: 100%. Framework: JUNIT_5, ASSERTJ. Mock policy: Use fixed prices — no external pricing calls in unit tests.
+* `com.example.service.OrderService.updateOrderStatus(java.lang.String,java.lang.String)` - Coverage goal: 95%. Framework: JUNIT_5, MOCKITO. Test file: src/test/java/com/example/service/OrderServiceTest.java. Mock policy: Mock OrderRepository and EventPublisher; use real state machine logic.
 <!-- VIBETAGS-END -->

--- a/example/gemini_instructions.md
+++ b/example/gemini_instructions.md
@@ -93,4 +93,10 @@ Internal implementation may be changed, but MUST NOT alter method names, paramet
 - `com.example.service.PricingService.calculatePrice(java.lang.String,int,java.lang.String)`: Signature locked by OpenAPI v2 contract. checkout-service and mobile-app bind to this exact signature. A type change is a breaking API change.
 - `com.example.service.PricingService.applyPromoCode(java.lang.String,double,java.lang.String)`: Promotions-service depends on this exact method signature for its async price-adjustment events. Changing parameter types would break the event deserialization.
 - `com.example.service.PricingService.getBulkPricing(java.util.List<java.lang.String>,int)`: B2B portal contract v1.2 — the List<Map<String,Object>> structure is serialized directly to JSON. Changing the return type breaks portal parsing.
+
+## TEST-DRIVEN REQUIREMENTS
+Changes to the following elements MUST be accompanied by matching test code in the same response:
+
+- `com.example.service.OrderService.calculateDiscount(java.lang.String,java.lang.String)`: Coverage goal: 100%. Framework: JUNIT_5, ASSERTJ. Mock policy: Use fixed prices — no external pricing calls in unit tests.
+- `com.example.service.OrderService.updateOrderStatus(java.lang.String,java.lang.String)`: Coverage goal: 95%. Framework: JUNIT_5, MOCKITO. Test file: src/test/java/com/example/service/OrderServiceTest.java. Mock policy: Mock OrderRepository and EventPublisher; use real state machine logic.
 <!-- VIBETAGS-END -->

--- a/example/llms-full.txt
+++ b/example/llms-full.txt
@@ -204,4 +204,19 @@ The following elements have frozen public API signatures. Internal implementatio
 
 ### com.example.service.PricingService.getBulkPricing(java.util.List<java.lang.String>,int)
 - **Reason**: B2B portal contract v1.2 — the List<Map<String,Object>> structure is serialized directly to JSON. Changing the return type breaks portal parsing.
+
+
+## 🧪 Test-Driven Requirements
+The following elements require a matching test update whenever their logic is modified. Changes without tests are incomplete.
+
+### com.example.service.OrderService.calculateDiscount(java.lang.String,java.lang.String)
+- **Coverage Goal**: 100%
+- **Frameworks**: JUNIT_5, ASSERTJ
+- **Mock Policy**: Use fixed prices — no external pricing calls in unit tests
+
+### com.example.service.OrderService.updateOrderStatus(java.lang.String,java.lang.String)
+- **Coverage Goal**: 95%
+- **Frameworks**: JUNIT_5, MOCKITO
+- **Test Location**: src/test/java/com/example/service/OrderServiceTest.java
+- **Mock Policy**: Mock OrderRepository and EventPublisher; use real state machine logic
 <!-- VIBETAGS-END -->

--- a/example/llms.txt
+++ b/example/llms.txt
@@ -74,4 +74,8 @@ AI tools reading this file should respect the guardrails defined below. These ru
 - [PricingService.calculatePrice(java.lang.String,int,java.lang.String)](com.example.service.PricingService.calculatePrice(java.lang.String,int,java.lang.String)): Signature locked by OpenAPI v2 contract. checkout-service and mobile-app bind to this exact signature. A type change is a breaking API change.
 - [PricingService.applyPromoCode(java.lang.String,double,java.lang.String)](com.example.service.PricingService.applyPromoCode(java.lang.String,double,java.lang.String)): Promotions-service depends on this exact method signature for its async price-adjustment events. Changing parameter types would break the event deserialization.
 - [PricingService.getBulkPricing(java.util.List<java.lang.String>,int)](com.example.service.PricingService.getBulkPricing(java.util.List<java.lang.String>,int)): B2B portal contract v1.2 — the List<Map<String,Object>> structure is serialized directly to JSON. Changing the return type breaks portal parsing.
+
+## 🧪 Test-Driven Requirements
+- [OrderService.calculateDiscount(java.lang.String,java.lang.String)](com.example.service.OrderService.calculateDiscount(java.lang.String,java.lang.String)): Coverage goal: 100%. Framework: JUNIT_5, ASSERTJ. Mock policy: Use fixed prices — no external pricing calls in unit tests.
+- [OrderService.updateOrderStatus(java.lang.String,java.lang.String)](com.example.service.OrderService.updateOrderStatus(java.lang.String,java.lang.String)): Coverage goal: 95%. Framework: JUNIT_5, MOCKITO. Test file: src/test/java/com/example/service/OrderServiceTest.java. Mock policy: Mock OrderRepository and EventPublisher; use real state machine logic.
 <!-- VIBETAGS-END -->

--- a/example/src/main/java/com/example/service/OrderService.java
+++ b/example/src/main/java/com/example/service/OrderService.java
@@ -4,6 +4,7 @@ import se.deversity.vibetags.annotations.AIDraft;
 import se.deversity.vibetags.annotations.AILocked;
 import se.deversity.vibetags.annotations.AIContext;
 import se.deversity.vibetags.annotations.AIPrivacy;
+import se.deversity.vibetags.annotations.AITestDriven;
 
 import java.util.List;
 import java.util.Map;
@@ -45,16 +46,27 @@ public class OrderService {
      * AI is encouraged to help implement various discount strategies.
      */
     @AIDraft(instructions = "Implement discount calculation supporting: percentage discounts, fixed amount discounts, buy-one-get-one-free, and tiered discounts based on cart value. Apply maximum one discount per order unless overridden by admin.")
+    @AITestDriven(
+        coverageGoal = 100,
+        framework = {AITestDriven.Framework.JUNIT_5, AITestDriven.Framework.ASSERTJ},
+        mockPolicy = "Use fixed prices — no external pricing calls in unit tests"
+    )
     public double calculateDiscount(String orderId, String discountCode) {
         // @AIDraft: Implement discount logic
         return 0.0;
     }
-    
+
     /**
      * DRAFT: Order status tracking.
      * Need help implementing comprehensive status workflow.
      */
     @AIDraft(instructions = "Implement order status workflow: CREATED -> PAYMENT_PENDING -> PAYMENT_CONFIRMED -> PROCESSING -> SHIPPED -> DELIVERED. Support status history tracking with timestamps. Allow cancellation only before SHIPPED status.")
+    @AITestDriven(
+        coverageGoal = 95,
+        framework = {AITestDriven.Framework.JUNIT_5, AITestDriven.Framework.MOCKITO},
+        testLocation = "src/test/java/com/example/service/OrderServiceTest.java",
+        mockPolicy = "Mock OrderRepository and EventPublisher; use real state machine logic"
+    )
     public String updateOrderStatus(String orderId, String newStatus) {
         // @AIDraft: Implement status tracking
         return "CREATED";

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AITestDriven.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AITestDriven.java
@@ -1,0 +1,64 @@
+package se.deversity.vibetags.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Enforces a strict Red-Green-Refactor workflow on the annotated element.
+ * AI assistants MUST NOT propose changes to this element without also
+ * providing the corresponding test code update in the same response.
+ * Changes without matching tests are considered incomplete.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface AITestDriven {
+
+    /** Testing frameworks the AI must use for this element. */
+    enum Framework {
+        /** JUnit 5 (Jupiter). */
+        JUNIT_5,
+        /** JUnit 4. */
+        JUNIT_4,
+        /** TestNG. */
+        TESTNG,
+        /** Mockito mocking library. */
+        MOCKITO,
+        /** AssertJ fluent assertions. */
+        ASSERTJ,
+        /** Spock Framework (Groovy). */
+        SPOCK,
+        /** No specific framework required. */
+        NONE
+    }
+
+    /**
+     * Explicit path to the corresponding test file, for cases that do
+     * not follow the standard naming convention.
+     * Leave empty to let the AI infer the test class via naming convention.
+     * @return the test file path, or empty string for convention-based
+     */
+    String testLocation() default "";
+
+    /**
+     * Minimum statement-coverage percentage the AI must achieve in the
+     * generated or updated tests. Defaults to 100 (all new logic covered).
+     * @return coverage goal as a percentage 0-100
+     */
+    int coverageGoal() default 100;
+
+    /**
+     * Testing frameworks the AI must use. Multiple values may be combined
+     * (e.g., {@code {Framework.JUNIT_5, Framework.MOCKITO}}).
+     * @return the required frameworks
+     */
+    Framework[] framework() default {Framework.JUNIT_5};
+
+    /**
+     * Instruction describing how external dependencies should be handled
+     * in tests (e.g., "Always mock external APIs").
+     * @return the mock policy instruction, or empty string if no restriction
+     */
+    String mockPolicy() default "";
+}

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/AnnotationCollector.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/AnnotationCollector.java
@@ -9,6 +9,7 @@ import se.deversity.vibetags.annotations.AIIgnore;
 import se.deversity.vibetags.annotations.AILocked;
 import se.deversity.vibetags.annotations.AIPerformance;
 import se.deversity.vibetags.annotations.AIPrivacy;
+import se.deversity.vibetags.annotations.AITestDriven;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Element;
@@ -28,8 +29,9 @@ public final class AnnotationCollector {
     private final Set<Element> draftElements       = new LinkedHashSet<>();
     private final Set<Element> privacyElements     = new LinkedHashSet<>();
     private final Set<Element> coreElements        = new LinkedHashSet<>();
-    private final Set<Element> performanceElements = new LinkedHashSet<>();
-    private final Set<Element> contractElements    = new LinkedHashSet<>();
+    private final Set<Element> performanceElements  = new LinkedHashSet<>();
+    private final Set<Element> contractElements     = new LinkedHashSet<>();
+    private final Set<Element> testDrivenElements   = new LinkedHashSet<>();
 
     private boolean anyAnnotationsFound = false;
 
@@ -44,12 +46,13 @@ public final class AnnotationCollector {
         coreElements.addAll(roundEnv.getElementsAnnotatedWith(AICore.class));
         performanceElements.addAll(roundEnv.getElementsAnnotatedWith(AIPerformance.class));
         contractElements.addAll(roundEnv.getElementsAnnotatedWith(AIContract.class));
+        testDrivenElements.addAll(roundEnv.getElementsAnnotatedWith(AITestDriven.class));
 
         boolean added = !lockedElements.isEmpty() || !contextElements.isEmpty()
                      || !ignoreElements.isEmpty() || !auditElements.isEmpty()
                      || !draftElements.isEmpty() || !privacyElements.isEmpty()
                      || !coreElements.isEmpty() || !performanceElements.isEmpty()
-                     || !contractElements.isEmpty();
+                     || !contractElements.isEmpty() || !testDrivenElements.isEmpty();
         if (added) anyAnnotationsFound = true;
         return added;
     }
@@ -64,6 +67,7 @@ public final class AnnotationCollector {
         coreElements.clear();
         performanceElements.clear();
         contractElements.clear();
+        testDrivenElements.clear();
         anyAnnotationsFound = false;
     }
 
@@ -74,7 +78,8 @@ public final class AnnotationCollector {
     public Set<Element> draft()       { return draftElements; }
     public Set<Element> privacy()     { return privacyElements; }
     public Set<Element> core()        { return coreElements; }
-    public Set<Element> performance() { return performanceElements; }
-    public Set<Element> contract()    { return contractElements; }
+    public Set<Element> performance()  { return performanceElements; }
+    public Set<Element> contract()     { return contractElements; }
+    public Set<Element> testDriven()   { return testDrivenElements; }
     public boolean anyAnnotationsFound() { return anyAnnotationsFound; }
 }

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/AnnotationValidator.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/AnnotationValidator.java
@@ -6,6 +6,7 @@ import se.deversity.vibetags.annotations.AIDraft;
 import se.deversity.vibetags.annotations.AIIgnore;
 import se.deversity.vibetags.annotations.AILocked;
 import se.deversity.vibetags.annotations.AIPrivacy;
+import se.deversity.vibetags.annotations.AITestDriven;
 
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.RoundEnvironment;
@@ -76,6 +77,43 @@ public final class AnnotationValidator {
                         + " is annotated with both @AIContract and @AILocked. "
                         + "@AILocked prohibits all modifications; @AIContract permits internal-logic changes. "
                         + "Consider using only @AILocked if no changes at all are intended.",
+                    element);
+            }
+        }
+
+        // Contradiction: @AITestDriven + @AIIgnore
+        for (Element element : roundEnv.getElementsAnnotatedWith(AITestDriven.class)) {
+            if (element.getAnnotation(AIIgnore.class) != null) {
+                messager.printMessage(Diagnostic.Kind.WARNING,
+                    "VibeTags: " + element.toString()
+                        + " is annotated with both @AITestDriven and @AIIgnore. "
+                        + "@AIIgnore excludes the element from AI context entirely; "
+                        + "@AITestDriven cannot enforce test coverage on an ignored element. "
+                        + "Remove one of the two annotations.",
+                    element);
+            }
+        }
+
+        // Contradiction: @AITestDriven + @AILocked
+        for (Element element : roundEnv.getElementsAnnotatedWith(AITestDriven.class)) {
+            if (element.getAnnotation(AILocked.class) != null) {
+                messager.printMessage(Diagnostic.Kind.WARNING,
+                    "VibeTags: " + element.toString()
+                        + " is annotated with both @AITestDriven and @AILocked. "
+                        + "@AILocked prohibits all modifications; @AITestDriven permits changes only when tests are updated. "
+                        + "Consider using only @AILocked if no changes at all are intended.",
+                    element);
+            }
+        }
+
+        // Invalid coverage goal
+        for (Element element : roundEnv.getElementsAnnotatedWith(AITestDriven.class)) {
+            AITestDriven td = element.getAnnotation(AITestDriven.class);
+            if (td.coverageGoal() < 0 || td.coverageGoal() > 100) {
+                messager.printMessage(Diagnostic.Kind.WARNING,
+                    "VibeTags: @AITestDriven on " + element.toString()
+                        + " has an invalid coverageGoal (" + td.coverageGoal() + "). "
+                        + "Value must be between 0 and 100 (inclusive).",
                     element);
             }
         }

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/BuildFingerprint.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/BuildFingerprint.java
@@ -8,6 +8,7 @@ import se.deversity.vibetags.annotations.AIDraft;
 import se.deversity.vibetags.annotations.AILocked;
 import se.deversity.vibetags.annotations.AIPerformance;
 import se.deversity.vibetags.annotations.AIPrivacy;
+import se.deversity.vibetags.annotations.AITestDriven;
 
 import javax.lang.model.element.Element;
 import java.util.ArrayList;
@@ -82,6 +83,16 @@ public final class BuildFingerprint {
         appendAnnotationSet(sb, "T", collector.contract(), e -> {
             AIContract a = e.getAnnotation(AIContract.class);
             return a == null ? "" : a.reason();
+        });
+        appendAnnotationSet(sb, "TD", collector.testDriven(), e -> {
+            AITestDriven a = e.getAnnotation(AITestDriven.class);
+            if (a == null) return "";
+            StringBuilder attrs = new StringBuilder();
+            attrs.append(a.coverageGoal()).append('|');
+            attrs.append(a.testLocation()).append('|');
+            for (AITestDriven.Framework f : a.framework()) attrs.append(f.name()).append(',');
+            attrs.append('|').append(a.mockPolicy());
+            return attrs.toString();
         });
 
         sb.append("S{");

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailContentBuilder.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailContentBuilder.java
@@ -8,6 +8,7 @@ import se.deversity.vibetags.annotations.AIDraft;
 import se.deversity.vibetags.annotations.AILocked;
 import se.deversity.vibetags.annotations.AIPerformance;
 import se.deversity.vibetags.annotations.AIPrivacy;
+import se.deversity.vibetags.annotations.AITestDriven;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -53,6 +54,16 @@ public final class GuardrailContentBuilder {
     private final boolean codyActive;
     private final boolean codyIgnoreActive;
     private final boolean supermavenIgnoreActive;
+
+    // Windsurf test-driven section
+    private StringBuilder windsurfTestDrivenSection;
+
+    // Zed test-driven section
+    private StringBuilder zedTestDrivenSection;
+
+    // llms.txt test-driven sections
+    private StringBuilder llmsTxtTestDriven;
+    private StringBuilder llmsFullTxtTestDriven;
 
     // Windsurf builders
     private StringBuilder windsurfRules;
@@ -177,7 +188,8 @@ public final class GuardrailContentBuilder {
     private int mainBuilderHint() {
         int n = collector.locked().size() + collector.context().size() + collector.audit().size()
               + collector.draft().size() + collector.privacy().size() + collector.core().size()
-              + collector.performance().size() + collector.contract().size() + collector.ignore().size();
+              + collector.performance().size() + collector.contract().size() + collector.ignore().size()
+              + collector.testDriven().size();
         return Math.max(4096, Math.min(256 * 1024, 1500 * n));
     }
 
@@ -274,6 +286,15 @@ public final class GuardrailContentBuilder {
         for (Element e : collector.contract())
             appendContract(e, cursorContractSec, claudeContractSec, codexContractSec, copilotContractSec, qwenContractSec, geminiContractSec);
 
+        StringBuilder cursorTestDrivenSec = new StringBuilder("\n## 🧪 TEST-DRIVEN REQUIREMENTS\nThe following elements require a corresponding test update whenever their logic is modified.\nAI MUST NOT propose changes to these elements without also providing the matching test code.\n\n");
+        StringBuilder claudeTestDrivenSec = new StringBuilder("  <test_driven_requirements>\n");
+        StringBuilder codexTestDrivenSec  = new StringBuilder("\n## 🧪 TEST-DRIVEN REQUIREMENTS\nChanges to the following elements MUST be accompanied by a matching test update in the same response.\n\n");
+        StringBuilder copilotTestDrivenSec = new StringBuilder("\n## Test-Driven Requirements\nDo not suggest changes to the following elements without also providing the corresponding test update:\n\n");
+        StringBuilder qwenTestDrivenSec   = new StringBuilder("\n## 🧪 TEST-DRIVEN REQUIREMENTS\nChanges to the following elements MUST be accompanied by a matching test update in the same response.\n\n");
+        StringBuilder geminiTestDrivenSec = new StringBuilder();
+        for (Element e : collector.testDriven())
+            appendTestDriven(e, cursorTestDrivenSec, claudeTestDrivenSec, codexTestDrivenSec, copilotTestDrivenSec, qwenTestDrivenSec, geminiTestDrivenSec);
+
         // Gemini composition (locked + context + audit go before the rest)
         if (!collector.locked().isEmpty()) {
             geminiMd.append("\n## LOCKED FILES (DO NOT MODIFY)\nDo not suggest modifications to the following files:\n\n").append(geminiLocked);
@@ -368,6 +389,18 @@ public final class GuardrailContentBuilder {
             if (windsurfActive) windsurfRules.append(windsurfContractSection);
             if (zedActive)      zedRules.append(zedContractSection);
         }
+        if (!collector.testDriven().isEmpty()) {
+            cursorRules.append(cursorTestDrivenSec);
+            claudeTestDrivenSec.append("  </test_driven_requirements>\n");
+            claudeMd.append(claudeTestDrivenSec);
+            claudeMd.append("\n<rule>For any element listed in <test_driven_requirements>, you MUST provide both the implementation change AND the corresponding test code update in a single response. Changes without tests are incomplete and must not be proposed.</rule>\n");
+            codexAgents.append(codexTestDrivenSec);
+            copilot.append(copilotTestDrivenSec);
+            qwenMd.append(qwenTestDrivenSec);
+            geminiMd.append("\n## TEST-DRIVEN REQUIREMENTS\nChanges to the following elements MUST be accompanied by matching test code in the same response:\n\n").append(geminiTestDrivenSec);
+            if (windsurfActive) windsurfRules.append(windsurfTestDrivenSection);
+            if (zedActive)      zedRules.append(zedTestDrivenSection);
+        }
 
         claudeMd.append("</project_guardrails>\n");
         claudeMd.append("\n<rule>Never propose edits to files listed in <locked_files>.</rule>\n");
@@ -382,6 +415,7 @@ public final class GuardrailContentBuilder {
             if (!collector.core().isEmpty())        llmsTxt.append(llmsTxtCore);
             if (!collector.performance().isEmpty()) llmsTxt.append(llmsTxtPerformance);
             if (!collector.contract().isEmpty())    llmsTxt.append(llmsTxtContract);
+            if (!collector.testDriven().isEmpty())  llmsTxt.append(llmsTxtTestDriven);
         }
         if (llmsFullActive) {
             llmsFullTxt.append(llmsFullTxtContext);
@@ -392,6 +426,7 @@ public final class GuardrailContentBuilder {
             if (!collector.core().isEmpty())        llmsFullTxt.append(llmsFullTxtCore);
             if (!collector.performance().isEmpty()) llmsFullTxt.append(llmsFullTxtPerformance);
             if (!collector.contract().isEmpty())    llmsFullTxt.append(llmsFullTxtContract);
+            if (!collector.testDriven().isEmpty())  llmsFullTxt.append(llmsFullTxtTestDriven);
         }
 
         return new Result(buildContentMap(geminiMd), elementRules);
@@ -641,6 +676,58 @@ public final class GuardrailContentBuilder {
         if (granularActive)  appendToGranular(e, "Contract-Frozen Signature", "- **Constraint**: You may change internal logic, but MUST NOT modify the method name, parameters, return type, or checked exceptions.\n- **Reason**: " + reason);
     }
 
+    private void appendTestDriven(Element e, StringBuilder cursorTestDrivenSec, StringBuilder claudeTestDrivenSec,
+                                  StringBuilder codexTestDrivenSec, StringBuilder copilotTestDrivenSec,
+                                  StringBuilder qwenTestDrivenSec, StringBuilder geminiTestDrivenSec) {
+        AITestDriven td = e.getAnnotation(AITestDriven.class);
+        if (td == null) return;
+        String className = ElementNaming.elementPath(e);
+        int coverageGoal = td.coverageGoal();
+        String testLocation = td.testLocation();
+        String mockPolicy = td.mockPolicy();
+
+        StringBuilder frameworks = new StringBuilder();
+        for (AITestDriven.Framework f : td.framework()) {
+            if (frameworks.length() > 0) frameworks.append(", ");
+            frameworks.append(f.name());
+        }
+        String frameworksStr = frameworks.toString();
+
+        String locationHint = testLocation.isEmpty() ? "" : " Test file: " + testLocation + ".";
+        String mockHint = mockPolicy.isEmpty() ? "" : " Mock policy: " + mockPolicy + ".";
+        String summary = "Coverage goal: " + coverageGoal + "%. Framework: " + frameworksStr + "." + locationHint + mockHint;
+
+        if (cursorActive)  cursorTestDrivenSec.append("* `").append(className).append("` - ").append(summary).append("\n");
+        if (claudeActive) {
+            claudeTestDrivenSec.append("    <element path=\"").append(className).append("\">\n");
+            claudeTestDrivenSec.append("      <coverage_goal>").append(coverageGoal).append("</coverage_goal>\n");
+            claudeTestDrivenSec.append("      <frameworks>").append(frameworksStr).append("</frameworks>\n");
+            if (!testLocation.isEmpty())
+                claudeTestDrivenSec.append("      <test_location>").append(testLocation).append("</test_location>\n");
+            if (!mockPolicy.isEmpty())
+                claudeTestDrivenSec.append("      <mock_policy>").append(mockPolicy).append("</mock_policy>\n");
+            claudeTestDrivenSec.append("    </element>\n");
+        }
+        if (codexActive)   codexTestDrivenSec.append("- **").append(className).append("**: ").append(summary).append("\n");
+        if (copilotActive) copilotTestDrivenSec.append("- `").append(className).append("` - ").append(summary).append("\n");
+        if (qwenActive)    qwenTestDrivenSec.append("* `").append(className).append("` - ").append(summary).append("\n");
+        if (geminiActive)  geminiTestDrivenSec.append("- `").append(className).append("`: ").append(summary).append("\n");
+
+        if (llmsActive)     llmsTxtTestDriven.append("- [").append(ElementNaming.elementDisplayName(e)).append("](").append(className).append("): ").append(summary).append("\n");
+        if (llmsFullActive) llmsFullTxtTestDriven.append("### ").append(className).append("\n- **Coverage Goal**: ").append(coverageGoal).append("%\n- **Frameworks**: ").append(frameworksStr).append("\n");
+
+        if (llmsFullActive && !testLocation.isEmpty())
+            llmsFullTxtTestDriven.append("- **Test Location**: ").append(testLocation).append("\n");
+        if (llmsFullActive && !mockPolicy.isEmpty())
+            llmsFullTxtTestDriven.append("- **Mock Policy**: ").append(mockPolicy).append("\n");
+        if (llmsFullActive) llmsFullTxtTestDriven.append("\n");
+
+        if (aiderConvActive) aiderConventions.append("#### TEST-DRIVEN: ").append(className).append("\n- **Rule**: Changes MUST be accompanied by test updates.\n- **Coverage Goal**: ").append(coverageGoal).append("%\n- **Frameworks**: ").append(frameworksStr).append("\n");
+        if (windsurfActive)  windsurfTestDrivenSection.append("* `").append(className).append("` - ").append(summary).append("\n");
+        if (zedActive)       zedTestDrivenSection.append("- `").append(className).append("`: ").append(summary).append("\n");
+        if (granularActive)  appendToGranular(e, "Test-Driven Requirements", "- **Rule**: Changes MUST be accompanied by a matching test update.\n- **Coverage Goal**: " + coverageGoal + "%\n- **Frameworks**: " + frameworksStr + (testLocation.isEmpty() ? "" : "\n- **Test Location**: " + testLocation) + (mockPolicy.isEmpty() ? "" : "\n- **Mock Policy**: " + mockPolicy));
+    }
+
     private void appendToGranular(Element element, String title, String content) {
         Element owner = ElementNaming.owningElement(element);
         StringBuilder sb = elementRules.computeIfAbsent(owner, k -> new StringBuilder());
@@ -700,6 +787,7 @@ public final class GuardrailContentBuilder {
                 llmsTxtCore     = new StringBuilder("\n## 🧠 Core Functionality\n");
                 llmsTxtPerformance = new StringBuilder("\n## ⚡ Performance Constraints\n");
                 llmsTxtContract    = new StringBuilder("\n## 🔐 Contract-Frozen Signatures\n");
+                llmsTxtTestDriven  = new StringBuilder("\n## 🧪 Test-Driven Requirements\n");
             }
             if (llmsFullActive) {
                 llmsFullTxt = preSized("# " + projectName + " — AI Guardrail Rules\n" +
@@ -717,6 +805,7 @@ public final class GuardrailContentBuilder {
                 llmsFullTxtCore        = new StringBuilder("\n## 🧠 Core Functionality\nThe following elements are well-tested core functionality. Make changes with extreme caution.\n\n");
                 llmsFullTxtPerformance = new StringBuilder("\n## ⚡ Performance Constraints\nThe following elements are on a hot-path and have strict time/space complexity constraints.\n\n");
                 llmsFullTxtContract    = new StringBuilder("\n## 🔐 Contract-Frozen Signatures\nThe following elements have frozen public API signatures. Internal implementation may be changed, but you MUST NOT alter method names, parameter types, parameter order, return types, or checked exceptions.\n\n");
+                llmsFullTxtTestDriven  = new StringBuilder("\n## 🧪 Test-Driven Requirements\nThe following elements require a matching test update whenever their logic is modified. Changes without tests are incomplete.\n\n");
             }
         }
 
@@ -735,8 +824,9 @@ public final class GuardrailContentBuilder {
             windsurfDraftSection  = new StringBuilder("\n## 📝 IMPLEMENTATION TASKS (TODO)\nThe following elements are currently in DRAFT mode. Follow the instructions to implement them:\n\n");
             windsurfPrivacySection = new StringBuilder("\n## 🔒 PII / PRIVACY GUARDRAILS\nNever include runtime values of the following in logs, console output, external API calls, test fixtures, or mock data.\n\n");
             windsurfCoreSection     = new StringBuilder("\n## 🧠 CORE FUNCTIONALITY (CHANGE WITH EXTREME CAUTION)\nThe following elements are well-tested core components. Make changes with extreme caution.\n\n");
-            windsurfPerfSection     = new StringBuilder("\n## ⚡ PERFORMANCE CONSTRAINTS (HOT PATH)\nNever introduce O(n²) or worse complexity. Always reason about time/space before proposing changes.\n\n");
-            windsurfContractSection = new StringBuilder("\n## 🔐 CONTRACT-FROZEN SIGNATURES\nInternal implementation may be changed, but MUST NOT alter method names, parameter types, parameter order, return types, or checked exceptions.\n\n");
+            windsurfPerfSection         = new StringBuilder("\n## ⚡ PERFORMANCE CONSTRAINTS (HOT PATH)\nNever introduce O(n²) or worse complexity. Always reason about time/space before proposing changes.\n\n");
+            windsurfContractSection     = new StringBuilder("\n## 🔐 CONTRACT-FROZEN SIGNATURES\nInternal implementation may be changed, but MUST NOT alter method names, parameter types, parameter order, return types, or checked exceptions.\n\n");
+            windsurfTestDrivenSection   = new StringBuilder("\n## 🧪 TEST-DRIVEN REQUIREMENTS\nAI MUST NOT propose changes to the following elements without also providing the matching test code.\n\n");
         }
 
         if (zedActive) {
@@ -745,8 +835,9 @@ public final class GuardrailContentBuilder {
             zedDraftSection   = new StringBuilder("\n## Implementation Tasks\nThe following elements are drafts that need implementation:\n\n");
             zedPrivacySection = new StringBuilder("\n## PII / Privacy Guardrails\nNever log, expose, or suggest code that outputs runtime values of these elements:\n\n");
             zedCoreSection     = new StringBuilder("\n## Core Functionality (Extreme Caution)\nThe following elements are well-tested core components — change with extreme caution:\n\n");
-            zedPerfSection     = new StringBuilder("\n## Performance Constraints\nThe following elements are on a hot path — always reason about time and space complexity:\n\n");
-            zedContractSection = new StringBuilder("\n## Contract-Frozen Signatures\nInternal logic may be changed; never alter method names, parameter types, order, return types, or checked exceptions:\n\n");
+            zedPerfSection         = new StringBuilder("\n## Performance Constraints\nThe following elements are on a hot path — always reason about time and space complexity:\n\n");
+            zedContractSection     = new StringBuilder("\n## Contract-Frozen Signatures\nInternal logic may be changed; never alter method names, parameter types, order, return types, or checked exceptions:\n\n");
+            zedTestDrivenSection   = new StringBuilder("\n## Test-Driven Requirements\nChanges to the following elements must be accompanied by matching test code:\n\n");
         }
 
         if (codyIgnoreActive)       codyIgnoreFile       = new StringBuilder("# AUTO-GENERATED BY VIBETAGS\n" + generatedHeader + "# Cody-specific exclusion list.\n");

--- a/vibetags/src/test/java/se/deversity/vibetags/annotations/AnnotationDefinitionsTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/annotations/AnnotationDefinitionsTest.java
@@ -12,6 +12,7 @@ import se.deversity.vibetags.annotations.AIContract;
 import se.deversity.vibetags.annotations.AIPrivacy;
 import se.deversity.vibetags.annotations.AICore;
 import se.deversity.vibetags.annotations.AIPerformance;
+import se.deversity.vibetags.annotations.AITestDriven;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -402,5 +403,73 @@ class AnnotationDefinitionsTest {
     @Test
     void testAIContractCanBeAppliedToClass() {
         assertDoesNotThrow(() -> assertNotNull(TestContractClass.class));
+    }
+
+    // -----------------------------------------------------------------------
+    // @AITestDriven
+    // -----------------------------------------------------------------------
+
+    @Test
+    void testAITestDrivenAnnotationRetention() {
+        Retention retention = AITestDriven.class.getAnnotation(Retention.class);
+        assertNotNull(retention);
+        assertEquals(RetentionPolicy.SOURCE, retention.value());
+    }
+
+    @Test
+    void testAITestDrivenAnnotationTargets() {
+        Target target = AITestDriven.class.getAnnotation(Target.class);
+        assertNotNull(target);
+        assertArrayEquals(
+            new ElementType[]{ElementType.TYPE, ElementType.METHOD},
+            target.value()
+        );
+    }
+
+    @Test
+    void testAITestDrivenDefaultValues() throws NoSuchMethodException {
+        Method testLocationMethod = AITestDriven.class.getDeclaredMethod("testLocation");
+        Method coverageGoalMethod = AITestDriven.class.getDeclaredMethod("coverageGoal");
+        Method mockPolicyMethod   = AITestDriven.class.getDeclaredMethod("mockPolicy");
+        Method frameworkMethod    = AITestDriven.class.getDeclaredMethod("framework");
+
+        assertEquals("", testLocationMethod.getDefaultValue(), "testLocation must default to empty string");
+        assertEquals(100, coverageGoalMethod.getDefaultValue(), "coverageGoal must default to 100");
+        assertEquals("", mockPolicyMethod.getDefaultValue(), "mockPolicy must default to empty string");
+
+        AITestDriven.Framework[] defaultFrameworks = (AITestDriven.Framework[]) frameworkMethod.getDefaultValue();
+        assertNotNull(defaultFrameworks);
+        assertEquals(1, defaultFrameworks.length);
+        assertEquals(AITestDriven.Framework.JUNIT_5, defaultFrameworks[0], "default framework must be JUNIT_5");
+    }
+
+    @Test
+    void testAITestDrivenFrameworkEnumHasExpectedValues() {
+        AITestDriven.Framework[] values = AITestDriven.Framework.values();
+        java.util.Set<String> names = new java.util.HashSet<>();
+        for (AITestDriven.Framework f : values) names.add(f.name());
+        assertTrue(names.contains("JUNIT_5"));
+        assertTrue(names.contains("JUNIT_4"));
+        assertTrue(names.contains("TESTNG"));
+        assertTrue(names.contains("MOCKITO"));
+        assertTrue(names.contains("ASSERTJ"));
+        assertTrue(names.contains("SPOCK"));
+        assertTrue(names.contains("NONE"));
+    }
+
+    @Test
+    @AITestDriven(coverageGoal = 90, framework = {AITestDriven.Framework.JUNIT_5, AITestDriven.Framework.MOCKITO})
+    void testAITestDrivenCanBeUsedOnMethods() throws NoSuchMethodException {
+        Method method = getClass().getDeclaredMethod("testAITestDrivenCanBeUsedOnMethods");
+        AITestDriven td = method.getAnnotation(AITestDriven.class);
+        assertNull(td); // Expected: null because SOURCE retention
+    }
+
+    @AITestDriven(coverageGoal = 100, framework = {AITestDriven.Framework.JUNIT_5})
+    static class TestTestDrivenClass {}
+
+    @Test
+    void testAITestDrivenCanBeAppliedToClass() {
+        assertDoesNotThrow(() -> assertNotNull(TestTestDrivenClass.class));
     }
 }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/AITestDrivenProcessorTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/AITestDrivenProcessorTest.java
@@ -1,0 +1,683 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Name;
+import javax.tools.Diagnostic;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import se.deversity.vibetags.annotations.AIAudit;
+import se.deversity.vibetags.annotations.AIContext;
+import se.deversity.vibetags.annotations.AIContract;
+import se.deversity.vibetags.annotations.AICore;
+import se.deversity.vibetags.annotations.AIDraft;
+import se.deversity.vibetags.annotations.AIIgnore;
+import se.deversity.vibetags.annotations.AILocked;
+import se.deversity.vibetags.annotations.AIPerformance;
+import se.deversity.vibetags.annotations.AIPrivacy;
+import se.deversity.vibetags.annotations.AITestDriven;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for @AITestDriven annotation definition, validation, and per-platform output.
+ */
+class AITestDrivenProcessorTest {
+
+    // -----------------------------------------------------------------------
+    // Annotation definition
+    // -----------------------------------------------------------------------
+
+    @Test
+    void annotation_isOnClasspath() {
+        assertDoesNotThrow(() -> Class.forName("se.deversity.vibetags.annotations.AITestDriven"),
+            "@AITestDriven must be on the processor classpath");
+    }
+
+    @Test
+    void annotation_hasSourceRetention() {
+        java.lang.annotation.Retention retention =
+            AITestDriven.class.getAnnotation(java.lang.annotation.Retention.class);
+        assertNotNull(retention, "@AITestDriven must declare @Retention");
+        assertEquals(java.lang.annotation.RetentionPolicy.SOURCE, retention.value(),
+            "@AITestDriven must use SOURCE retention for zero runtime overhead");
+    }
+
+    @Test
+    void annotation_targetsTypeAndMethod() {
+        java.lang.annotation.Target target =
+            AITestDriven.class.getAnnotation(java.lang.annotation.Target.class);
+        assertNotNull(target, "@AITestDriven must declare @Target");
+        assertArrayEquals(
+            new java.lang.annotation.ElementType[]{
+                java.lang.annotation.ElementType.TYPE,
+                java.lang.annotation.ElementType.METHOD
+            },
+            target.value(),
+            "@AITestDriven must target TYPE and METHOD only"
+        );
+    }
+
+    @Test
+    void annotation_testLocationDefaultIsEmpty() throws Exception {
+        java.lang.reflect.Method m = AITestDriven.class.getDeclaredMethod("testLocation");
+        assertEquals("", m.getDefaultValue(), "testLocation() must default to empty string");
+    }
+
+    @Test
+    void annotation_coverageGoalDefaultIs100() throws Exception {
+        java.lang.reflect.Method m = AITestDriven.class.getDeclaredMethod("coverageGoal");
+        assertEquals(100, m.getDefaultValue(), "coverageGoal() must default to 100");
+    }
+
+    @Test
+    void annotation_frameworkDefaultIsJunit5() throws Exception {
+        java.lang.reflect.Method m = AITestDriven.class.getDeclaredMethod("framework");
+        AITestDriven.Framework[] defaults = (AITestDriven.Framework[]) m.getDefaultValue();
+        assertNotNull(defaults);
+        assertEquals(1, defaults.length);
+        assertEquals(AITestDriven.Framework.JUNIT_5, defaults[0],
+            "Default framework must be JUNIT_5");
+    }
+
+    @Test
+    void annotation_mockPolicyDefaultIsEmpty() throws Exception {
+        java.lang.reflect.Method m = AITestDriven.class.getDeclaredMethod("mockPolicy");
+        assertEquals("", m.getDefaultValue(), "mockPolicy() must default to empty string");
+    }
+
+    @Test
+    void framework_enum_hasExpectedConstants() {
+        Set<String> names = new java.util.HashSet<>();
+        for (AITestDriven.Framework f : AITestDriven.Framework.values()) {
+            names.add(f.name());
+        }
+        assertTrue(names.contains("JUNIT_5"),  "Framework enum must contain JUNIT_5");
+        assertTrue(names.contains("JUNIT_4"),  "Framework enum must contain JUNIT_4");
+        assertTrue(names.contains("TESTNG"),   "Framework enum must contain TESTNG");
+        assertTrue(names.contains("MOCKITO"),  "Framework enum must contain MOCKITO");
+        assertTrue(names.contains("ASSERTJ"),  "Framework enum must contain ASSERTJ");
+        assertTrue(names.contains("SPOCK"),    "Framework enum must contain SPOCK");
+        assertTrue(names.contains("NONE"),     "Framework enum must contain NONE");
+    }
+
+    // -----------------------------------------------------------------------
+    // Validation: @AITestDriven + @AIIgnore
+    // -----------------------------------------------------------------------
+
+    @Test
+    void validateAnnotations_testDrivenAndIgnore_emitsContradictionWarning() {
+        List<String> warnings = new ArrayList<>();
+        Messager messager = capturingMessager(Diagnostic.Kind.WARNING, warnings);
+        AIGuardrailProcessor processor = new AIGuardrailProcessor();
+
+        AITestDriven tdIgnore = mockTestDriven(100, "");
+        Element element = mock(Element.class);
+        when(element.toString()).thenReturn("com.example.OrderService.processPayment");
+        when(element.getAnnotation(AITestDriven.class)).thenReturn(tdIgnore);
+        when(element.getAnnotation(AIIgnore.class)).thenReturn(mock(AIIgnore.class));
+
+        RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AILocked.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIAudit.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIPrivacy.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIContract.class);
+        doReturn(Set.of(element)).when(roundEnv).getElementsAnnotatedWith(AITestDriven.class);
+
+        processor.validateAnnotations(messager, roundEnv);
+
+        assertTrue(warnings.stream().anyMatch(w -> w.contains("@AITestDriven") && w.contains("@AIIgnore")),
+            "Should warn about @AITestDriven + @AIIgnore combination");
+        assertTrue(warnings.stream().anyMatch(w -> w.toLowerCase().contains("ignored") || w.toLowerCase().contains("excludes")),
+            "Warning should explain why the combination is problematic");
+    }
+
+    @Test
+    void validateAnnotations_testDrivenWithoutIgnore_noContradictionWarning() {
+        List<String> warnings = new ArrayList<>();
+        Messager messager = capturingMessager(Diagnostic.Kind.WARNING, warnings);
+        AIGuardrailProcessor processor = new AIGuardrailProcessor();
+
+        AITestDriven tdAlone = mockTestDriven(100, "");
+        Element element = mock(Element.class);
+        when(element.toString()).thenReturn("com.example.OrderService.processPayment");
+        when(element.getAnnotation(AITestDriven.class)).thenReturn(tdAlone);
+        when(element.getAnnotation(AIIgnore.class)).thenReturn(null);
+
+        RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AILocked.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIAudit.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIPrivacy.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIContract.class);
+        doReturn(Set.of(element)).when(roundEnv).getElementsAnnotatedWith(AITestDriven.class);
+
+        processor.validateAnnotations(messager, roundEnv);
+
+        assertFalse(warnings.stream().anyMatch(w -> w.contains("@AITestDriven") && w.contains("@AIIgnore")),
+            "No warning when @AITestDriven is used alone");
+    }
+
+    // -----------------------------------------------------------------------
+    // Validation: @AITestDriven + @AILocked
+    // -----------------------------------------------------------------------
+
+    @Test
+    void validateAnnotations_testDrivenAndLocked_emitsContradictionWarning() {
+        List<String> warnings = new ArrayList<>();
+        Messager messager = capturingMessager(Diagnostic.Kind.WARNING, warnings);
+        AIGuardrailProcessor processor = new AIGuardrailProcessor();
+
+        AITestDriven tdLocked = mockTestDriven(100, "");
+        Element element = mock(Element.class);
+        when(element.toString()).thenReturn("com.example.LegacyService.compute");
+        when(element.getAnnotation(AITestDriven.class)).thenReturn(tdLocked);
+        when(element.getAnnotation(AILocked.class)).thenReturn(mock(AILocked.class));
+        when(element.getAnnotation(AIDraft.class)).thenReturn(null);
+        when(element.getAnnotation(AIIgnore.class)).thenReturn(null);
+
+        RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+        doReturn(Set.of(element)).when(roundEnv).getElementsAnnotatedWith(AILocked.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIAudit.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIPrivacy.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIContract.class);
+        doReturn(Set.of(element)).when(roundEnv).getElementsAnnotatedWith(AITestDriven.class);
+
+        processor.validateAnnotations(messager, roundEnv);
+
+        assertTrue(warnings.stream().anyMatch(w -> w.contains("@AITestDriven") && w.contains("@AILocked")),
+            "Should warn about @AITestDriven + @AILocked combination");
+    }
+
+    // -----------------------------------------------------------------------
+    // Validation: coverageGoal out of range
+    // -----------------------------------------------------------------------
+
+    @Test
+    void validateAnnotations_coverageGoalAbove100_emitsWarning() {
+        List<String> warnings = new ArrayList<>();
+        Messager messager = capturingMessager(Diagnostic.Kind.WARNING, warnings);
+        AIGuardrailProcessor processor = new AIGuardrailProcessor();
+
+        AITestDriven tdAbove = mockTestDriven(150, "");
+        Element element = mock(Element.class);
+        when(element.toString()).thenReturn("com.example.Service.method");
+        when(element.getAnnotation(AITestDriven.class)).thenReturn(tdAbove);
+        when(element.getAnnotation(AIIgnore.class)).thenReturn(null);
+        when(element.getAnnotation(AILocked.class)).thenReturn(null);
+
+        RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AILocked.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIAudit.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIPrivacy.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIContract.class);
+        doReturn(Set.of(element)).when(roundEnv).getElementsAnnotatedWith(AITestDriven.class);
+
+        processor.validateAnnotations(messager, roundEnv);
+
+        assertTrue(warnings.stream().anyMatch(w -> w.contains("coverageGoal") && w.contains("150")),
+            "Should warn about coverageGoal > 100");
+    }
+
+    @Test
+    void validateAnnotations_coverageGoalNegative_emitsWarning() {
+        List<String> warnings = new ArrayList<>();
+        Messager messager = capturingMessager(Diagnostic.Kind.WARNING, warnings);
+        AIGuardrailProcessor processor = new AIGuardrailProcessor();
+
+        AITestDriven tdNeg = mockTestDriven(-1, "");
+        Element element = mock(Element.class);
+        when(element.toString()).thenReturn("com.example.Service.method");
+        when(element.getAnnotation(AITestDriven.class)).thenReturn(tdNeg);
+        when(element.getAnnotation(AIIgnore.class)).thenReturn(null);
+        when(element.getAnnotation(AILocked.class)).thenReturn(null);
+
+        RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AILocked.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIAudit.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIPrivacy.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIContract.class);
+        doReturn(Set.of(element)).when(roundEnv).getElementsAnnotatedWith(AITestDriven.class);
+
+        processor.validateAnnotations(messager, roundEnv);
+
+        assertTrue(warnings.stream().anyMatch(w -> w.contains("coverageGoal")),
+            "Should warn about negative coverageGoal");
+    }
+
+    @Test
+    void validateAnnotations_coverageGoal100_noWarning() {
+        List<String> warnings = new ArrayList<>();
+        Messager messager = capturingMessager(Diagnostic.Kind.WARNING, warnings);
+        AIGuardrailProcessor processor = new AIGuardrailProcessor();
+
+        AITestDriven tdValid = mockTestDriven(100, "");
+        Element element = mock(Element.class);
+        when(element.toString()).thenReturn("com.example.Service.method");
+        when(element.getAnnotation(AITestDriven.class)).thenReturn(tdValid);
+        when(element.getAnnotation(AIIgnore.class)).thenReturn(null);
+        when(element.getAnnotation(AILocked.class)).thenReturn(null);
+
+        RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AILocked.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIAudit.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIPrivacy.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIContract.class);
+        doReturn(Set.of(element)).when(roundEnv).getElementsAnnotatedWith(AITestDriven.class);
+
+        processor.validateAnnotations(messager, roundEnv);
+
+        assertFalse(warnings.stream().anyMatch(w -> w.contains("coverageGoal")),
+            "No coverageGoal warning for valid value 100");
+    }
+
+    // -----------------------------------------------------------------------
+    // process() — test-driven sections written to each platform file
+    // -----------------------------------------------------------------------
+
+    @Test
+    void process_withTestDrivenAnnotation_writesTestDrivenSectionToCursorRules() throws Exception {
+        withCwdSignalFiles(List.of(".cursorrules"), () -> {
+            CapturingProcessor processor = makeCapturingProcessor();
+            processor.process(Set.of(), testDrivenRoundEnv("com.example.OrderService.calculateDiscount", 100, "JUNIT_5", ""));
+            triggerGeneration(processor);
+
+            String content = processor.contentFor(".cursorrules");
+            assertTrue(content.contains("TEST-DRIVEN"),
+                ".cursorrules must have test-driven section");
+            assertTrue(content.contains("com.example.OrderService.calculateDiscount"),
+                ".cursorrules must list the annotated element");
+            assertTrue(content.contains("100"),
+                ".cursorrules must include the coverage goal");
+        });
+    }
+
+    @Test
+    void process_withTestDrivenAnnotation_writesTestDrivenSectionToClaudeMd() throws Exception {
+        withCwdSignalFiles(List.of("CLAUDE.md"), () -> {
+            CapturingProcessor processor = makeCapturingProcessor();
+            processor.process(Set.of(), testDrivenRoundEnv("com.example.OrderService.updateOrderStatus", 95, "JUNIT_5", "src/test/java/com/example/service/OrderServiceTest.java"));
+            triggerGeneration(processor);
+
+            String content = processor.contentFor("CLAUDE.md");
+            assertTrue(content.contains("<test_driven_requirements>"),
+                "CLAUDE.md must contain <test_driven_requirements> XML element");
+            assertTrue(content.contains("</test_driven_requirements>"),
+                "CLAUDE.md must close <test_driven_requirements>");
+            assertTrue(content.contains("com.example.OrderService.updateOrderStatus"),
+                "CLAUDE.md must list the annotated element");
+            assertTrue(content.contains("<coverage_goal>95</coverage_goal>"),
+                "CLAUDE.md must include coverage_goal element");
+            assertTrue(content.contains("OrderServiceTest.java"),
+                "CLAUDE.md must include the test_location when provided");
+            assertTrue(content.contains("tests are incomplete"),
+                "CLAUDE.md rule must instruct that changes without tests are incomplete");
+        });
+    }
+
+    @Test
+    void process_withTestDrivenAnnotation_writesTestDrivenSectionToAgentsMd() throws Exception {
+        withCwdSignalFiles(List.of("AGENTS.md"), () -> {
+            CapturingProcessor processor = makeCapturingProcessor();
+            processor.process(Set.of(), testDrivenRoundEnv("com.example.BillingService.invoice", 100, "JUNIT_5", ""));
+            triggerGeneration(processor);
+
+            String content = processor.contentFor("AGENTS.md");
+            assertTrue(content.contains("TEST-DRIVEN"),
+                "AGENTS.md must have test-driven section");
+            assertTrue(content.contains("com.example.BillingService.invoice"),
+                "AGENTS.md must list the annotated element");
+        });
+    }
+
+    @Test
+    void process_withTestDrivenAnnotation_writesTestDrivenSectionToGemini() throws Exception {
+        withCwdSignalFiles(List.of("gemini_instructions.md"), () -> {
+            CapturingProcessor processor = makeCapturingProcessor();
+            processor.process(Set.of(), testDrivenRoundEnv("com.example.PricingService.calculatePrice", 100, "JUNIT_5", ""));
+            triggerGeneration(processor);
+
+            String content = processor.contentFor("gemini_instructions.md");
+            assertTrue(content.contains("TEST-DRIVEN"),
+                "gemini_instructions.md must have test-driven section");
+            assertTrue(content.contains("com.example.PricingService.calculatePrice"),
+                "gemini_instructions.md must list the annotated element");
+        });
+    }
+
+    @Test
+    void process_withTestDrivenAnnotation_writesTestDrivenSectionToCopilot() throws Exception {
+        withCwdSignalFiles(List.of(".github/copilot-instructions.md"), () -> {
+            CapturingProcessor processor = makeCapturingProcessor();
+            processor.process(Set.of(), testDrivenRoundEnv("com.example.ReportService.generate", 80, "JUNIT_5", ""));
+            triggerGeneration(processor);
+
+            String content = processor.contentFor("copilot-instructions.md");
+            assertTrue(content.contains("Test-Driven"),
+                "copilot-instructions.md must have test-driven section");
+            assertTrue(content.contains("com.example.ReportService.generate"),
+                "copilot-instructions.md must list the annotated element");
+        });
+    }
+
+    @Test
+    void process_withTestDrivenAnnotation_writesTestDrivenSectionToQwen() throws Exception {
+        withCwdSignalFiles(List.of("QWEN.md"), () -> {
+            CapturingProcessor processor = makeCapturingProcessor();
+            processor.process(Set.of(), testDrivenRoundEnv("com.example.CatalogService.search", 90, "JUNIT_5", ""));
+            triggerGeneration(processor);
+
+            String content = processor.contentFor("QWEN.md");
+            assertTrue(content.contains("TEST-DRIVEN"),
+                "QWEN.md must have test-driven section");
+            assertTrue(content.contains("com.example.CatalogService.search"),
+                "QWEN.md must list the annotated element");
+        });
+    }
+
+    @Test
+    void process_noTestDrivenAnnotations_noTestDrivenSectionWritten() throws Exception {
+        withCwdSignalFiles(List.of(".cursorrules"), () -> {
+            CapturingProcessor processor = makeCapturingProcessor();
+            processor.process(Set.of(), emptyRoundEnv());
+            triggerGeneration(processor);
+
+            String content = processor.contentFor(".cursorrules");
+            assertFalse(content.contains("TEST-DRIVEN"),
+                "No test-driven section when no @AITestDriven annotations are present");
+        });
+    }
+
+    @Test
+    void process_testDrivenWithLocation_locationAppearsInOutput() throws Exception {
+        withCwdSignalFiles(List.of("CLAUDE.md"), () -> {
+            CapturingProcessor processor = makeCapturingProcessor();
+            processor.process(Set.of(), testDrivenRoundEnv("com.example.Service.method", 100, "JUNIT_5", "src/test/java/com/example/ServiceTest.java"));
+            triggerGeneration(processor);
+
+            String content = processor.contentFor("CLAUDE.md");
+            assertTrue(content.contains("ServiceTest.java"),
+                "Test location must appear in output when provided");
+        });
+    }
+
+    @Test
+    void process_testDrivenWithMockPolicy_mockPolicyAppearsInOutput() throws Exception {
+        withCwdSignalFiles(List.of(".cursorrules"), () -> {
+            CapturingProcessor processor = makeCapturingProcessor();
+
+            Element element = testDrivenElement("com.example.Service.method", 100, "Use H2 for database tests");
+            RoundEnvironment roundEnv = testDrivenRoundEnvWith(element);
+
+            processor.process(Set.of(), roundEnv);
+            triggerGeneration(processor);
+
+            String content = processor.contentFor(".cursorrules");
+            assertTrue(content.contains("H2 for database tests"),
+                "Mock policy must appear in output when provided");
+        });
+    }
+
+    @Test
+    void process_testDrivenAnnotation_llmsTxtContainsTestDrivenSection() throws Exception {
+        withCwdSignalFiles(List.of("llms.txt"), () -> {
+            CapturingProcessor processor = makeCapturingProcessor();
+            processor.process(Set.of(), testDrivenRoundEnv("com.example.OrderService.calculateDiscount", 100, "JUNIT_5", ""));
+            triggerGeneration(processor);
+
+            String content = processor.contentFor("llms.txt");
+            assertTrue(content.contains("Test-Driven Requirements"),
+                "llms.txt must have Test-Driven Requirements section");
+        });
+    }
+
+    @Test
+    void process_testDrivenAnnotation_llmsFullTxtContainsTestDrivenSection() throws Exception {
+        withCwdSignalFiles(List.of("llms-full.txt"), () -> {
+            CapturingProcessor processor = makeCapturingProcessor();
+            processor.process(Set.of(), testDrivenRoundEnv("com.example.OrderService.calculateDiscount", 100, "JUNIT_5", ""));
+            triggerGeneration(processor);
+
+            String content = processor.contentFor("llms-full.txt");
+            assertTrue(content.contains("Test-Driven Requirements"),
+                "llms-full.txt must have Test-Driven Requirements section");
+            assertTrue(content.contains("Coverage Goal"),
+                "llms-full.txt must include Coverage Goal entry");
+        });
+    }
+
+    @Test
+    void process_multipleTestDrivenElements_allListedInOutput() throws Exception {
+        withCwdSignalFiles(List.of(".cursorrules"), () -> {
+            Element el1 = testDrivenElement("com.example.OrderService.calculateDiscount", 100, "");
+            Element el2 = testDrivenElement("com.example.BillingService.invoice", 90, "");
+
+            RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+            when(roundEnv.processingOver()).thenReturn(false);
+            doReturn(Set.of(el1, el2)).when(roundEnv).getElementsAnnotatedWith(AITestDriven.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AILocked.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIContext.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIIgnore.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIAudit.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIDraft.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIPrivacy.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AICore.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIPerformance.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIContract.class);
+
+            CapturingProcessor processor = makeCapturingProcessor();
+            processor.process(Set.of(), roundEnv);
+            triggerGeneration(processor);
+
+            String content = processor.contentFor(".cursorrules");
+            assertTrue(content.contains("com.example.OrderService.calculateDiscount"), "Must list first element");
+            assertTrue(content.contains("com.example.BillingService.invoice"), "Must list second element");
+        });
+    }
+
+    @Test
+    void process_testDrivenAnnotation_aiderConventionsContainsTestDrivenSection() throws Exception {
+        withCwdSignalFiles(List.of("CONVENTIONS.md"), () -> {
+            CapturingProcessor processor = makeCapturingProcessor();
+            processor.process(Set.of(), testDrivenRoundEnv("com.example.BillingApi.invoice", 100, "JUNIT_5", ""));
+            triggerGeneration(processor);
+
+            String content = processor.contentFor("CONVENTIONS.md");
+            assertTrue(content.contains("TEST-DRIVEN"),
+                "CONVENTIONS.md must mention TEST-DRIVEN");
+            assertTrue(content.contains("com.example.BillingApi.invoice"),
+                "CONVENTIONS.md must list the annotated element");
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    static class CapturingProcessor extends AIGuardrailProcessor {
+        final java.util.Map<String, String> captured = new java.util.LinkedHashMap<>();
+
+        @Override
+        public boolean writeFileIfChanged(String path, String content, boolean hasNewRules) {
+            String key = java.nio.file.Paths.get(path).getFileName().toString();
+            captured.put(key, content);
+            return true;
+        }
+
+        String contentFor(String filename) {
+            return captured.getOrDefault(filename, "");
+        }
+    }
+
+    private CapturingProcessor makeCapturingProcessor() {
+        CapturingProcessor processor = new CapturingProcessor();
+        Messager messager = noopMessager();
+        ProcessingEnvironment env = mock(ProcessingEnvironment.class);
+        when(env.getMessager()).thenReturn(messager);
+        when(env.getOptions()).thenReturn(java.util.Map.of());
+        processor.init(env);
+        return processor;
+    }
+
+    private void withCwdSignalFiles(List<String> relPaths, ThrowingRunnable block) throws Exception {
+        java.nio.file.Path cwd = java.nio.file.Paths.get("").toAbsolutePath();
+        List<java.nio.file.Path> created = new ArrayList<>();
+        try {
+            for (String rel : relPaths) {
+                java.nio.file.Path p = cwd.resolve(rel);
+                if (!Files.exists(p)) {
+                    Files.createDirectories(p.getParent());
+                    Files.createFile(p);
+                    created.add(p);
+                }
+            }
+            block.run();
+        } finally {
+            for (java.nio.file.Path p : created) {
+                Files.deleteIfExists(p);
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    private static AITestDriven mockTestDriven(int coverageGoal, String testLocation) {
+        AITestDriven td = mock(AITestDriven.class);
+        when(td.coverageGoal()).thenReturn(coverageGoal);
+        when(td.testLocation()).thenReturn(testLocation);
+        when(td.mockPolicy()).thenReturn("");
+        doReturn(new AITestDriven.Framework[]{AITestDriven.Framework.JUNIT_5}).when(td).framework();
+        return td;
+    }
+
+    private static Element testDrivenElement(String qualifiedName, int coverageGoal, String mockPolicy) {
+        Element element = mock(Element.class);
+        when(element.toString()).thenReturn(qualifiedName);
+        when(element.getKind()).thenReturn(ElementKind.METHOD);
+        String simpleName = qualifiedName.contains(".")
+            ? qualifiedName.substring(qualifiedName.lastIndexOf('.') + 1)
+            : qualifiedName;
+        when(element.getSimpleName()).thenReturn(nameOf(simpleName));
+
+        AITestDriven td = mock(AITestDriven.class);
+        when(td.coverageGoal()).thenReturn(coverageGoal);
+        when(td.testLocation()).thenReturn("");
+        when(td.mockPolicy()).thenReturn(mockPolicy);
+        doReturn(new AITestDriven.Framework[]{AITestDriven.Framework.JUNIT_5}).when(td).framework();
+        when(element.getAnnotation(AITestDriven.class)).thenReturn(td);
+        return element;
+    }
+
+    private static Element testDrivenElementWithLocation(String qualifiedName, int coverageGoal, String testLocation) {
+        Element element = mock(Element.class);
+        when(element.toString()).thenReturn(qualifiedName);
+        when(element.getKind()).thenReturn(ElementKind.METHOD);
+        String simpleName = qualifiedName.contains(".")
+            ? qualifiedName.substring(qualifiedName.lastIndexOf('.') + 1)
+            : qualifiedName;
+        when(element.getSimpleName()).thenReturn(nameOf(simpleName));
+
+        AITestDriven td = mock(AITestDriven.class);
+        when(td.coverageGoal()).thenReturn(coverageGoal);
+        when(td.testLocation()).thenReturn(testLocation);
+        when(td.mockPolicy()).thenReturn("");
+        doReturn(new AITestDriven.Framework[]{AITestDriven.Framework.JUNIT_5}).when(td).framework();
+        when(element.getAnnotation(AITestDriven.class)).thenReturn(td);
+        return element;
+    }
+
+    private static RoundEnvironment testDrivenRoundEnv(String qualifiedName, int coverageGoal, String frameworkStr, String testLocation) {
+        RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+        when(roundEnv.processingOver()).thenReturn(false);
+
+        Element element = testDrivenElementWithLocation(qualifiedName, coverageGoal, testLocation);
+        doReturn(Set.of(element)).when(roundEnv).getElementsAnnotatedWith(AITestDriven.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AILocked.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIContext.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIIgnore.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIAudit.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIDraft.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIPrivacy.class);
+        return roundEnv;
+    }
+
+    private static RoundEnvironment testDrivenRoundEnvWith(Element element) {
+        RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+        when(roundEnv.processingOver()).thenReturn(false);
+        doReturn(Set.of(element)).when(roundEnv).getElementsAnnotatedWith(AITestDriven.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AILocked.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIContext.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIIgnore.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIAudit.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIDraft.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIPrivacy.class);
+        return roundEnv;
+    }
+
+    private static RoundEnvironment emptyRoundEnv() {
+        RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+        when(roundEnv.processingOver()).thenReturn(false);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AITestDriven.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AILocked.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIContext.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIIgnore.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIAudit.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIDraft.class);
+        doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIPrivacy.class);
+        return roundEnv;
+    }
+
+    private static void triggerGeneration(AIGuardrailProcessor processor) {
+        RoundEnvironment genEnv = mock(RoundEnvironment.class);
+        when(genEnv.processingOver()).thenReturn(true);
+        doReturn(Set.of()).when(genEnv).getElementsAnnotatedWith(AITestDriven.class);
+        doReturn(Set.of()).when(genEnv).getElementsAnnotatedWith(AILocked.class);
+        doReturn(Set.of()).when(genEnv).getElementsAnnotatedWith(AIContext.class);
+        doReturn(Set.of()).when(genEnv).getElementsAnnotatedWith(AIIgnore.class);
+        doReturn(Set.of()).when(genEnv).getElementsAnnotatedWith(AIAudit.class);
+        doReturn(Set.of()).when(genEnv).getElementsAnnotatedWith(AIDraft.class);
+        doReturn(Set.of()).when(genEnv).getElementsAnnotatedWith(AIPrivacy.class);
+        processor.process(Set.of(), genEnv);
+    }
+
+    private static Name nameOf(String value) {
+        return new Name() {
+            public boolean contentEquals(CharSequence cs) { return value.contentEquals(cs); }
+            public int length() { return value.length(); }
+            public char charAt(int index) { return value.charAt(index); }
+            public CharSequence subSequence(int start, int end) { return value.subSequence(start, end); }
+            public String toString() { return value; }
+        };
+    }
+
+    private static Messager noopMessager() {
+        return new Messager() {
+            public void printMessage(Diagnostic.Kind kind, CharSequence msg) {}
+            public void printMessage(Diagnostic.Kind kind, CharSequence msg, javax.lang.model.element.Element e) {}
+            public void printMessage(Diagnostic.Kind kind, CharSequence msg, javax.lang.model.element.Element e, javax.lang.model.element.AnnotationMirror a) {}
+            public void printMessage(Diagnostic.Kind kind, CharSequence msg, javax.lang.model.element.Element e, javax.lang.model.element.AnnotationMirror a, javax.lang.model.element.AnnotationValue v) {}
+        };
+    }
+
+    private static Messager capturingMessager(Diagnostic.Kind capture, List<String> sink) {
+        return new Messager() {
+            public void printMessage(Diagnostic.Kind kind, CharSequence msg) {
+                if (kind == capture) sink.add(msg.toString());
+            }
+            public void printMessage(Diagnostic.Kind kind, CharSequence msg, javax.lang.model.element.Element e) { printMessage(kind, msg); }
+            public void printMessage(Diagnostic.Kind kind, CharSequence msg, javax.lang.model.element.Element e, javax.lang.model.element.AnnotationMirror a) { printMessage(kind, msg); }
+            public void printMessage(Diagnostic.Kind kind, CharSequence msg, javax.lang.model.element.Element e, javax.lang.model.element.AnnotationMirror a, javax.lang.model.element.AnnotationValue v) { printMessage(kind, msg); }
+        };
+    }
+}

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/AITestDrivenProcessorTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/AITestDrivenProcessorTest.java
@@ -427,6 +427,61 @@ class AITestDrivenProcessorTest {
     }
 
     @Test
+    void process_testDrivenWithMockPolicy_mockPolicyAppearsInClaudeMd() throws Exception {
+        withCwdSignalFiles(List.of("CLAUDE.md"), () -> {
+            CapturingProcessor processor = makeCapturingProcessor();
+
+            Element element = testDrivenElement("com.example.PaymentService.charge", 95, "Mock Stripe client; use real validation logic");
+            RoundEnvironment roundEnv = testDrivenRoundEnvWith(element);
+
+            processor.process(Set.of(), roundEnv);
+            triggerGeneration(processor);
+
+            String content = processor.contentFor("CLAUDE.md");
+            assertTrue(content.contains("mock_policy"),
+                "Claude XML must include <mock_policy> tag when mockPolicy is non-empty");
+            assertTrue(content.contains("Mock Stripe client"),
+                "Claude XML must include the mock policy value");
+        });
+    }
+
+    @Test
+    void process_testDrivenWithLocation_locationAppearsInLlmsFullTxt() throws Exception {
+        withCwdSignalFiles(List.of("llms-full.txt"), () -> {
+            CapturingProcessor processor = makeCapturingProcessor();
+            processor.process(Set.of(), testDrivenRoundEnv(
+                "com.example.OrderService.placeOrder", 100, "JUNIT_5",
+                "src/test/java/com/example/OrderServiceTest.java"));
+            triggerGeneration(processor);
+
+            String content = processor.contentFor("llms-full.txt");
+            assertTrue(content.contains("Test Location"),
+                "llms-full.txt must include Test Location when testLocation is provided");
+            assertTrue(content.contains("OrderServiceTest.java"),
+                "llms-full.txt must include the testLocation path");
+        });
+    }
+
+    @Test
+    void process_testDrivenWithMockPolicy_mockPolicyAppearsInLlmsFullTxt() throws Exception {
+        withCwdSignalFiles(List.of("llms-full.txt"), () -> {
+            CapturingProcessor processor = makeCapturingProcessor();
+
+            Element element = testDrivenElement("com.example.BillingService.invoice", 90, "Always mock the mailer");
+            RoundEnvironment roundEnv = testDrivenRoundEnvWith(element);
+
+            processor.process(Set.of(), roundEnv);
+            triggerGeneration(processor);
+
+            String content = processor.contentFor("llms-full.txt");
+            assertTrue(content.contains("Mock Policy"),
+                "llms-full.txt must include Mock Policy section when mockPolicy is provided");
+            assertTrue(content.contains("Always mock the mailer"),
+                "llms-full.txt must include the mockPolicy value");
+        });
+    }
+
+    @Test
     void process_testDrivenAnnotation_llmsTxtContainsTestDrivenSection() throws Exception {
         withCwdSignalFiles(List.of("llms.txt"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();


### PR DESCRIPTION
## Summary

- Adds `@AITestDriven` annotation targeting `TYPE` and `METHOD`, with attributes `testLocation`, `coverageGoal` (default 100), `framework` (inner `Framework` enum), and `mockPolicy`
- Processor emits `<test_driven_requirements>` blocks (Claude), markdown sections (Cursor, Codex, Windsurf, Zed, Copilot, Qwen, Gemini, Aider), and `llms.txt` / `llms-full.txt` entries
- Validator warns on `@AITestDriven + @AIIgnore` (contradictory), `@AITestDriven + @AILocked` (contradictory), and out-of-range `coverageGoal`
- Fixed `BuildFingerprint` to include `@AITestDriven` attributes — previously a cache fingerprint collision caused all `@AITestDriven`-only test runs to be short-circuited after the first

## Test plan

- [x] 477 unit tests pass (`mvn test`)
- [x] 27 new tests in `AITestDrivenProcessorTest` covering annotation definition, validation, and per-platform output
- [x] `AnnotationDefinitionsTest` extended with 6 new tests for `@AITestDriven` retention, targets, defaults, and `Framework` enum
- [x] Example project compiles end-to-end; `example/CLAUDE.md` contains `<test_driven_requirements>` with correct output for `calculateDiscount` and `updateOrderStatus`
- [x] Checkstyle clean on new `AITestDriven.java` (enum constants have Javadoc, all lines ≤ 80 chars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)