### PR TITLE
Correctness: stale fingerprints, cross-root logger shutdown, invalid Mentat JSON, dropped Plandex privacy

### DIFF
--- a/vibetags/src/main/java/se/deversity/vibetags/processor/VibeTagsLogger.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/VibeTagsLogger.java
@@ -165,14 +165,17 @@ public final class VibeTagsLogger {
         if (projectRoot != null) {
             THREAD_PROJECT_ROOTS.get().add(projectRoot);
         }
-        // Resolve the effective log file path
-        Path logFile = resolveLogFile(projectRoot, logPath);
-
-        // Handle OFF level — return no-op immediately, release any previous handle
+        // Handle OFF level BEFORE resolving the log file path: OFF never creates a file,
+        // and resolving would NPE for a null (permitted, @Nullable) projectRoot. Release
+        // only THIS root's previous handle — a global shutdown() here would silently
+        // detach the appenders of other roots' still-active loggers on the same thread.
         if ("OFF".equalsIgnoreCase(level)) {
-            shutdown();
+            detachAppendersFor(projectRoot);
             return NOPLogger.NOP_LOGGER;
         }
+
+        // Resolve the effective log file path
+        Path logFile = resolveLogFile(projectRoot, logPath);
 
         try {
             ILoggerFactory factory = LoggerFactory.getILoggerFactory();
@@ -211,11 +214,33 @@ public final class VibeTagsLogger {
         }
     }
 
+    /**
+     * Detaches and stops the appenders of the logger belonging to {@code projectRoot} only
+     * (or the base logger when {@code projectRoot} is null), leaving other roots' loggers
+     * on this thread untouched.
+     */
+    private static void detachAppendersFor(@Nullable Path projectRoot) {
+        try {
+            ILoggerFactory factory = LoggerFactory.getILoggerFactory();
+            if (factory instanceof LoggerContext context) {
+                context.getLogger(getLoggerName(projectRoot)).detachAndStopAllAppenders();
+            }
+            if (projectRoot != null) {
+                THREAD_PROJECT_ROOTS.get().remove(projectRoot);
+            }
+        } catch (RuntimeException ignored) {
+            // Never let logging teardown propagate.
+        }
+    }
+
     private static Path resolveLogFile(@Nullable Path projectRoot, @Nullable String logPath) {
+        // projectRoot is @Nullable: fall back to the JVM working directory, matching the
+        // processor's own default root (Paths.get("")).
+        Path base = projectRoot != null ? projectRoot : Paths.get("").toAbsolutePath();
         if (logPath == null || logPath.isBlank()) {
-            return projectRoot.resolve(DEFAULT_LOG_FILE);
+            return base.resolve(DEFAULT_LOG_FILE);
         }
         Path p = Paths.get(logPath);
-        return p.isAbsolute() ? p : projectRoot.resolve(p);
+        return p.isAbsolute() ? p : base.resolve(p);
     }
 }

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/BuildFingerprint.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/BuildFingerprint.java
@@ -18,6 +18,18 @@ import se.deversity.vibetags.annotations.AIArchitecture;
 import se.deversity.vibetags.annotations.AIIdempotent;
 import se.deversity.vibetags.annotations.AIFeatureFlag;
 import se.deversity.vibetags.annotations.AISecure;
+import se.deversity.vibetags.annotations.AICallersOnly;
+import se.deversity.vibetags.annotations.AISandboxOnly;
+import se.deversity.vibetags.annotations.AIMemoryBudget;
+import se.deversity.vibetags.annotations.AIPure;
+import se.deversity.vibetags.annotations.AIDomainModel;
+import se.deversity.vibetags.annotations.AIExtensible;
+import se.deversity.vibetags.annotations.AIInputSanitized;
+import se.deversity.vibetags.annotations.AISecureLogging;
+import se.deversity.vibetags.annotations.AIExplain;
+import se.deversity.vibetags.annotations.AIPrototype;
+import se.deversity.vibetags.annotations.AISunset;
+import se.deversity.vibetags.annotations.AITemporary;
 
 import javax.lang.model.element.Element;
 import java.util.ArrayList;
@@ -169,6 +181,67 @@ public final class BuildFingerprint {
         appendAnnotationSet(sb, "SEC", collector.secure(), e -> {
             AISecure a = e.getAnnotation(AISecure.class);
             return a == null ? "" : a.aspect();
+        });
+        appendAnnotationSet(sb, "CO", collector.callersOnly(), e -> {
+            AICallersOnly a = e.getAnnotation(AICallersOnly.class);
+            return a == null ? "" : String.join(",", a.value());
+        });
+        appendAnnotationSet(sb, "SO", collector.sandboxOnly(), e -> {
+            AISandboxOnly a = e.getAnnotation(AISandboxOnly.class);
+            return a == null ? "" : a.reason();
+        });
+        appendAnnotationSet(sb, "MB", collector.memoryBudget(), e -> {
+            AIMemoryBudget a = e.getAnnotation(AIMemoryBudget.class);
+            return a == null ? "" : a.value().name();
+        });
+        appendAnnotationSet(sb, "PU", collector.pure(), e -> {
+            AIPure a = e.getAnnotation(AIPure.class);
+            return a == null ? "" : a.reason();
+        });
+        appendAnnotationSet(sb, "DM", collector.domainModel(), e -> {
+            AIDomainModel a = e.getAnnotation(AIDomainModel.class);
+            return a == null ? "" : String.join(",", a.allow());
+        });
+        appendAnnotationSet(sb, "EX", collector.extensible(), e -> {
+            AIExtensible a = e.getAnnotation(AIExtensible.class);
+            return a == null ? "" : a.value().name();
+        });
+        appendAnnotationSet(sb, "IZ", collector.inputSanitized(), e -> {
+            AIInputSanitized a = e.getAnnotation(AIInputSanitized.class);
+            if (a == null) return "";
+            StringBuilder types = new StringBuilder();
+            for (AIInputSanitized.SanitizerType t : a.value()) types.append(t.name()).append(',');
+            return types.toString();
+        });
+        appendAnnotationSet(sb, "SL", collector.secureLogging(), e -> {
+            AISecureLogging a = e.getAnnotation(AISecureLogging.class);
+            return a == null ? "" : a.value().name();
+        });
+        appendAnnotationSet(sb, "XP", collector.explain(), e -> {
+            AIExplain a = e.getAnnotation(AIExplain.class);
+            return a == null ? "" : a.value().name();
+        });
+        appendAnnotationSet(sb, "PR", collector.prototype(), e -> {
+            AIPrototype a = e.getAnnotation(AIPrototype.class);
+            return a == null ? "" : a.reason();
+        });
+        appendAnnotationSet(sb, "SN", collector.sunset(), e -> {
+            AISunset a = e.getAnnotation(AISunset.class);
+            if (a == null) return "";
+            // Class-valued attributes throw MirroredTypeException during annotation processing;
+            // the mirror's toString() is the replacement type's canonical name.
+            String replacement;
+            try {
+                Class<?> c = a.replacement();
+                replacement = c == null ? "" : c.getName();
+            } catch (javax.lang.model.type.MirroredTypeException mte) {
+                replacement = String.valueOf(mte.getTypeMirror());
+            }
+            return a.jira() + "|" + replacement;
+        });
+        appendAnnotationSet(sb, "TM", collector.temporary(), e -> {
+            AITemporary a = e.getAnnotation(AITemporary.class);
+            return a == null ? "" : a.expiresOn() + "|" + a.reason();
         });
 
         sb.append("S{");

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIPrivacyFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIPrivacyFormatter.java
@@ -59,6 +59,11 @@ public final class AIPrivacyFormatter implements AnnotationFormatter {
             case SWEEP:
                 sb.append("  - \"PII protection required for ").append(Escape.json(className)).append(": never log or expose runtime values\"\n");
                 break;
+            case PLANDEX:
+                // Same list-entry shape as AILockedFormatter's PLANDEX case; PlandexRenderer
+                // nests these under its "  privacy:" key.
+                sb.append("    - path: \"").append(Escape.json(className)).append("\"\n      reason: \"").append(Escape.json(reason)).append("\"\n");
+                break;
             case INTERPRETER:
                 sb.append("- `").append(className).append("` (privacy): ").append(reason).append("\n");
                 break;

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/platforms/MentatRenderer.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/platforms/MentatRenderer.java
@@ -51,6 +51,14 @@ public final class MentatRenderer implements PlatformRenderer {
         for (Element e : collector.testDriven()) FormatterRegistry.testDriven().format(e, testDriven, Platform.MENTAT);
         appendJsonSection(sb, "test_driven", testDriven);
 
+        // The last section leaves a separator comma behind — strip it, JSON forbids
+        // trailing commas and strict parsers reject the whole file.
+        int len = sb.length();
+        if (len >= 2 && sb.charAt(len - 2) == ',' && sb.charAt(len - 1) == '\n') {
+            sb.setLength(len - 2);
+            sb.append('\n');
+        }
+
         sb.append("  }\n}\n");
         return sb.toString();
     }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/BuildFingerprintUnitTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/BuildFingerprintUnitTest.java
@@ -190,6 +190,81 @@ class BuildFingerprintUnitTest {
         assertFalse(v.isBlank(), "ProcessorVersion.get() must never return blank");
     }
 
+    /**
+     * Every collected annotation bucket must be part of the fingerprint input. If a bucket is
+     * omitted, adding/removing that annotation leaves the fingerprint unchanged, and the top-level
+     * short-circuit in {@code generateFiles()} skips regeneration — the generated guardrail files
+     * silently go stale. This exercises the 12 newest buckets (v1.1 annotations), which are
+     * rendered by every renderer (LlmsRenderer, ClaudeRenderer, GranularRenderer, ...) and must
+     * therefore invalidate the cache like the original 27.
+     */
+    @Test
+    void compute_everyNewestAnnotationBucket_affectsFingerprint() {
+        String emptyFp = BuildFingerprint.compute(new AnnotationCollector(), Set.of("cursor"), "1.0.0");
+
+        java.util.Map<String, Class<? extends java.lang.annotation.Annotation>> buckets =
+            new java.util.LinkedHashMap<>();
+        buckets.put("callersOnly",    se.deversity.vibetags.annotations.AICallersOnly.class);
+        buckets.put("sandboxOnly",    se.deversity.vibetags.annotations.AISandboxOnly.class);
+        buckets.put("memoryBudget",   se.deversity.vibetags.annotations.AIMemoryBudget.class);
+        buckets.put("pure",           se.deversity.vibetags.annotations.AIPure.class);
+        buckets.put("domainModel",    se.deversity.vibetags.annotations.AIDomainModel.class);
+        buckets.put("extensible",     se.deversity.vibetags.annotations.AIExtensible.class);
+        buckets.put("inputSanitized", se.deversity.vibetags.annotations.AIInputSanitized.class);
+        buckets.put("secureLogging",  se.deversity.vibetags.annotations.AISecureLogging.class);
+        buckets.put("explain",        se.deversity.vibetags.annotations.AIExplain.class);
+        buckets.put("prototype",      se.deversity.vibetags.annotations.AIPrototype.class);
+        buckets.put("sunset",         se.deversity.vibetags.annotations.AISunset.class);
+        buckets.put("temporary",      se.deversity.vibetags.annotations.AITemporary.class);
+
+        for (var entry : buckets.entrySet()) {
+            AnnotationCollector collector = new AnnotationCollector();
+            RoundEnvironment re = mock(RoundEnvironment.class);
+            Element elem = namedElement("com.example." + entry.getKey());
+            doReturn(Set.of(elem)).when(re).getElementsAnnotatedWith(entry.getValue());
+            collector.collect(re);
+
+            assertNotEquals(emptyFp,
+                BuildFingerprint.compute(collector, Set.of("cursor"), "1.0.0"),
+                "An element in the '" + entry.getKey() + "' bucket must change the fingerprint "
+                    + "(otherwise the short-circuit skips regeneration and output goes stale)");
+        }
+    }
+
+    /**
+     * Attribute values of the newest buckets must also be fingerprinted: editing
+     * {@code @AITemporary(expiresOn = ...)} on an already-annotated element changes the rendered
+     * output, so it must change the fingerprint too.
+     */
+    @Test
+    void compute_temporaryAttributeChange_invalidatesFingerprint() {
+        String fpA = fingerprintWithTemporary("2026-01-01", "hotfix A");
+        String fpB = fingerprintWithTemporary("2027-12-31", "hotfix A");
+
+        assertNotEquals(fpA, fpB,
+            "Changing @AITemporary.expiresOn must change the fingerprint — the rendered "
+                + "expiration date differs, so regeneration must not be skipped");
+        assertEquals(fpA, fingerprintWithTemporary("2026-01-01", "hotfix A"),
+            "Identical @AITemporary attributes must stay deterministic");
+    }
+
+    private static String fingerprintWithTemporary(String expiresOn, String reason) {
+        se.deversity.vibetags.annotations.AITemporary ann =
+            mock(se.deversity.vibetags.annotations.AITemporary.class);
+        when(ann.expiresOn()).thenReturn(expiresOn);
+        when(ann.reason()).thenReturn(reason);
+
+        Element elem = namedElement("com.example.TempFix");
+        when(elem.getAnnotation(se.deversity.vibetags.annotations.AITemporary.class)).thenReturn(ann);
+
+        RoundEnvironment re = mock(RoundEnvironment.class);
+        doReturn(Set.of(elem)).when(re).getElementsAnnotatedWith(se.deversity.vibetags.annotations.AITemporary.class);
+
+        AnnotationCollector collector = new AnnotationCollector();
+        collector.collect(re);
+        return BuildFingerprint.compute(collector, Set.of("cursor"), "1.0.0");
+    }
+
     // -----------------------------------------------------------------------
     // Helper
     // -----------------------------------------------------------------------

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/NewPlatformsV2EndToEndTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/NewPlatformsV2EndToEndTest.java
@@ -200,6 +200,19 @@ class NewPlatformsV2EndToEndTest {
         assertTrue(content.contains("DatabaseConnector"), "Should mention @AIAudit DatabaseConnector");
     }
 
+    @Test
+    void testPlandexYamlHasPrivacySection() throws IOException {
+        String content = harness.readFile(".plandex.yaml");
+
+        // PlandexRenderer builds a privacy section from collector.privacy() — if the
+        // formatter has no PLANDEX case, the loop is a silent no-op and every
+        // @AIPrivacy guardrail is missing from .plandex.yaml.
+        assertTrue(content.contains("privacy:"),
+            "Should have privacy: section — the sources contain @AIPrivacy on UserProfile.email");
+        assertTrue(content.contains("UserProfile"), "Should mention the @AIPrivacy element");
+        assertTrue(content.contains("Contains PII - GDPR protected"), "Should carry the privacy reason");
+    }
+
     // -----------------------------------------------------------------------
     // Double.bot .doubleignore
     // -----------------------------------------------------------------------

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/NewPlatformsV2EndToEndTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/NewPlatformsV2EndToEndTest.java
@@ -92,6 +92,19 @@ class NewPlatformsV2EndToEndTest {
     }
 
     @Test
+    void testMentatConfigHasNoTrailingCommas() throws IOException {
+        String content = harness.readFile(".mentatconfig.json");
+
+        // JSON forbids trailing commas ("...],\n  }" is invalid). A strict parser —
+        // which is what Mentat uses to read its own config — rejects the whole file,
+        // so every guardrail in it is silently ignored.
+        java.util.regex.Matcher m = java.util.regex.Pattern.compile(",\\s*[}\\]]").matcher(content);
+        assertFalse(m.find(),
+            "Generated .mentatconfig.json contains a trailing comma before a closing brace/bracket "
+                + "— invalid JSON, strict parsers reject the entire file:\n" + content);
+    }
+
+    @Test
     void testMentatConfigHasLockedFiles() throws IOException {
         String content = harness.readFile(".mentatconfig.json");
 

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/VibeTagsLoggerUnitTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/VibeTagsLoggerUnitTest.java
@@ -60,6 +60,35 @@ class VibeTagsLoggerUnitTest {
         assertSame(NOPLogger.NOP_LOGGER, logger);
     }
 
+    @Test
+    void forRootOffLevel_nullRoot_returnsNopWithoutThrowing() {
+        // projectRoot is declared @Nullable; OFF must not NPE trying to resolve a log
+        // file it will never create.
+        Logger logger = assertDoesNotThrow(() -> VibeTagsLogger.forRoot(null, null, "OFF"),
+            "forRoot(null, null, \"OFF\") must not throw — projectRoot is @Nullable");
+        assertSame(NOPLogger.NOP_LOGGER, logger);
+    }
+
+    @Test
+    void forRootOffLevel_doesNotDetachSiblingRootsActiveLogger(@TempDir Path rootA, @TempDir Path rootB)
+            throws Exception {
+        // Two roots on the same thread (e.g. two modules compiled by the same daemon
+        // thread). Turning logging OFF for root B must only release B's handle — it must
+        // not silently detach the appender of root A's still-active logger.
+        Logger loggerA = VibeTagsLogger.forRoot(rootA, null, "INFO");
+        loggerA.info("before-off");
+
+        VibeTagsLogger.forRoot(rootB, null, "OFF");
+
+        loggerA.info("after-off");
+        VibeTagsLogger.shutdown(rootA);
+
+        String logged = Files.readString(rootA.resolve(VibeTagsLogger.DEFAULT_LOG_FILE));
+        assertTrue(logged.contains("before-off"), "sanity: the first message must be on file");
+        assertTrue(logged.contains("after-off"),
+            "OFF for root B must not detach root A's appender — root A's messages were silently lost");
+    }
+
     // --- resolveLogFile: relative path ---
 
     @Test


### PR DESCRIPTION
Correctness hunt: four verified bugs, each fixed test-first (the failing test was confirmed red for the right reason before the fix, and ships in the same commit). All four silently corrupt or drop generated output — the worst kind for this library.

## Bugs fixed

1. **Fingerprint ignores the 12 newest annotation buckets → permanently stale output** (`BuildFingerprint.compute`). `callersOnly, sandboxOnly, memoryBudget, pure, domainModel, extensible, inputSanitized, secureLogging, explain, prototype, sunset, temporary` were never hashed, though every renderer emits them. Add/edit/remove e.g. `@AITemporary(expiresOn=...)` and recompile → identical fingerprint → `generateFiles()` short-circuits → CLAUDE.md/.cursorrules/llms.txt never update.
2. **OFF log level NPEs on null root and kills sibling roots' logging** (`VibeTagsLogger.forRoot`). The `@Nullable` projectRoot was dereferenced before the OFF check, and the OFF path called global `shutdown()`, detaching the live appenders of *every* root tracked on the thread — turning logging off for project B silently swallowed project A's log output.
3. **`.mentatconfig.json` is invalid JSON** (`MentatRenderer.appendJsonSection`). Every rules section ended with a trailing comma; strict parsers reject the whole file, so all guardrails in it were ignored. The existing "valid JSON structure" test passed on substring checks — it never parsed anything. The new test rejects `,` before `}` / `]` structurally.
4. **`.plandex.yaml` silently omits every `@AIPrivacy` guardrail** (`AIPrivacyFormatter` had no `PLANDEX` case while `PlandexRenderer` builds a `privacy:` section from it). After the fix, all 39 formatters were audited against every renderer↔platform pairing — no other gap of this shape remains.

## Verification
- `mvn -B verify -Drun.integration.tests=true`: **1070 tests (6 new), 0 failures/errors/skipped; PMD, CPD, SpotBugs green.**
- pre-commit hooks (checkstyle/gitleaks) aren't installed on this machine; changed files were manually checked against their rules.

## Found but deliberately not fixed
- Multi-module builds never refresh existing JSON/TOML outputs (`generateFiles()` derives `hasNewRules` from sidecars that only carry marker bodies) — **that method is `@AILocked`**, so this needs an owner decision.
- Multi-module YAML merge concatenates complete YAML documents (duplicate top-level keys) for sweep/coderabbit/ellipsis/plandex/roomodes — design-level decision.
- Marker-scan robustness issues overlap with the unmerged `fix/marker-detection-corrupts-prose` branch and were not duplicated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgHAmoyEgqd7HuJQp7nCtN
