### PR TITLE
ci: improve OSSF Scorecard score

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,39 @@
+name: Validate Gradle Wrapper
+
+# Verifies the checked-in gradle-wrapper.jar matches a known-good Gradle
+# release checksum. Scorecard's Binary-Artifacts check treats the wrapper
+# jar as acceptable when this validation workflow is present.
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**/gradle/wrapper/gradle-wrapper.jar'
+      - '**/gradle/wrapper/gradle-wrapper.properties'
+      - '.github/workflows/gradle-wrapper-validation.yml'
+  pull_request:
+    paths:
+      - '**/gradle/wrapper/gradle-wrapper.jar'
+      - '**/gradle/wrapper/gradle-wrapper.properties'
+      - '.github/workflows/gradle-wrapper-validation.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     name: Publish to Maven Central
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write   # attach signed artifacts to the GitHub release
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -56,3 +56,15 @@ jobs:
         env:
           CENTRAL_TOKEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
           CENTRAL_TOKEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
+
+      # Attach the GPG-signed jars/poms (and their .asc signatures) to the
+      # GitHub release so Scorecard's Signed-Releases check can verify them.
+      - name: Attach signed artifacts to the GitHub release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          files: |
+            vibetags-annotations/target/*.jar
+            vibetags-annotations/target/*.jar.asc
+            vibetags/target/*.jar
+            vibetags/target/*.jar.asc
+            vibetags-bom/target/*.pom.asc


### PR DESCRIPTION
Raises the [OSSF Scorecard](https://securityscorecards.dev/viewer/?uri=github.com/PIsberg/vibetags) score via two CI changes. Current live score: **7.8/10**.

## Changes
- **Binary-Artifacts (9 → 10)** — adds a `gradle-wrapper-validation` workflow. Scorecard treats the checked-in `gradle-wrapper.jar` as acceptable once a wrapper-validation workflow validates it against the official Gradle checksum.
- **Signed-Releases** — `publish.yml` now attaches the GPG-signed jars/poms (+ `.asc` signatures) to the GitHub Release. Previously the signed artifacts went only to Maven Central, so releases had no verifiable assets. The publish job opts into `contents: write` (top-level stays `read`).
- Both new action refs are pinned by commit SHA to preserve **Pinned-Dependencies (10)**.

## Scoring notes
- Binary-Artifacts updates on the next weekly `scorecards.yml` run after merge.
- Signed-Releases only scores once a **new release** is cut with these signed assets attached (existing releases have no assets).

## Not addressed here (need repo settings / external steps — see PR discussion)
- Branch-Protection (token read error + no required reviews), Code-Review (solo repo), Maintained (repo age, auto-resolves), Contributors (single org), CII-Best-Practices (complete the questionnaire to raise 2 → 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)