### PR TITLE
release: 1.0.0-RC2

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary annotations, or wants to control how AI tools interact with Java code.
-version: 1.0.0-RC1
+version: 1.0.0-RC2
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.0-RC1</version>
+    <version>1.0.0-RC2</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.0-RC1'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC1'
+compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.0-RC2'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC2'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.0-RC1</version>
+            <version>1.0.0-RC2</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -70,7 +70,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.0-RC1</version>
+                        <version>1.0.0-RC2</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -111,8 +111,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC2')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -346,7 +346,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.0-RC1</version>
+            <version>1.0.0-RC2</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -371,7 +371,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.0-RC1</version>
+                        <version>1.0.0-RC2</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -385,8 +385,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC2')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -400,15 +400,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.0-RC1</version>
+    <version>1.0.0-RC2</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC1'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC1'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC2'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC2'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-RC2] - 2026-06-28
+
+Second release candidate for 1.0. Rolls up everything since RC1: ten new AI platforms (43 → see
+project facts), the `AGENTS.md` sole-file fallback, optional `reason` on the eleven marker
+annotations, processing-path performance work, and a documentation consistency pass with an
+enforced single source of truth for the project counts.
+
 ### Documentation
 - **Single source of truth for the project counts.** The README "At a glance" line now states the
   two headline numbers once — **39 annotations**, **37 AI platforms** — and every other doc links
@@ -891,7 +898,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC1...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC2...HEAD
+[1.0.0-RC2]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC1...v1.0.0-RC2
 [1.0.0-RC1]: https://github.com/PIsberg/vibetags/compare/v0.9.9...v1.0.0-RC1
 [0.9.9]: https://github.com/PIsberg/vibetags/compare/v0.9.8...v0.9.9
 [0.9.8]: https://github.com/PIsberg/vibetags/compare/v0.9.7...v0.9.8

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC2')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.0.0-RC1</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0-RC2</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
     </properties>
 

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.0.0-RC1</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0-RC2</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.0-RC1'
+version = '1.0.0-RC2'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.0.0-RC1'
+            version = '1.0.0-RC2'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.0-RC1</version>
+    <version>1.0.0-RC2</version>
     <packaging>jar</packaging>
 
     <name>VibeTags Annotations</name>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-bom</artifactId>
-    <version>1.0.0-RC1</version>
+    <version>1.0.0-RC2</version>
     <packaging>pom</packaging>
 
     <name>VibeTags BOM</name>
@@ -25,7 +25,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.0.0-RC1&lt;/version&gt;
+                        &lt;version&gt;1.0.0-RC2&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -33,8 +33,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC1')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC1')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC2')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC2')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>
@@ -66,7 +66,7 @@
         <!-- Single source of truth for the VibeTags artifact set. Bump this when releasing
              a new processor version; all consumers that import this BOM track the bump
              without further changes. -->
-        <vibetags.version>1.0.0-RC1</vibetags.version>
+        <vibetags.version>1.0.0-RC2</vibetags.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.0-RC1'
+version = '1.0.0-RC2'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.0.0-RC1'
+            version = '1.0.0-RC2'
             from components.java
 
             pom {
@@ -84,7 +84,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC1'
+    api 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC2'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.0'

--- a/vibetags/pom.xml
+++ b/vibetags/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.0-RC1</version>
+    <version>1.0.0-RC2</version>
     <packaging>jar</packaging>
 
     <name>VibeTags Processor</name>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-annotations</artifactId>
-            <version>1.0.0-RC1</version>
+            <version>1.0.0-RC2</version>
         </dependency>
 
         <!-- JSpecify null annotations (@NullMarked, @Nullable, @NonNull).

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
@@ -53,7 +53,7 @@ public class AIGuardrailProcessor extends AbstractProcessor {
     /** Public constructor for the service loader. */
     public AIGuardrailProcessor() {}
 
-    static final String VERSION = "0.9.5";
+    static final String VERSION = "1.0.0-RC2";
     private static final String GITHUB_URL = "https://github.com/PIsberg/vibetags";
 
     /** Header written into every generated file — no version so bumping the dep never creates spurious diffs. */


### PR DESCRIPTION
## Release 1.0.0-RC2

Second release candidate for 1.0 — version bump + changelog for everything merged since RC1.

### Version bumps (`1.0.0-RC1` → `1.0.0-RC2`)
- **Maven:** `vibetags-annotations`, `vibetags(-processor)`, `vibetags-bom` (including the BOM's managed `vibetags.version` property and the processor → annotations dependency).
- **Gradle:** `vibetags-annotations` and `vibetags` `build.gradle` (including the annotations dependency).
- **Consumers:** `example/pom.xml`, `example/build.gradle`, `tools/demo/pom.xml`.
- **Docs:** README dependency snippets (Maven + Gradle, both quick-start and full sections), the `vibetags-usage` skill (`version:` frontmatter + snippets).
- **Code:** `AIGuardrailProcessor.VERSION` display constant (was a stale `"0.9.5"` — the real artifact version is resolved separately by `ProcessorVersion`, but the log line now reads correctly).

### CHANGELOG
Rolled `[Unreleased]` into a dated **`[1.0.0-RC2] - 2026-06-28`** section with a rollup summary, and added the `v1.0.0-RC1...v1.0.0-RC2` compare links. The RC1→RC2 delta: 10 new AI platforms, the `AGENTS.md` sole-file fallback, optional `reason` on the eleven marker annotations, the processing-path performance work, and the documentation single-source-of-truth pass.

### Verification
- **All 1038 tests pass; Checkstyle clean.**
- Installed the RC2 artifacts (annotations → processor → BOM) and confirmed the **example compiles against the RC2 BOM**; the processor logs `VibeTags v1.0.0-RC2`.
- No stale `1.0.0-RC1` left anywhere except the CHANGELOG's historical entries.
- `load-tests` keeps its intentional `processor.version` pin (it's a cross-version benchmark harness, not a released artifact).

### Remaining release steps (after merge)
This PR is the source-side preparation. To actually ship RC2: merge → create the GitHub **release `v1.0.0-RC2`**, which triggers `publish.yml` to deploy the signed artifacts to Maven Central and attach them to the release. I did **not** create/push a tag, since the `v1.0.0-RC2` tag should point at the post-merge commit on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)