### PR TITLE
release: v0.9.8

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -706,7 +706,9 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v0.9.5...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v0.9.8...HEAD
+[0.9.8]: https://github.com/PIsberg/vibetags/compare/v0.9.7...v0.9.8
+[0.9.7]: https://github.com/PIsberg/vibetags/compare/v0.9.5...v0.9.7
 [0.9.5]: https://github.com/PIsberg/vibetags/compare/v0.8.0...v0.9.5
 [0.8.0]: https://github.com/PIsberg/vibetags/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/PIsberg/vibetags/compare/v0.7.0...v0.7.1


### PR DESCRIPTION
## v0.9.8

### Added
- **JSpecify 1.0.0 null annotations** — `@NullMarked` package-info.java for all 5 processor packages; `@Nullable` on all nullable return types, fields, and constructor parameters throughout the codebase
- **ArchUnit 1.4.0 architecture fitness functions** — 7 rules enforcing formatter/renderer structural invariants (final, stateless, correct interface) as part of the normal test suite
- **SpotBugs static analysis** — `spotbugs-maven-plugin:4.9.8.3`, `effort=Max`, `threshold=Low`; runs in verify phase, fails on any finding

### Fixed
- `AnnotationCollector` — unmodifiable set wrappers on all 27 getters (SpotBugs EI_EXPOSE_REP)
- `RenderingContext` — defensive copy in constructor (SpotBugs EI_EXPOSE_REP2)
- `LlmsRenderer` — 25 anonymous classes → lambdas (SpotBugs SIC_INNER_SHOULD_BE_STATIC_ANON)
- `VibeTagsLogger` — narrowed catch to RuntimeException (SpotBugs REC_CATCH_EXCEPTION)
- `GuardrailFileWriter`, `ModuleSidecar`, `WriteCache` — null guards for Path.getFileName/getParent
- `AIGuardrailProcessor` — removed 5 unread field declarations
- `ClineRenderer`, `JunieRenderer` — shared CursorRenderer field changed to static final (ArchUnit)

### Refactored
- **`GuardrailContentBuilder` modularised** (PR #178): 2100-line monolith decomposed into `AnnotationFormatter` SPI (27 formatter classes), `PlatformRenderer` SPI (18 renderer classes), `FormatterRegistry`, `PlatformRendererRegistry`, `RenderingContext`, and `Platform` enum

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)