### PR TITLE
feat: add optional reason to the 11 marker annotations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,27 +300,27 @@ An opt-in pseudo-platform (service key `locks_report`, touch `.vibetags-locks` t
 | `@AIObservability` | TYPE, METHOD | `metrics: String[]`, `traces: String[]`, `logs: String[]`, `note: String` |
 | `@AIRegulation` | TYPE, METHOD, FIELD | `standard: String`, `clause: String`, `description: String` |
 | `@AIArchitecture` | TYPE | `belongsTo: String`, `cannotReference: String[]` |
-| `@AILegacyBridge` | TYPE, METHOD | *(none)* |
-| `@AIStrictClasspath` | TYPE, METHOD | *(none)* |
-| `@AIInternationalized` | TYPE, METHOD | *(none)* |
-| `@AIPublicAPI` | TYPE, METHOD | *(none)* |
-| `@AISchemaSafe` | TYPE, FIELD | *(none)* |
-| `@AIStrictExceptions` | TYPE, METHOD | *(none)* |
-| `@AIStrictTypes` | TYPE, METHOD, FIELD | *(none)* |
-| `@AIParallelTests` | TYPE, METHOD | *(none)* |
+| `@AILegacyBridge` | TYPE, METHOD | `reason: String` |
+| `@AIStrictClasspath` | TYPE, METHOD | `reason: String` |
+| `@AIInternationalized` | TYPE, METHOD | `reason: String` |
+| `@AIPublicAPI` | TYPE, METHOD | `reason: String` |
+| `@AISchemaSafe` | TYPE, FIELD | `reason: String` |
+| `@AIStrictExceptions` | TYPE, METHOD | `reason: String` |
+| `@AIStrictTypes` | TYPE, METHOD, FIELD | `reason: String` |
+| `@AIParallelTests` | TYPE, METHOD | `reason: String` |
 | `@AIIdempotent` | TYPE, METHOD | `reason: String` |
 | `@AIFeatureFlag` | TYPE, METHOD, FIELD | `flag: String`, `defaultValue: boolean` |
 | `@AISecure` | TYPE, METHOD | `aspect: String` |
 | `@AICallersOnly` | TYPE, METHOD | `value: String[]` |
-| `@AISandboxOnly` | TYPE, METHOD | *(none)* |
+| `@AISandboxOnly` | TYPE, METHOD | `reason: String` |
 | `@AIMemoryBudget` | TYPE, METHOD | `value: AllocationPolicy` |
-| `@AIPure` | METHOD | *(none)* |
+| `@AIPure` | METHOD | `reason: String` |
 | `@AIDomainModel` | TYPE | `allow: String[]` |
 | `@AIExtensible` | TYPE | `value: Strategy` |
 | `@AIInputSanitized` | PARAMETER, FIELD | `value: SanitizerType[]` |
 | `@AISecureLogging` | FIELD, PARAMETER | `value: MaskingPolicy` |
 | `@AIExplain` | TYPE, METHOD | `value: ComplexityLevel` |
-| `@AIPrototype` | TYPE | *(none)* |
+| `@AIPrototype` | TYPE | `reason: String` |
 | `@AISunset` | TYPE, METHOD, FIELD | `jira: String`, `replacement: Class<?>` |
 | `@AITemporary` | TYPE, METHOD | `expiresOn: String`, `reason: String` |
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Optional `reason` on the eleven marker annotations** — `@AILegacyBridge`, `@AIStrictClasspath`,
+  `@AIInternationalized`, `@AIPublicAPI`, `@AISchemaSafe`, `@AIStrictExceptions`, `@AIStrictTypes`,
+  `@AIParallelTests`, `@AISandboxOnly`, `@AIPure`, `@AIPrototype`. These previously carried no
+  attributes, so they could only emit a canned, generic instruction. They now accept an optional
+  `reason` (defaulting to `""`, so existing usages compile unchanged) that is surfaced in the
+  generated output — appended to the rule text on the markdown/plain-text platforms and as a
+  `<reason>…</reason>` element in `CLAUDE.md`. The point is to **carry the *why* across AI
+  sessions**: a marker preserves only a verdict ("be strict here"), but the rationale ("currency
+  math broke in INC-4412 when a double leaked in") is exactly the non-inferable context a later
+  agent — which no longer has the originating session — needs to weigh or safely override the
+  rule. Nothing is emitted when `reason` is left blank. Covered by `MarkerReasonEndToEndTest`.
+
 ### Performance
 Four changes to the per-round processing and rendering paths, all behaviour-preserving (every one
 of the 1033 unit tests passes unchanged):

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIInternationalized.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIInternationalized.java
@@ -13,4 +13,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface AIInternationalized {
+
+    /**
+     * Optional rationale, persisted across AI sessions: why this rule applies to this element
+     * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
+     * it is surfaced in the generated guardrail output.
+     */
+    String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AILegacyBridge.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AILegacyBridge.java
@@ -13,4 +13,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface AILegacyBridge {
+
+    /**
+     * Optional rationale, persisted across AI sessions: why this rule applies to this element
+     * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
+     * it is surfaced in the generated guardrail output.
+     */
+    String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIParallelTests.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIParallelTests.java
@@ -13,4 +13,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface AIParallelTests {
+
+    /**
+     * Optional rationale, persisted across AI sessions: why this rule applies to this element
+     * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
+     * it is surfaced in the generated guardrail output.
+     */
+    String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIPrototype.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIPrototype.java
@@ -12,4 +12,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface AIPrototype {
+
+    /**
+     * Optional rationale, persisted across AI sessions: why this rule applies to this element
+     * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
+     * it is surfaced in the generated guardrail output.
+     */
+    String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIPublicAPI.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIPublicAPI.java
@@ -12,4 +12,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface AIPublicAPI {
+
+    /**
+     * Optional rationale, persisted across AI sessions: why this rule applies to this element
+     * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
+     * it is surfaced in the generated guardrail output.
+     */
+    String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIPure.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIPure.java
@@ -12,4 +12,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.METHOD)
 public @interface AIPure {
+
+    /**
+     * Optional rationale, persisted across AI sessions: why this rule applies to this element
+     * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
+     * it is surfaced in the generated guardrail output.
+     */
+    String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AISandboxOnly.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AISandboxOnly.java
@@ -12,4 +12,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface AISandboxOnly {
+
+    /**
+     * Optional rationale, persisted across AI sessions: why this rule applies to this element
+     * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
+     * it is surfaced in the generated guardrail output.
+     */
+    String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AISchemaSafe.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AISchemaSafe.java
@@ -13,4 +13,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.TYPE, ElementType.FIELD})
 public @interface AISchemaSafe {
+
+    /**
+     * Optional rationale, persisted across AI sessions: why this rule applies to this element
+     * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
+     * it is surfaced in the generated guardrail output.
+     */
+    String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIStrictClasspath.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIStrictClasspath.java
@@ -13,4 +13,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface AIStrictClasspath {
+
+    /**
+     * Optional rationale, persisted across AI sessions: why this rule applies to this element
+     * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
+     * it is surfaced in the generated guardrail output.
+     */
+    String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIStrictExceptions.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIStrictExceptions.java
@@ -13,4 +13,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface AIStrictExceptions {
+
+    /**
+     * Optional rationale, persisted across AI sessions: why this rule applies to this element
+     * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
+     * it is surfaced in the generated guardrail output.
+     */
+    String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIStrictTypes.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIStrictTypes.java
@@ -12,4 +12,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
 public @interface AIStrictTypes {
+
+    /**
+     * Optional rationale, persisted across AI sessions: why this rule applies to this element
+     * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
+     * it is surfaced in the generated guardrail output.
+     */
+    String reason() default "";
 }

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIInternationalizedFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIInternationalizedFormatter.java
@@ -3,6 +3,7 @@ package se.deversity.vibetags.processor.internal.content.annotations;
 // CPD-OFF
 
 import javax.lang.model.element.Element;
+import se.deversity.vibetags.annotations.AIInternationalized;
 import se.deversity.vibetags.processor.internal.ElementNaming;
 import se.deversity.vibetags.processor.internal.content.AnnotationFormatter;
 import se.deversity.vibetags.processor.internal.content.Platform;
@@ -14,7 +15,10 @@ public final class AIInternationalizedFormatter implements AnnotationFormatter {
     @Override
     public void format(Element element, StringBuilder sb, Platform platform) {
         String className = ElementNaming.elementPath(element);
-        String summary = "Internationalization mandated. User-facing strings must not be hardcoded; retrieve from resources.";
+        AIInternationalized ann = element.getAnnotation(AIInternationalized.class);
+        String reason = ann == null ? "" : ann.reason();
+        String summary = CommonFormatterHelper.withReason(
+            "Internationalization mandated. User-facing strings must not be hardcoded; retrieve from resources.", reason);
 
         switch (platform) {
             case CURSOR:
@@ -22,7 +26,7 @@ public final class AIInternationalizedFormatter implements AnnotationFormatter {
                 sb.append("* `").append(className).append("` - ").append(summary).append("\n");
                 break;
             case CLAUDE:
-                sb.append("    <element path=\"").append(className).append("\">\n      <i18n>required</i18n>\n    </element>\n");
+                sb.append("    <element path=\"").append(className).append("\">\n      <i18n>required</i18n>").append(CommonFormatterHelper.claudeReason(reason)).append("\n    </element>\n");
                 break;
             case CODEX:
                 sb.append("- **").append(className).append("**: ").append(summary).append("\n");

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AILegacyBridgeFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AILegacyBridgeFormatter.java
@@ -3,6 +3,7 @@ package se.deversity.vibetags.processor.internal.content.annotations;
 // CPD-OFF
 
 import javax.lang.model.element.Element;
+import se.deversity.vibetags.annotations.AILegacyBridge;
 import se.deversity.vibetags.processor.internal.ElementNaming;
 import se.deversity.vibetags.processor.internal.content.AnnotationFormatter;
 import se.deversity.vibetags.processor.internal.content.Platform;
@@ -14,7 +15,10 @@ public final class AILegacyBridgeFormatter implements AnnotationFormatter {
     @Override
     public void format(Element element, StringBuilder sb, Platform platform) {
         String className = ElementNaming.elementPath(element);
-        String summary = "Legacy/compatibility bridge. Do not refactor structural patterns; only modify internal business logic as explicitly requested.";
+        AILegacyBridge ann = element.getAnnotation(AILegacyBridge.class);
+        String reason = ann == null ? "" : ann.reason();
+        String summary = CommonFormatterHelper.withReason(
+            "Legacy/compatibility bridge. Do not refactor structural patterns; only modify internal business logic as explicitly requested.", reason);
 
         switch (platform) {
             case CURSOR:
@@ -22,7 +26,7 @@ public final class AILegacyBridgeFormatter implements AnnotationFormatter {
                 sb.append("* `").append(className).append("` - ").append(summary).append("\n");
                 break;
             case CLAUDE:
-                sb.append("    <element path=\"").append(className).append("\">\n      <refactor>prohibited</refactor>\n    </element>\n");
+                sb.append("    <element path=\"").append(className).append("\">\n      <refactor>prohibited</refactor>").append(CommonFormatterHelper.claudeReason(reason)).append("\n    </element>\n");
                 break;
             case CODEX:
                 sb.append("- **").append(className).append("**: ").append(summary).append("\n");

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIParallelTestsFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIParallelTestsFormatter.java
@@ -3,6 +3,7 @@ package se.deversity.vibetags.processor.internal.content.annotations;
 // CPD-OFF
 
 import javax.lang.model.element.Element;
+import se.deversity.vibetags.annotations.AIParallelTests;
 import se.deversity.vibetags.processor.internal.ElementNaming;
 import se.deversity.vibetags.processor.internal.content.AnnotationFormatter;
 import se.deversity.vibetags.processor.internal.content.Platform;
@@ -14,7 +15,10 @@ public final class AIParallelTestsFormatter implements AnnotationFormatter {
     @Override
     public void format(Element element, StringBuilder sb, Platform platform) {
         String className = ElementNaming.elementPath(element);
-        String summary = "Strict test isolation required. No shared mutable state or external resource conflicts.";
+        AIParallelTests ann = element.getAnnotation(AIParallelTests.class);
+        String reason = ann == null ? "" : ann.reason();
+        String summary = CommonFormatterHelper.withReason(
+            "Strict test isolation required. No shared mutable state or external resource conflicts.", reason);
 
         switch (platform) {
             case CURSOR:
@@ -22,7 +26,7 @@ public final class AIParallelTestsFormatter implements AnnotationFormatter {
                 sb.append("* `").append(className).append("` - ").append(summary).append("\n");
                 break;
             case CLAUDE:
-                sb.append("    <element path=\"").append(className).append("\">\n      <isolation>strict</isolation>\n    </element>\n");
+                sb.append("    <element path=\"").append(className).append("\">\n      <isolation>strict</isolation>").append(CommonFormatterHelper.claudeReason(reason)).append("\n    </element>\n");
                 break;
             case CODEX:
                 sb.append("- **").append(className).append("**: ").append(summary).append("\n");

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIPrototypeFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIPrototypeFormatter.java
@@ -15,7 +15,9 @@ public final class AIPrototypeFormatter implements AnnotationFormatter {
         AIPrototype prototype = element.getAnnotation(AIPrototype.class);
         if (prototype == null) return;
         String className = ElementNaming.elementPath(element);
-        String summary = "Experimental prototype class. Strict constraints (test coverage, i18n) are suspended. Stable production code must never depend on it.";
+        String reason = prototype.reason();
+        String summary = CommonFormatterHelper.withReason(
+            "Experimental prototype class. Strict constraints (test coverage, i18n) are suspended. Stable production code must never depend on it.", reason);
 
         if (CommonFormatterHelper.formatStandardPlatform(element, sb, platform, summary)) {
             return;
@@ -23,7 +25,7 @@ public final class AIPrototypeFormatter implements AnnotationFormatter {
 
         switch (platform) {
             case CLAUDE:
-                sb.append("    <file path=\"").append(className).append("\">\n      <status>Experimental Prototype</status>\n    </file>\n");
+                sb.append("    <file path=\"").append(className).append("\">\n      <status>Experimental Prototype</status>").append(CommonFormatterHelper.claudeReason(reason)).append("\n    </file>\n");
                 break;
             case LLMS_FULL:
                 sb.append("### ").append(className).append("\n- **Scope**: Experimental Prototype. Bypasses strict validation rules.\n\n");

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIPublicAPIFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIPublicAPIFormatter.java
@@ -3,6 +3,7 @@ package se.deversity.vibetags.processor.internal.content.annotations;
 // CPD-OFF
 
 import javax.lang.model.element.Element;
+import se.deversity.vibetags.annotations.AIPublicAPI;
 import se.deversity.vibetags.processor.internal.ElementNaming;
 import se.deversity.vibetags.processor.internal.content.AnnotationFormatter;
 import se.deversity.vibetags.processor.internal.content.Platform;
@@ -14,7 +15,10 @@ public final class AIPublicAPIFormatter implements AnnotationFormatter {
     @Override
     public void format(Element element, StringBuilder sb, Platform platform) {
         String className = ElementNaming.elementPath(element);
-        String summary = "Public API surface. Preserve signature, Javadoc, backwards compatibility, and binary/source stability.";
+        AIPublicAPI ann = element.getAnnotation(AIPublicAPI.class);
+        String reason = ann == null ? "" : ann.reason();
+        String summary = CommonFormatterHelper.withReason(
+            "Public API surface. Preserve signature, Javadoc, backwards compatibility, and binary/source stability.", reason);
 
         switch (platform) {
             case CURSOR:
@@ -22,7 +26,7 @@ public final class AIPublicAPIFormatter implements AnnotationFormatter {
                 sb.append("* `").append(className).append("` - ").append(summary).append("\n");
                 break;
             case CLAUDE:
-                sb.append("    <element path=\"").append(className).append("\">\n      <api>public</api>\n    </element>\n");
+                sb.append("    <element path=\"").append(className).append("\">\n      <api>public</api>").append(CommonFormatterHelper.claudeReason(reason)).append("\n    </element>\n");
                 break;
             case CODEX:
                 sb.append("- **").append(className).append("**: ").append(summary).append("\n");

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIPureFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIPureFormatter.java
@@ -15,7 +15,9 @@ public final class AIPureFormatter implements AnnotationFormatter {
         AIPure pure = element.getAnnotation(AIPure.class);
         if (pure == null) return;
         String className = ElementNaming.elementPath(element);
-        String summary = "Must remain a pure function. Forbid assignments to enclosing state, fields, or static members.";
+        String reason = pure.reason();
+        String summary = CommonFormatterHelper.withReason(
+            "Must remain a pure function. Forbid assignments to enclosing state, fields, or static members.", reason);
 
         if (CommonFormatterHelper.formatStandardPlatform(element, sb, platform, summary)) {
             return;
@@ -23,7 +25,7 @@ public final class AIPureFormatter implements AnnotationFormatter {
 
         switch (platform) {
             case CLAUDE:
-                sb.append("    <file path=\"").append(className).append("\">\n      <policy>Pure function: no side effects, deterministic.</policy>\n    </file>\n");
+                sb.append("    <file path=\"").append(className).append("\">\n      <policy>Pure function: no side effects, deterministic.</policy>").append(CommonFormatterHelper.claudeReason(reason)).append("\n    </file>\n");
                 break;
             case LLMS_FULL:
                 sb.append("### ").append(className).append("\n- **Requirement**: Mathematically pure function. No side effects.\n\n");

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AISandboxOnlyFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AISandboxOnlyFormatter.java
@@ -15,7 +15,9 @@ public final class AISandboxOnlyFormatter implements AnnotationFormatter {
         AISandboxOnly sandboxOnly = element.getAnnotation(AISandboxOnly.class);
         if (sandboxOnly == null) return;
         String className = ElementNaming.elementPath(element);
-        String summary = "Strictly sandbox or test environment only. Production code must never import or invoke.";
+        String reason = sandboxOnly.reason();
+        String summary = CommonFormatterHelper.withReason(
+            "Strictly sandbox or test environment only. Production code must never import or invoke.", reason);
 
         if (CommonFormatterHelper.formatStandardPlatform(element, sb, platform, summary)) {
             return;
@@ -23,7 +25,7 @@ public final class AISandboxOnlyFormatter implements AnnotationFormatter {
 
         switch (platform) {
             case CLAUDE:
-                sb.append("    <file path=\"").append(className).append("\">\n      <policy>Sandbox or test only. Do not invoke from production.</policy>\n    </file>\n");
+                sb.append("    <file path=\"").append(className).append("\">\n      <policy>Sandbox or test only. Do not invoke from production.</policy>").append(CommonFormatterHelper.claudeReason(reason)).append("\n    </file>\n");
                 break;
             case LLMS_FULL:
                 sb.append("### ").append(className).append("\n- **Scope**: Sandbox/testing environments only. Never use in production.\n\n");

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AISchemaSafeFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AISchemaSafeFormatter.java
@@ -3,6 +3,7 @@ package se.deversity.vibetags.processor.internal.content.annotations;
 // CPD-OFF
 
 import javax.lang.model.element.Element;
+import se.deversity.vibetags.annotations.AISchemaSafe;
 import se.deversity.vibetags.processor.internal.ElementNaming;
 import se.deversity.vibetags.processor.internal.content.AnnotationFormatter;
 import se.deversity.vibetags.processor.internal.content.Platform;
@@ -14,7 +15,10 @@ public final class AISchemaSafeFormatter implements AnnotationFormatter {
     @Override
     public void format(Element element, StringBuilder sb, Platform platform) {
         String className = ElementNaming.elementPath(element);
-        String summary = "Schema/serialization safety guaranteed. Prohibit altering data formats or fields without migration plan.";
+        AISchemaSafe ann = element.getAnnotation(AISchemaSafe.class);
+        String reason = ann == null ? "" : ann.reason();
+        String summary = CommonFormatterHelper.withReason(
+            "Schema/serialization safety guaranteed. Prohibit altering data formats or fields without migration plan.", reason);
 
         switch (platform) {
             case CURSOR:
@@ -22,7 +26,7 @@ public final class AISchemaSafeFormatter implements AnnotationFormatter {
                 sb.append("* `").append(className).append("` - ").append(summary).append("\n");
                 break;
             case CLAUDE:
-                sb.append("    <element path=\"").append(className).append("\">\n      <schema>safe</schema>\n    </element>\n");
+                sb.append("    <element path=\"").append(className).append("\">\n      <schema>safe</schema>").append(CommonFormatterHelper.claudeReason(reason)).append("\n    </element>\n");
                 break;
             case CODEX:
                 sb.append("- **").append(className).append("**: ").append(summary).append("\n");

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIStrictClasspathFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIStrictClasspathFormatter.java
@@ -3,6 +3,7 @@ package se.deversity.vibetags.processor.internal.content.annotations;
 // CPD-OFF
 
 import javax.lang.model.element.Element;
+import se.deversity.vibetags.annotations.AIStrictClasspath;
 import se.deversity.vibetags.processor.internal.ElementNaming;
 import se.deversity.vibetags.processor.internal.content.AnnotationFormatter;
 import se.deversity.vibetags.processor.internal.content.Platform;
@@ -14,7 +15,10 @@ public final class AIStrictClasspathFormatter implements AnnotationFormatter {
     @Override
     public void format(Element element, StringBuilder sb, Platform platform) {
         String className = ElementNaming.elementPath(element);
-        String summary = "Strict compile-time dependency/classpath constraints. Dynamic loading and reflection hacks prohibited.";
+        AIStrictClasspath ann = element.getAnnotation(AIStrictClasspath.class);
+        String reason = ann == null ? "" : ann.reason();
+        String summary = CommonFormatterHelper.withReason(
+            "Strict compile-time dependency/classpath constraints. Dynamic loading and reflection hacks prohibited.", reason);
 
         switch (platform) {
             case CURSOR:
@@ -22,7 +26,7 @@ public final class AIStrictClasspathFormatter implements AnnotationFormatter {
                 sb.append("* `").append(className).append("` - ").append(summary).append("\n");
                 break;
             case CLAUDE:
-                sb.append("    <element path=\"").append(className).append("\">\n      <classpath>strict</classpath>\n    </element>\n");
+                sb.append("    <element path=\"").append(className).append("\">\n      <classpath>strict</classpath>").append(CommonFormatterHelper.claudeReason(reason)).append("\n    </element>\n");
                 break;
             case CODEX:
                 sb.append("- **").append(className).append("**: ").append(summary).append("\n");

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIStrictExceptionsFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIStrictExceptionsFormatter.java
@@ -3,6 +3,7 @@ package se.deversity.vibetags.processor.internal.content.annotations;
 // CPD-OFF
 
 import javax.lang.model.element.Element;
+import se.deversity.vibetags.annotations.AIStrictExceptions;
 import se.deversity.vibetags.processor.internal.ElementNaming;
 import se.deversity.vibetags.processor.internal.content.AnnotationFormatter;
 import se.deversity.vibetags.processor.internal.content.Platform;
@@ -14,7 +15,10 @@ public final class AIStrictExceptionsFormatter implements AnnotationFormatter {
     @Override
     public void format(Element element, StringBuilder sb, Platform platform) {
         String className = ElementNaming.elementPath(element);
-        String summary = "Strict exception handling required. Catching/throwing generic Exception/Throwable is prohibited.";
+        AIStrictExceptions ann = element.getAnnotation(AIStrictExceptions.class);
+        String reason = ann == null ? "" : ann.reason();
+        String summary = CommonFormatterHelper.withReason(
+            "Strict exception handling required. Catching/throwing generic Exception/Throwable is prohibited.", reason);
 
         switch (platform) {
             case CURSOR:
@@ -22,7 +26,7 @@ public final class AIStrictExceptionsFormatter implements AnnotationFormatter {
                 sb.append("* `").append(className).append("` - ").append(summary).append("\n");
                 break;
             case CLAUDE:
-                sb.append("    <element path=\"").append(className).append("\">\n      <exceptions>strict</exceptions>\n    </element>\n");
+                sb.append("    <element path=\"").append(className).append("\">\n      <exceptions>strict</exceptions>").append(CommonFormatterHelper.claudeReason(reason)).append("\n    </element>\n");
                 break;
             case CODEX:
                 sb.append("- **").append(className).append("**: ").append(summary).append("\n");

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIStrictTypesFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIStrictTypesFormatter.java
@@ -3,6 +3,7 @@ package se.deversity.vibetags.processor.internal.content.annotations;
 // CPD-OFF
 
 import javax.lang.model.element.Element;
+import se.deversity.vibetags.annotations.AIStrictTypes;
 import se.deversity.vibetags.processor.internal.ElementNaming;
 import se.deversity.vibetags.processor.internal.content.AnnotationFormatter;
 import se.deversity.vibetags.processor.internal.content.Platform;
@@ -14,7 +15,10 @@ public final class AIStrictTypesFormatter implements AnnotationFormatter {
     @Override
     public void format(Element element, StringBuilder sb, Platform platform) {
         String className = ElementNaming.elementPath(element);
-        String summary = "Loose typing (Object, Map<String, Object>, raw types) is prohibited. Enforce type safety.";
+        AIStrictTypes ann = element.getAnnotation(AIStrictTypes.class);
+        String reason = ann == null ? "" : ann.reason();
+        String summary = CommonFormatterHelper.withReason(
+            "Loose typing (Object, Map<String, Object>, raw types) is prohibited. Enforce type safety.", reason);
 
         switch (platform) {
             case CURSOR:
@@ -22,7 +26,7 @@ public final class AIStrictTypesFormatter implements AnnotationFormatter {
                 sb.append("* `").append(className).append("` - ").append(summary).append("\n");
                 break;
             case CLAUDE:
-                sb.append("    <element path=\"").append(className).append("\">\n      <types>strict</types>\n    </element>\n");
+                sb.append("    <element path=\"").append(className).append("\">\n      <types>strict</types>").append(CommonFormatterHelper.claudeReason(reason)).append("\n    </element>\n");
                 break;
             case CODEX:
                 sb.append("- **").append(className).append("**: ").append(summary).append("\n");

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/CommonFormatterHelper.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/CommonFormatterHelper.java
@@ -12,6 +12,24 @@ final class CommonFormatterHelper {
     private CommonFormatterHelper() {}
 
     /**
+     * Appends the optional rationale to a plain-text/markdown {@code summary} when present, so the
+     * "why" carried by a marker annotation survives into the generated guardrail output (and thus
+     * across AI sessions). Returns {@code summary} unchanged when {@code reason} is blank.
+     */
+    public static String withReason(String summary, String reason) {
+        return (reason == null || reason.isBlank()) ? summary : summary + " Reason: " + reason;
+    }
+
+    /**
+     * Returns an indented {@code <reason>…</reason>} XML fragment for the Claude format when
+     * {@code reason} is present (to be inserted before the element's closing tag), or an empty
+     * string otherwise.
+     */
+    public static String claudeReason(String reason) {
+        return (reason == null || reason.isBlank()) ? "" : "\n      <reason>" + reason + "</reason>";
+    }
+
+    /**
      * Attempts to format standard markdown/plain-text platforms.
      * Returns true if the platform was formatted and handled, false otherwise.
      */

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/MarkerReasonEndToEndTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/MarkerReasonEndToEndTest.java
@@ -1,0 +1,86 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies that the previously attribute-less "marker" annotations now carry an optional
+ * {@code reason} that is surfaced in the generated output — so the rationale survives across AI
+ * sessions — and that nothing extra is emitted when the reason is left blank.
+ */
+class MarkerReasonEndToEndTest {
+
+    @TempDir
+    static Path tempDir;
+
+    private static ProcessorTestHarness harness;
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        harness = new ProcessorTestHarness(tempDir);
+
+        harness.addSource("com.example.Api",
+            "package com.example;\n"
+                + "import se.deversity.vibetags.annotations.AIPublicAPI;\n"
+                + "@AIPublicAPI(reason = \"Frozen for the v2 mobile contract\")\n"
+                + "public class Api {}\n");
+
+        harness.addSource("com.example.Money",
+            "package com.example;\n"
+                + "import se.deversity.vibetags.annotations.AIStrictTypes;\n"
+                + "@AIStrictTypes(reason = \"Currency math broke in INC-4412 when a double leaked in\")\n"
+                + "public class Money {}\n");
+
+        // Same marker, no reason — must not emit any Reason suffix or empty <reason> element.
+        harness.addSource("com.example.Plain",
+            "package com.example;\n"
+                + "import se.deversity.vibetags.annotations.AIStrictTypes;\n"
+                + "@AIStrictTypes\n"
+                + "public class Plain {}\n");
+
+        harness.compile();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        VibeTagsLogger.shutdown();
+    }
+
+    @Test
+    void cursorRulesCarriesTheReason() throws IOException {
+        String cursor = harness.readFile(".cursorrules");
+        assertTrue(cursor.contains("Frozen for the v2 mobile contract"),
+            ".cursorrules must carry the @AIPublicAPI reason");
+        assertTrue(cursor.contains("Currency math broke in INC-4412 when a double leaked in"),
+            ".cursorrules must carry the @AIStrictTypes reason");
+    }
+
+    @Test
+    void claudeMdCarriesTheReasonAsXml() throws IOException {
+        String claude = harness.readFile("CLAUDE.md");
+        assertTrue(claude.contains("<reason>Frozen for the v2 mobile contract</reason>"),
+            "CLAUDE.md must carry the @AIPublicAPI reason as a <reason> element");
+        assertTrue(claude.contains("<reason>Currency math broke in INC-4412 when a double leaked in</reason>"),
+            "CLAUDE.md must carry the @AIStrictTypes reason as a <reason> element");
+    }
+
+    @Test
+    void blankReasonEmitsNothingExtra() throws IOException {
+        String cursor = harness.readFile(".cursorrules");
+        assertTrue(cursor.contains("com.example.Plain"), "Plain should still be listed");
+        assertFalse(
+            cursor.lines().anyMatch(l -> l.contains("com.example.Plain") && l.contains("Reason:")),
+            "A marker with no reason must not emit a 'Reason:' suffix");
+
+        String claude = harness.readFile("CLAUDE.md");
+        assertFalse(claude.contains("<reason></reason>"),
+            "A blank reason must not emit an empty <reason> element");
+    }
+}


### PR DESCRIPTION
## Summary

Eleven annotations were previously bare markers with no attributes, so they could only emit a canned, generic instruction. This adds an optional `reason` to each and surfaces it in the generated guardrail output.

**Annotations updated:** `@AILegacyBridge`, `@AIStrictClasspath`, `@AIInternationalized`, `@AIPublicAPI`, `@AISchemaSafe`, `@AIStrictExceptions`, `@AIStrictTypes`, `@AIParallelTests`, `@AISandboxOnly`, `@AIPure`, `@AIPrototype`.

## Why

A bare marker preserves only a *verdict* ("be strict here"). The **rationale** — *"currency math broke in INC-4412 when a double leaked in"* — is exactly the non-inferable context that a later AI session (which no longer has the originating conversation, exploration, or stack trace) needs to weigh the rule or safely override it. The annotation is a durable, cross-session handoff; carrying the *why*, not just the conclusion, is what makes that handoff worth reading.

## What

- Each annotation gains `String reason() default "";` — **fully backward-compatible**; existing no-arg usages compile unchanged.
- The reason is surfaced in the output: appended to the rule text on the markdown/plain-text platforms (`.cursorrules`, Copilot, Gemini, Qwen, llms.txt, Zed, Codex, Windsurf, Interpreter) and as a `<reason>…</reason>` element in `CLAUDE.md`.
- Nothing extra is emitted when `reason` is blank (`CommonFormatterHelper.withReason` / `claudeReason` guard on it).

## Tests
- New `MarkerReasonEndToEndTest`: reason surfaces in `.cursorrules` and `CLAUDE.md`; blank reason emits no `Reason:` suffix and no empty `<reason>` element.
- **All 1036 tests pass; Checkstyle clean.** `CLAUDE.md` annotation table (`*(none)*` → `reason: String`) and `docs/CHANGELOG.md` updated.

## Context
This came out of a design discussion: bare markers are easy for agents to apply and survive across sessions (both real strengths), but they drop the *why*. Adding `reason` keeps the low-friction application while making the cross-session payload actually useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)