### PR TITLE
release: 1.0.0-RC1

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary annotations, or wants to control how AI tools interact with Java code.
-version: 0.9.9
+version: 1.0.0-RC1
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>0.9.9</version>
+    <version>1.0.0-RC1</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:0.9.9'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:0.9.9'
+compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.0-RC1'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC1'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>0.9.9</version>
+            <version>1.0.0-RC1</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -66,7 +66,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>0.9.9</version>
+                        <version>1.0.0-RC1</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -107,8 +107,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:0.9.9')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:0.9.9')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC1')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -323,7 +323,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>0.9.9</version>
+            <version>1.0.0-RC1</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -348,7 +348,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>0.9.9</version>
+                        <version>1.0.0-RC1</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -362,8 +362,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:0.9.9')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:0.9.9')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC1')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -377,15 +377,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>0.9.9</version>
+    <version>1.0.0-RC1</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:0.9.9'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:0.9.9'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC1'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC1'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-RC1] - 2026-06-13
+
+First release candidate for 1.0. All on-disk machine formats are now version-stamped, the
+build fingerprint folds in the processor version, and the public API surface is frozen ahead
+of the stable 1.0.0 release.
+
 ### Added
 - **`Automatic-Module-Name` in both jar manifests** (`se.deversity.vibetags.annotations`,
   `se.deversity.vibetags.processor`) so JPMS consumers get a stable module name instead of a
@@ -763,7 +769,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v0.9.9...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC1...HEAD
+[1.0.0-RC1]: https://github.com/PIsberg/vibetags/compare/v0.9.9...v1.0.0-RC1
 [0.9.9]: https://github.com/PIsberg/vibetags/compare/v0.9.8...v0.9.9
 [0.9.8]: https://github.com/PIsberg/vibetags/compare/v0.9.7...v0.9.8
 [0.9.7]: https://github.com/PIsberg/vibetags/compare/v0.9.5...v0.9.7

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:0.9.9')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:0.9.9')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC1')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>0.9.9</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0-RC1</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
     </properties>
 

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>0.9.9</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0-RC1</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '0.9.9'
+version = '1.0.0-RC1'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '0.9.9'
+            version = '1.0.0-RC1'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>0.9.9</version>
+    <version>1.0.0-RC1</version>
     <packaging>jar</packaging>
 
     <name>VibeTags Annotations</name>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-bom</artifactId>
-    <version>0.9.9</version>
+    <version>1.0.0-RC1</version>
     <packaging>pom</packaging>
 
     <name>VibeTags BOM</name>
@@ -25,7 +25,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;0.9.9&lt;/version&gt;
+                        &lt;version&gt;1.0.0-RC1&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -33,8 +33,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:0.9.9')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:0.9.9')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC1')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC1')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>
@@ -66,7 +66,7 @@
         <!-- Single source of truth for the VibeTags artifact set. Bump this when releasing
              a new processor version; all consumers that import this BOM track the bump
              without further changes. -->
-        <vibetags.version>0.9.9</vibetags.version>
+        <vibetags.version>1.0.0-RC1</vibetags.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '0.9.9'
+version = '1.0.0-RC1'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '0.9.9'
+            version = '1.0.0-RC1'
             from components.java
 
             pom {
@@ -84,7 +84,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:0.9.9'
+    api 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC1'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.0'

--- a/vibetags/pom.xml
+++ b/vibetags/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>0.9.9</version>
+    <version>1.0.0-RC1</version>
     <packaging>jar</packaging>
 
     <name>VibeTags Processor</name>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-annotations</artifactId>
-            <version>0.9.9</version>
+            <version>1.0.0-RC1</version>
         </dependency>
 
         <!-- JSpecify null annotations (@NullMarked, @Nullable, @NonNull).


### PR DESCRIPTION
First release candidate for 1.0. Bumps the library version `0.9.9` → `1.0.0-RC1` and updates all version references that ship with the release.

## Version bump (`0.9.9` → `1.0.0-RC1`)
- **Annotations** — `vibetags-annotations/` pom.xml + build.gradle
- **Processor** — `vibetags/` pom.xml (project + annotations dep) + build.gradle
- **BOM** — `vibetags-bom/` pom.xml (`<version>`, `<vibetags.version>` property, doc snippets)

## Examples
- `example/pom.xml` + `example/build.gradle` — BOM reference (the example app's own version stays `1.0.0`)
- `tools/demo/pom.xml` — BOM reference
- `README.md` — install snippets

## Skill
- `.claude/skills/vibetags-usage/SKILL.md` — frontmatter `version:` + install snippets

## Changelog
- Promoted the `[Unreleased]` content under a new `## [1.0.0-RC1] - 2026-06-13` heading with an RC summary, kept `[Unreleased]` as a placeholder, and added the compare-link references.

## Deliberately untouched
- `load-tests/` keeps `processor.version` pinned at `0.9.5` (cross-version benchmark — the wrong workload for a BOM, per project convention).
- USAGE.md's historical "New in v0.9.9" section headers stay as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)