### PR TITLE
chore(skill): bump vibetags-usage skill to v0.9.5

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation annotations, or wants to control how AI tools interact with Java code.
-version: 0.9.0
+version: 0.9.5
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>0.9.0</version>
+    <version>0.9.5</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:0.9.0'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:0.9.0'
+compileOnly 'se.deversity.vibetags:vibetags-processor:0.9.5'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:0.9.5'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)
@@ -60,6 +60,7 @@ touch .plandex.yaml                        # Plandex
 touch .doubleignore                        # Double.bot
 mkdir -p .interpreter/profiles && touch .interpreter/profiles/vibetags.yaml  # Open Interpreter
 touch .codeiumignore                       # Codeium
+touch DESIGN.md                            # AI design agents (Cursor, Claude, Copilot, etc.)
 ```
 
 To remove a platform: delete its file — VibeTags will never recreate it.
@@ -545,3 +546,4 @@ tasks.withType(JavaCompile) {
 | `.doubleignore` | Double.bot |
 | `.interpreter/profiles/vibetags.yaml` | Open Interpreter |
 | `.codeiumignore` | Codeium |
+| `DESIGN.md` | AI design agents (Cursor, Claude, Copilot, etc.) |


### PR DESCRIPTION
Update dependency versions and add DESIGN.md to the opt-in and output file tables. All five v0.9.5 annotations were already documented.