### PR TITLE
fix: resolve OSSF Scorecard code-scanning alerts

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -11,14 +11,17 @@ on:
       - '.github/workflows/demo.yml'
   workflow_dispatch:
 
+# Least privilege at the top level; the commit/PR job opts into the writes it needs.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   generate-demo:
     name: Record demo and convert to GIF
     runs-on: ubuntu-latest
+    permissions:
+      contents: write        # push the GIF branch
+      pull-requests: write    # open the update PR
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Maven Central](https://img.shields.io/maven-central/v/se.deversity.vibetags/vibetags-processor.svg)](https://central.sonatype.com/artifact/se.deversity.vibetags/vibetags-processor)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/PIsberg/vibetags/badge)](https://securityscorecards.dev/viewer/?uri=github.com/PIsberg/vibetags)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13275/badge)](https://www.bestpractices.dev/projects/13275)
 [![Build and Test](https://github.com/PIsberg/vibetags/actions/workflows/build.yml/badge.svg)](https://github.com/PIsberg/vibetags/actions/workflows/build.yml)
 [![Java 21 | 25 | 26](https://img.shields.io/badge/Java-21%20%7C%2025%20%7C%2026-orange?logo=openjdk)](https://github.com/PIsberg/vibetags/actions/workflows/build.yml)
 [![Maven](https://img.shields.io/badge/build-Maven-blue?logo=apachemaven)](https://github.com/PIsberg/vibetags/actions/workflows/build.yml)

--- a/oss-fuzz/Dockerfile
+++ b/oss-fuzz/Dockerfile
@@ -1,4 +1,6 @@
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+# Pinned by digest for reproducible builds (Scorecard Pinned-Dependencies).
+# Tag: gcr.io/oss-fuzz-base/base-builder-jvm:latest — bump the digest when upgrading.
+FROM gcr.io/oss-fuzz-base/base-builder-jvm@sha256:a3652934a4580fc62e1798b15ae257b7740a2815c4fcf1bd631b5a9743780e62
 
 RUN apt-get update && apt-get install -y maven
 


### PR DESCRIPTION
Addresses the open [code-scanning / OSSF Scorecard alerts](https://github.com/PIsberg/vibetags/security/code-scanning).

## Code fixes
- **Token-Permissions (#20, high)** — `.github/workflows/demo.yml` now uses least-privilege top-level `permissions: contents: read`; the commit/PR job opts into `contents: write` + `pull-requests: write` only where it pushes the GIF branch and opens the PR.
- **Pinned-Dependencies (#17, medium)** — pinned the `oss-fuzz/Dockerfile` base image (`base-builder-jvm`) by sha256 digest for reproducible builds. ⚠️ OSS-Fuzz garbage-collects old base-image digests; bump or revert this line if the fuzz build later fails.
- **CII-Best-Practices (#2, low)** — registered OpenSSF Best Practices project [13275](https://www.bestpractices.dev/projects/13275) (`repo_url` matches this repo) and added the badge to `README.md`. Badge image verified HTTP 200.

## Handled outside this PR
- **Binary-Artifacts (#11, high)** — dismissed as "won't fix": `gradle-wrapper.jar` is the official Gradle wrapper binary required for `./gradlew`.
- **Maintained (#5, high)** — time-based (repo < 90 days); auto-resolves with age.
- **Code-Review (#3, high)** — requires branch-protection (approvals); repo-settings decision, not code.

## Notes
Scorecard alerts re-evaluate on the weekly `scorecards.yml` run, so #20/#17/#2 clear on a lag after merge — not immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)