### PR TITLE
chore: prepare release v1.0.0-RC3

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary annotations, or wants to control how AI tools interact with Java code.
-version: 1.0.0-RC2
+version: 1.0.0-RC3
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.0-RC2</version>
+    <version>1.0.0-RC3</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.0-RC2'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC2'
+compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.0-RC3'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC3'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.0-RC2</version>
+            <version>1.0.0-RC3</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -70,7 +70,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.0-RC2</version>
+                        <version>1.0.0-RC3</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -111,8 +111,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC3')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -346,7 +346,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.0-RC2</version>
+            <version>1.0.0-RC3</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -371,7 +371,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.0-RC2</version>
+                        <version>1.0.0-RC3</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -385,8 +385,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC3')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -400,15 +400,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.0-RC2</version>
+    <version>1.0.0-RC3</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC2'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC2'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC3'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC3'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-RC3] - 2026-07-17
+
 ### Security
 - **Escape interpolated values in all structured outputs.** Annotation attribute text (`reason`,
   `note`, `focus`, …) and element paths are now escaped per format before being written into the
@@ -923,7 +925,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC2...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC3...HEAD
+[1.0.0-RC3]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC2...v1.0.0-RC3
 [1.0.0-RC2]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC1...v1.0.0-RC2
 [1.0.0-RC1]: https://github.com/PIsberg/vibetags/compare/v0.9.9...v1.0.0-RC1
 [0.9.9]: https://github.com/PIsberg/vibetags/compare/v0.9.8...v0.9.9

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC3')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.0.0-RC2</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0-RC3</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
     </properties>
 

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.0.0-RC2</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0-RC3</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.0-RC2'
+version = '1.0.0-RC3'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.0.0-RC2'
+            version = '1.0.0-RC3'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.0-RC2</version>
+    <version>1.0.0-RC3</version>
     <packaging>jar</packaging>
 
     <name>VibeTags Annotations</name>
@@ -23,12 +23,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.0.0-RC2&lt;/version&gt;
+                &lt;version&gt;1.0.0-RC3&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC2'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC2'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC3'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC3'
     </description>
     <url>https://github.com/PIsberg/vibetags</url>
 

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-bom</artifactId>
-    <version>1.0.0-RC2</version>
+    <version>1.0.0-RC3</version>
     <packaging>pom</packaging>
 
     <name>VibeTags BOM</name>
@@ -25,7 +25,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.0.0-RC2&lt;/version&gt;
+                        &lt;version&gt;1.0.0-RC3&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -33,8 +33,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC2')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC2')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC3')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC3')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>
@@ -66,7 +66,7 @@
         <!-- Single source of truth for the VibeTags artifact set. Bump this when releasing
              a new processor version; all consumers that import this BOM track the bump
              without further changes. -->
-        <vibetags.version>1.0.0-RC2</vibetags.version>
+        <vibetags.version>1.0.0-RC3</vibetags.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.0-RC2'
+version = '1.0.0-RC3'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.0.0-RC2'
+            version = '1.0.0-RC3'
             from components.java
 
             pom {
@@ -77,7 +77,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC2'
+    api 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC3'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.0'

--- a/vibetags/pom.xml
+++ b/vibetags/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.0-RC2</version>
+    <version>1.0.0-RC3</version>
     <packaging>jar</packaging>
 
     <name>VibeTags Processor</name>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-annotations</artifactId>
-            <version>1.0.0-RC2</version>
+            <version>1.0.0-RC3</version>
         </dependency>
 
         <!-- JSpecify null annotations (@NullMarked, @Nullable, @NonNull).


### PR DESCRIPTION
Prepares the `v1.0.0-RC3` release. Cut with the new `/release` skill.

## Version

`1.0.0-RC2` → `1.0.0-RC3` via `scripts/set-version.sh` (annotations, processor, BOM), plus the consumers that track a released BOM: `example/`, `tools/demo/`, `README.md`, and `.claude/skills/vibetags-usage/SKILL.md`.

Deliberately **not** bumped:
- `load-tests/pom.xml` — `<processor.version>` stays pinned at `0.9.5` for cross-version benchmark comparison.
- `docs/vibetags-in-practice.md` — its `1.0.0-RC2` mentions are survey data about what consuming codebases actually use, not install snippets. Bumping them would falsify the survey.

## Changelog

`[Unreleased]` → `[1.0.0-RC3] - 2026-07-17`, carrying the security work: output escaping across XML/JSON/YAML structured outputs, locked-files action option-injection hardening, secure random staging files in `GuardrailFileWriter`, and the documented threat model. Comparison links updated.

## Verification

- 1069 tests pass (75 classes, 0 failures, 0 errors).
- `example/` compiles against the freshly installed RC3 BOM with annotation processing firing.
- Version sweep is clean: no stray `1.0.0-RC2` outside the changelog history and the survey doc.
- `pre-commit` is not installed on the release machine, so hooks were not run locally — relying on CI for Checkstyle/gitleaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GMJvkJX8YQ3rwf7SqJCHh