### PR TITLE
ci(pit): add honest mutation-score badge, parallelize PIT with threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Maven](https://img.shields.io/badge/build-Maven-blue?logo=apachemaven)](https://github.com/PIsberg/vibetags/actions/workflows/build.yml)
 [![Gradle](https://img.shields.io/badge/build-Gradle-blue?logo=gradle)](https://github.com/PIsberg/vibetags/actions/workflows/build.yml)
 [![codecov](https://codecov.io/gh/PIsberg/vibetags/branch/main/graph/badge.svg)](https://codecov.io/gh/PIsberg/vibetags)
+[![PIT Mutation Testing](https://img.shields.io/badge/PIT%20Mutation-56%25-yellow?logo=apachemaven&logoColor=white)](https://github.com/PIsberg/vibetags/actions/workflows/build.yml)
 [![Lines of Code](https://www.aschey.tech/tokei/github/PIsberg/VibeTags?languages=Java&category=code)](https://github.com/PIsberg/VibeTags)
 [![PMD](https://img.shields.io/badge/PMD-passing-brightgreen)](https://pmd.github.io/)
 [![SpotBugs](https://img.shields.io/badge/SpotBugs-passing-brightgreen)](https://spotbugs.github.io/)

--- a/vibetags/pom.xml
+++ b/vibetags/pom.xml
@@ -418,6 +418,10 @@
                                 <param>XML</param>
                             </outputFormats>
                             <timestampedReports>false</timestampedReports>
+                            <!-- PIT defaults to a single thread; GitHub-hosted ubuntu-latest runners
+                                 provide 4 vCPUs, so running mutants in parallel cuts wall-clock time
+                                 roughly proportionally without changing what gets analyzed. -->
+                            <threads>4</threads>
                         </configuration>
                         <dependencies>
                             <dependency>


### PR DESCRIPTION
## Summary

Two small, related fixes prompted by a question about the PIT mutation testing job.

- **README badge**: added a PIT mutation-coverage badge showing the real current score (**56%**, from the last report) instead of a misleading "passing" claim. The job has no `mutationThreshold` configured and runs with `continue-on-error: true`, so it always reports green in CI regardless of the actual score — a static "passing"-style badge (matching the PMD/SpotBugs/Checkstyle style already in the README) would have been inaccurate. This is a manual snapshot and will need updating as the score changes; a threshold-gated badge is a natural follow-up once there's a real bar to enforce.
- **PIT parallelism**: added `<threads>4</threads>` to the `mutation` Maven profile. PIT defaults to a single thread. On the last completed run, every other job in `build.yml` (3× Maven builds, 3× Gradle builds, cross-platform tests, load tests) finished in under 8 minutes combined, while `Mutation Testing (PIT)` alone ran for ~45 minutes (mutating the entire codebase serially on every push/PR). 4 threads matches the vCPU count on GitHub-hosted `ubuntu-latest` runners.

## Test plan

- [x] `mvn -Pmutation help:evaluate -Dexpression=project.version -DforceStdout` — confirms the `mutation` profile (with the new `<threads>` element) still parses and activates cleanly
- [ ] Full PIT run in CI will confirm the wall-clock improvement (not run locally — that's the whole point, it's slow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014o5qFzPMQYSg3bA6JHmst7