### PR TITLE
test(pit): comprehensive all-39-annotation-type coverage for shared dispatch points

### DIFF
--- a/vibetags/src/test/java/se/deversity/vibetags/processor/AnnotationCollectorUnitTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/AnnotationCollectorUnitTest.java
@@ -208,6 +208,192 @@ class AnnotationCollectorUnitTest {
     }
 
     // ------------------------------------------------------------------
+    // Middle-batch annotations (v0.9.x) — added across several releases and never covered by
+    // a per-bucket check here; each collectInto(...) call in collect() must be independently
+    // verified, otherwise PIT can delete the call for any of these types undetected.
+    // ------------------------------------------------------------------
+
+    @Test
+    void collect_onlyLockedAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AILocked.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.locked().isEmpty());
+    }
+
+    @Test
+    void collect_onlyIgnoreAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AIIgnore.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.ignore().isEmpty());
+    }
+
+    @Test
+    void collect_onlyContractAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AIContract.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.contract().isEmpty());
+    }
+
+    @Test
+    void collect_onlyTestDrivenAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AITestDriven.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.testDriven().isEmpty());
+    }
+
+    @Test
+    void collect_onlyThreadSafeAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AIThreadSafe.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.threadSafe().isEmpty());
+    }
+
+    @Test
+    void collect_onlyObservabilityAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AIObservability.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.observability().isEmpty());
+    }
+
+    @Test
+    void collect_onlyParallelTestsAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AIParallelTests.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.parallelTests().isEmpty());
+    }
+
+    @Test
+    void collect_onlyLegacyBridgeAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AILegacyBridge.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.legacyBridge().isEmpty());
+    }
+
+    @Test
+    void collect_onlyArchitectureAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AIArchitecture.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.architecture().isEmpty());
+    }
+
+    @Test
+    void collect_onlyPublicApiAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AIPublicAPI.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.publicApi().isEmpty());
+    }
+
+    @Test
+    void collect_onlyStrictExceptionsAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AIStrictExceptions.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.strictExceptions().isEmpty());
+    }
+
+    @Test
+    void collect_onlyStrictTypesAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AIStrictTypes.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.strictTypes().isEmpty());
+    }
+
+    @Test
+    void collect_onlyInternationalizedAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AIInternationalized.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.internationalized().isEmpty());
+    }
+
+    @Test
+    void collect_onlyStrictClasspathAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AIStrictClasspath.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.strictClasspath().isEmpty());
+    }
+
+    @Test
+    void collect_onlySchemaSafeAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AISchemaSafe.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.schemaSafe().isEmpty());
+    }
+
+    @Test
+    void collect_onlyIdempotentAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AIIdempotent.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.idempotent().isEmpty());
+    }
+
+    @Test
+    void collect_onlyFeatureFlagAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AIFeatureFlag.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.featureFlag().isEmpty());
+    }
+
+    @Test
+    void collect_onlySecureAnnotation_returnsTrue() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = reWithOnly(AISecure.class);
+        boolean added = collector.collect(re);
+        assertTrue(added);
+        assertTrue(collector.anyAnnotationsFound());
+        assertFalse(collector.secure().isEmpty());
+    }
+
+    // ------------------------------------------------------------------
     // Position 16+: New annotations
     // ------------------------------------------------------------------
 

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/BuildFingerprintUnitTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/BuildFingerprintUnitTest.java
@@ -248,6 +248,48 @@ class BuildFingerprintUnitTest {
             "Identical @AITemporary attributes must stay deterministic");
     }
 
+    /**
+     * The 13 "middle batch" buckets that fall between the original 15 (covered by
+     * {@link #compute_nullAnnotationsOnAllTypes_returnsValidFingerprint}) and the newest 12
+     * (covered by {@link #compute_everyNewestAnnotationBucket_affectsFingerprint} above) — added
+     * across v0.9.x releases and never wired into either existing sweep. Same rationale as that
+     * test: an element in any of these buckets must change the fingerprint, otherwise the
+     * top-level short-circuit skips regeneration and the generated files silently go stale.
+     */
+    @Test
+    void compute_everyMiddleBatchAnnotationBucket_affectsFingerprint() {
+        String emptyFp = BuildFingerprint.compute(new AnnotationCollector(), Set.of("cursor"), "1.0.0");
+
+        java.util.Map<String, Class<? extends java.lang.annotation.Annotation>> buckets =
+            new java.util.LinkedHashMap<>();
+        buckets.put("ignore",             se.deversity.vibetags.annotations.AIIgnore.class);
+        buckets.put("parallelTests",      se.deversity.vibetags.annotations.AIParallelTests.class);
+        buckets.put("legacyBridge",       se.deversity.vibetags.annotations.AILegacyBridge.class);
+        buckets.put("architecture",       se.deversity.vibetags.annotations.AIArchitecture.class);
+        buckets.put("publicApi",          se.deversity.vibetags.annotations.AIPublicAPI.class);
+        buckets.put("strictExceptions",   se.deversity.vibetags.annotations.AIStrictExceptions.class);
+        buckets.put("strictTypes",        se.deversity.vibetags.annotations.AIStrictTypes.class);
+        buckets.put("internationalized",  se.deversity.vibetags.annotations.AIInternationalized.class);
+        buckets.put("strictClasspath",    se.deversity.vibetags.annotations.AIStrictClasspath.class);
+        buckets.put("schemaSafe",         se.deversity.vibetags.annotations.AISchemaSafe.class);
+        buckets.put("idempotent",         se.deversity.vibetags.annotations.AIIdempotent.class);
+        buckets.put("featureFlag",        se.deversity.vibetags.annotations.AIFeatureFlag.class);
+        buckets.put("secure",             se.deversity.vibetags.annotations.AISecure.class);
+
+        for (var entry : buckets.entrySet()) {
+            AnnotationCollector collector = new AnnotationCollector();
+            RoundEnvironment re = mock(RoundEnvironment.class);
+            Element elem = namedElement("com.example." + entry.getKey());
+            doReturn(Set.of(elem)).when(re).getElementsAnnotatedWith(entry.getValue());
+            collector.collect(re);
+
+            assertNotEquals(emptyFp,
+                BuildFingerprint.compute(collector, Set.of("cursor"), "1.0.0"),
+                "An element in the '" + entry.getKey() + "' bucket must change the fingerprint "
+                    + "(otherwise the short-circuit skips regeneration and output goes stale)");
+        }
+    }
+
     private static String fingerprintWithTemporary(String expiresOn, String reason) {
         se.deversity.vibetags.annotations.AITemporary ann =
             mock(se.deversity.vibetags.annotations.AITemporary.class);

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/GuardrailContentBuilderUnitTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/GuardrailContentBuilderUnitTest.java
@@ -27,6 +27,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -173,6 +174,162 @@ class GuardrailContentBuilderUnitTest {
         when(regAnn.description()).thenReturn("handles PII");
         when(reg.getAnnotation(AIRegulation.class)).thenReturn(regAnn);
         doReturn(Set.of(reg)).when(re).getElementsAnnotatedWith(AIRegulation.class);
+
+        // appendParallelTests/appendLegacyBridge/appendPublicApi/appendStrictExceptions/
+        // appendStrictTypes/appendInternationalized/appendStrictClasspath/appendSchemaSafe/
+        // appendSandboxOnly/appendPure/appendPrototype do not call getAnnotation() — element only.
+        Element parallelTests = namedClassElement("com.example.ParallelTests");
+        doReturn(Set.of(parallelTests)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AIParallelTests.class);
+
+        Element legacyBridge = namedClassElement("com.example.LegacyBridge");
+        doReturn(Set.of(legacyBridge)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AILegacyBridge.class);
+
+        Element architecture = namedClassElement("com.example.Architecture");
+        se.deversity.vibetags.annotations.AIArchitecture archAnn =
+            mock(se.deversity.vibetags.annotations.AIArchitecture.class);
+        when(archAnn.belongsTo()).thenReturn("domain");
+        when(archAnn.cannotReference()).thenReturn(new String[]{"infrastructure"});
+        when(architecture.getAnnotation(se.deversity.vibetags.annotations.AIArchitecture.class)).thenReturn(archAnn);
+        doReturn(Set.of(architecture)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AIArchitecture.class);
+
+        Element publicApi = namedClassElement("com.example.PublicApi");
+        doReturn(Set.of(publicApi)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AIPublicAPI.class);
+
+        Element strictExceptions = namedClassElement("com.example.StrictExceptions");
+        doReturn(Set.of(strictExceptions)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AIStrictExceptions.class);
+
+        Element strictTypes = namedClassElement("com.example.StrictTypes");
+        doReturn(Set.of(strictTypes)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AIStrictTypes.class);
+
+        Element internationalized = namedClassElement("com.example.Internationalized");
+        doReturn(Set.of(internationalized)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AIInternationalized.class);
+
+        Element strictClasspath = namedClassElement("com.example.StrictClasspath");
+        doReturn(Set.of(strictClasspath)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AIStrictClasspath.class);
+
+        Element schemaSafe = namedClassElement("com.example.SchemaSafe");
+        doReturn(Set.of(schemaSafe)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AISchemaSafe.class);
+
+        Element idempotent = namedClassElement("com.example.Idempotent");
+        se.deversity.vibetags.annotations.AIIdempotent idemAnn =
+            mock(se.deversity.vibetags.annotations.AIIdempotent.class);
+        when(idemAnn.reason()).thenReturn("must not double-fire");
+        when(idempotent.getAnnotation(se.deversity.vibetags.annotations.AIIdempotent.class)).thenReturn(idemAnn);
+        doReturn(Set.of(idempotent)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AIIdempotent.class);
+
+        Element featureFlag = namedClassElement("com.example.FeatureFlag");
+        se.deversity.vibetags.annotations.AIFeatureFlag ffAnn =
+            mock(se.deversity.vibetags.annotations.AIFeatureFlag.class);
+        when(ffAnn.flag()).thenReturn("inventory.push-alerts.enabled");
+        when(ffAnn.defaultValue()).thenReturn(false);
+        when(featureFlag.getAnnotation(se.deversity.vibetags.annotations.AIFeatureFlag.class)).thenReturn(ffAnn);
+        doReturn(Set.of(featureFlag)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AIFeatureFlag.class);
+
+        Element secure = namedClassElement("com.example.Secure");
+        se.deversity.vibetags.annotations.AISecure secureAnn =
+            mock(se.deversity.vibetags.annotations.AISecure.class);
+        when(secureAnn.aspect()).thenReturn("authentication");
+        when(secure.getAnnotation(se.deversity.vibetags.annotations.AISecure.class)).thenReturn(secureAnn);
+        doReturn(Set.of(secure)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AISecure.class);
+
+        Element callersOnly = namedClassElement("com.example.CallersOnly");
+        se.deversity.vibetags.annotations.AICallersOnly coAnn =
+            mock(se.deversity.vibetags.annotations.AICallersOnly.class);
+        when(coAnn.value()).thenReturn(new String[]{"com.example.PricingService"});
+        when(callersOnly.getAnnotation(se.deversity.vibetags.annotations.AICallersOnly.class)).thenReturn(coAnn);
+        doReturn(Set.of(callersOnly)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AICallersOnly.class);
+
+        Element sandboxOnly = namedClassElement("com.example.SandboxOnly");
+        doReturn(Set.of(sandboxOnly)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AISandboxOnly.class);
+
+        Element memoryBudget = namedClassElement("com.example.MemoryBudget");
+        se.deversity.vibetags.annotations.AIMemoryBudget mbAnn =
+            mock(se.deversity.vibetags.annotations.AIMemoryBudget.class);
+        when(mbAnn.value()).thenReturn(se.deversity.vibetags.annotations.AIMemoryBudget.AllocationPolicy.ZERO_ALLOCATION);
+        when(memoryBudget.getAnnotation(se.deversity.vibetags.annotations.AIMemoryBudget.class)).thenReturn(mbAnn);
+        doReturn(Set.of(memoryBudget)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AIMemoryBudget.class);
+
+        Element pure = namedClassElement("com.example.Pure");
+        doReturn(Set.of(pure)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AIPure.class);
+
+        Element domainModel = namedClassElement("com.example.DomainModel");
+        se.deversity.vibetags.annotations.AIDomainModel dmAnn =
+            mock(se.deversity.vibetags.annotations.AIDomainModel.class);
+        when(dmAnn.allow()).thenReturn(new String[]{"java.math.BigDecimal"});
+        when(domainModel.getAnnotation(se.deversity.vibetags.annotations.AIDomainModel.class)).thenReturn(dmAnn);
+        doReturn(Set.of(domainModel)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AIDomainModel.class);
+
+        Element extensible = namedClassElement("com.example.Extensible");
+        se.deversity.vibetags.annotations.AIExtensible extAnn =
+            mock(se.deversity.vibetags.annotations.AIExtensible.class);
+        when(extAnn.value()).thenReturn(se.deversity.vibetags.annotations.AIExtensible.Strategy.STRATEGY_PATTERN);
+        when(extensible.getAnnotation(se.deversity.vibetags.annotations.AIExtensible.class)).thenReturn(extAnn);
+        doReturn(Set.of(extensible)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AIExtensible.class);
+
+        Element inputSanitized = namedClassElement("com.example.InputSanitized");
+        se.deversity.vibetags.annotations.AIInputSanitized isAnn =
+            mock(se.deversity.vibetags.annotations.AIInputSanitized.class);
+        when(isAnn.value()).thenReturn(new se.deversity.vibetags.annotations.AIInputSanitized.SanitizerType[]{
+            se.deversity.vibetags.annotations.AIInputSanitized.SanitizerType.SQL_INJECTION});
+        when(inputSanitized.getAnnotation(se.deversity.vibetags.annotations.AIInputSanitized.class)).thenReturn(isAnn);
+        doReturn(Set.of(inputSanitized)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AIInputSanitized.class);
+
+        Element secureLogging = namedClassElement("com.example.SecureLogging");
+        se.deversity.vibetags.annotations.AISecureLogging slAnn =
+            mock(se.deversity.vibetags.annotations.AISecureLogging.class);
+        when(slAnn.value()).thenReturn(se.deversity.vibetags.annotations.AISecureLogging.MaskingPolicy.HASH);
+        when(secureLogging.getAnnotation(se.deversity.vibetags.annotations.AISecureLogging.class)).thenReturn(slAnn);
+        doReturn(Set.of(secureLogging)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AISecureLogging.class);
+
+        Element explain = namedClassElement("com.example.Explain");
+        se.deversity.vibetags.annotations.AIExplain expAnn =
+            mock(se.deversity.vibetags.annotations.AIExplain.class);
+        when(expAnn.value()).thenReturn(se.deversity.vibetags.annotations.AIExplain.ComplexityLevel.HIGH);
+        when(explain.getAnnotation(se.deversity.vibetags.annotations.AIExplain.class)).thenReturn(expAnn);
+        doReturn(Set.of(explain)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AIExplain.class);
+
+        Element prototype = namedClassElement("com.example.Prototype");
+        doReturn(Set.of(prototype)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AIPrototype.class);
+
+        Element sunset = namedClassElement("com.example.Sunset");
+        se.deversity.vibetags.annotations.AISunset sunsetAnn =
+            mock(se.deversity.vibetags.annotations.AISunset.class);
+        when(sunsetAnn.jira()).thenReturn("DEBT-742");
+        doReturn(Object.class).when(sunsetAnn).replacement();
+        when(sunset.getAnnotation(se.deversity.vibetags.annotations.AISunset.class)).thenReturn(sunsetAnn);
+        doReturn(Set.of(sunset)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AISunset.class);
+
+        Element temporary = namedClassElement("com.example.Temporary");
+        se.deversity.vibetags.annotations.AITemporary tempAnn =
+            mock(se.deversity.vibetags.annotations.AITemporary.class);
+        when(tempAnn.expiresOn()).thenReturn("2028-12-31");
+        when(tempAnn.reason()).thenReturn("upstream hotfix");
+        when(temporary.getAnnotation(se.deversity.vibetags.annotations.AITemporary.class)).thenReturn(tempAnn);
+        doReturn(Set.of(temporary)).when(re).getElementsAnnotatedWith(
+            se.deversity.vibetags.annotations.AITemporary.class);
 
         collector.collect(re);
         return collector;
@@ -613,5 +770,136 @@ class GuardrailContentBuilderUnitTest {
                 "empty audit section must not produce a JSON key");
         assertFalse(mentat.contains("\"draft\""),
                 "empty draft section must not produce a JSON key");
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Full-fixture content presence — proves every one of the 39 annotation types actually
+    // reaches ClaudeRenderer's and LlmsRenderer's rendered output. ClaudeRenderer hand-rolls one
+    // `if (!collector.X().isEmpty()) {...}` XML block per type; LlmsRenderer hand-rolls one
+    // appendSection(...) call per type with a unique markdown heading. Neither goes through the
+    // declarative AnnotationSections mechanism CursorRenderer uses, so nothing else in the test
+    // suite verifies most of these types individually reach either renderer's output.
+    // -------------------------------------------------------------------------------------------
+
+    private static Map<String, String> claudeXmlTagsByType() {
+        Map<String, String> tags = new java.util.LinkedHashMap<>();
+        tags.put("locked", "<locked_files>");
+        tags.put("context", "<contextual_instructions>");
+        tags.put("audit", "<audit_requirements>");
+        tags.put("ignore", "<ignored_elements>");
+        tags.put("draft", "<implementation_tasks>");
+        tags.put("privacy", "<pii_guardrails>");
+        tags.put("core", "<core_elements>");
+        tags.put("performance", "<performance_constraints>");
+        tags.put("contract", "<contract_signatures>");
+        tags.put("testDriven", "<test_driven_requirements>");
+        tags.put("threadSafe", "<thread_safe_elements>");
+        tags.put("immutable", "<immutable_types>");
+        tags.put("deprecated", "<deprecated_elements>");
+        tags.put("observability", "<observability_instrumentation>");
+        tags.put("regulation", "<regulatory_elements>");
+        tags.put("parallelTests", "<test_isolation_elements>");
+        tags.put("legacyBridge", "<legacy_bridge_elements>");
+        tags.put("architecture", "<architecture_elements>");
+        tags.put("publicApi", "<public_api_elements>");
+        tags.put("strictExceptions", "<strict_exceptions_elements>");
+        tags.put("strictTypes", "<strict_types_elements>");
+        tags.put("internationalized", "<internationalized_elements>");
+        tags.put("strictClasspath", "<strict_classpath_elements>");
+        tags.put("schemaSafe", "<schema_safe_elements>");
+        tags.put("idempotent", "<idempotent_elements>");
+        tags.put("featureFlag", "<feature_flag_elements>");
+        tags.put("secure", "<security_elements>");
+        tags.put("callersOnly", "<access_limitations>");
+        tags.put("sandboxOnly", "<sandbox_only_elements>");
+        tags.put("memoryBudget", "<memory_budget_elements>");
+        tags.put("pure", "<pure_functions>");
+        tags.put("domainModel", "<domain_model_elements>");
+        tags.put("extensible", "<extensible_patterns>");
+        tags.put("inputSanitized", "<sanitization_elements>");
+        tags.put("secureLogging", "<secure_logging_elements>");
+        tags.put("explain", "<explain_elements>");
+        tags.put("prototype", "<prototype_elements>");
+        tags.put("sunset", "<sunset_elements>");
+        tags.put("temporary", "<temporary_workarounds>");
+        return tags;
+    }
+
+    private static Map<String, String> llmsHeadingsByType() {
+        Map<String, String> headings = new java.util.LinkedHashMap<>();
+        headings.put("locked", "## Locked Files");
+        headings.put("context", "## Contextual Rules");
+        headings.put("audit", "## Security Audit Requirements");
+        headings.put("ignore", "## Ignored Elements");
+        headings.put("draft", "## Implementation Tasks");
+        headings.put("privacy", "## PII / Privacy Guardrails");
+        headings.put("core", "Core Functionality");
+        headings.put("performance", "Performance Constraints");
+        headings.put("contract", "Contract-Frozen Signatures");
+        headings.put("testDriven", "Test-Driven Requirements");
+        headings.put("threadSafe", "Thread-Safe by Design");
+        headings.put("immutable", "Immutable Types");
+        headings.put("deprecated", "Deprecated Elements");
+        headings.put("observability", "Observability Instrumentation");
+        headings.put("regulation", "Regulatory Compliance");
+        headings.put("parallelTests", "## Strict Test Isolation");
+        headings.put("legacyBridge", "## Legacy Compatibility Bridge");
+        headings.put("architecture", "## Architectural Boundary Constraints");
+        headings.put("publicApi", "## Public API Surface Protection");
+        headings.put("strictExceptions", "## Strict Exception Handling");
+        headings.put("strictTypes", "## Strict Type Safety");
+        headings.put("internationalized", "## Internationalization Mandate");
+        headings.put("strictClasspath", "## Strict Classpath Integrity");
+        headings.put("schemaSafe", "## Schema & Serialization Safety");
+        headings.put("idempotent", "Idempotency Guarantees");
+        headings.put("featureFlag", "Feature Flag Gated Code");
+        headings.put("secure", "Security-Critical Code");
+        headings.put("callersOnly", "## Access Limitations");
+        headings.put("sandboxOnly", "## Sandbox & Test Exclusion");
+        headings.put("memoryBudget", "## Memory Allocation Budgets");
+        headings.put("pure", "## Deterministic Pure Functions");
+        headings.put("domainModel", "## Framework-Free Domain Entities");
+        headings.put("extensible", "Extension Patterns");
+        headings.put("inputSanitized", "## Mandatory Input Sanitization");
+        headings.put("secureLogging", "## Secure Logging Masking");
+        headings.put("explain", "## Required Chain-of-Thought Explanations");
+        headings.put("prototype", "## Experimental Prototype Stubs");
+        headings.put("sunset", "## Sunset Deprecated APIs");
+        headings.put("temporary", "## Temporary Code Workarounds");
+        return headings;
+    }
+
+    @Test
+    void build_everyAnnotationType_reachesClaudeRendererOutput() {
+        AnnotationCollector collector = buildAllAnnotationTypes();
+        GuardrailContentBuilder builder = new GuardrailContentBuilder(
+                collector, Set.of("claude"), "Test", "");
+        GuardrailContentBuilder.Result result = assertDoesNotThrow(builder::build);
+        String claude = result.contentByService.get("claude");
+        assertNotNull(claude, "claude must appear in contentByService");
+
+        for (var entry : claudeXmlTagsByType().entrySet()) {
+            assertTrue(claude.contains(entry.getValue()),
+                "CLAUDE.md output must contain the '" + entry.getKey() + "' XML tag '"
+                    + entry.getValue() + "' — missing means that annotation type's "
+                    + "if (!collector.X().isEmpty()) block never fired");
+        }
+    }
+
+    @Test
+    void build_everyAnnotationType_reachesLlmsRendererOutput() {
+        AnnotationCollector collector = buildAllAnnotationTypes();
+        GuardrailContentBuilder builder = new GuardrailContentBuilder(
+                collector, Set.of("llms"), "Test", "");
+        GuardrailContentBuilder.Result result = assertDoesNotThrow(builder::build);
+        String llms = result.contentByService.get("llms");
+        assertNotNull(llms, "llms must appear in contentByService");
+
+        for (var entry : llmsHeadingsByType().entrySet()) {
+            assertTrue(llms.contains(entry.getValue()),
+                "llms.txt output must contain the '" + entry.getKey() + "' heading '"
+                    + entry.getValue() + "' — missing means that annotation type's "
+                    + "appendSection(...) call never fired");
+        }
     }
 }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/internal/content/platforms/GuardrailInstructionBlockTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/internal/content/platforms/GuardrailInstructionBlockTest.java
@@ -1,0 +1,282 @@
+package se.deversity.vibetags.processor.internal.content.platforms;
+
+import org.junit.jupiter.api.Test;
+import se.deversity.vibetags.annotations.*;
+import se.deversity.vibetags.processor.internal.AnnotationCollector;
+
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Name;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Proves every one of the 39 annotation types actually reaches
+ * {@link GuardrailInstructionBlock#build(AnnotationCollector)} — each
+ * {@code FormatterRegistry.X().format(...)} call in that method is otherwise unverified by any
+ * other test (the shared PR-reviewer/Roo-mode instruction block is a thin pass-through, easy to
+ * silently regress when a new annotation type is added but forgotten here).
+ */
+class GuardrailInstructionBlockTest {
+
+    private static Element namedElement(String fqn) {
+        Element e = mock(Element.class);
+        when(e.toString()).thenReturn(fqn);
+        Name simpleName = mock(Name.class);
+        String simple = fqn.substring(fqn.lastIndexOf('.') + 1);
+        when(simpleName.toString()).thenReturn(simple);
+        when(e.getSimpleName()).thenReturn(simpleName);
+        return e;
+    }
+
+    private static <A extends java.lang.annotation.Annotation> void wire(
+            RoundEnvironment re, Class<A> type, Element elem, A annotation) {
+        when(elem.getAnnotation(type)).thenReturn(annotation);
+        doReturn(Set.of(elem)).when(re).getElementsAnnotatedWith(type);
+    }
+
+    private static AnnotationCollector buildFullCollector() {
+        AnnotationCollector collector = new AnnotationCollector();
+        RoundEnvironment re = mock(RoundEnvironment.class);
+
+        AILocked locked = mock(AILocked.class);
+        when(locked.reason()).thenReturn("legacy schema");
+        wire(re, AILocked.class, namedElement("com.example.Locked"), locked);
+
+        AIContext context = mock(AIContext.class);
+        when(context.focus()).thenReturn("memory usage");
+        when(context.avoids()).thenReturn("regex");
+        wire(re, AIContext.class, namedElement("com.example.Context"), context);
+
+        AIIgnore ignore = mock(AIIgnore.class);
+        wire(re, AIIgnore.class, namedElement("com.example.Ignore"), ignore);
+
+        AIAudit audit = mock(AIAudit.class);
+        when(audit.checkFor()).thenReturn(new String[]{"SQL Injection"});
+        wire(re, AIAudit.class, namedElement("com.example.Audit"), audit);
+
+        AIDraft draft = mock(AIDraft.class);
+        when(draft.instructions()).thenReturn("implement retry logic");
+        wire(re, AIDraft.class, namedElement("com.example.Draft"), draft);
+
+        AIPrivacy privacy = mock(AIPrivacy.class);
+        when(privacy.reason()).thenReturn("PII under GDPR");
+        wire(re, AIPrivacy.class, namedElement("com.example.Privacy"), privacy);
+
+        AICore core = mock(AICore.class);
+        when(core.sensitivity()).thenReturn("Critical");
+        when(core.note()).thenReturn("18 months to stabilize");
+        wire(re, AICore.class, namedElement("com.example.Core"), core);
+
+        AIPerformance performance = mock(AIPerformance.class);
+        when(performance.constraint()).thenReturn("O(1) required");
+        wire(re, AIPerformance.class, namedElement("com.example.Performance"), performance);
+
+        AIContract contract = mock(AIContract.class);
+        when(contract.reason()).thenReturn("partner API SLA");
+        wire(re, AIContract.class, namedElement("com.example.Contract"), contract);
+
+        AITestDriven testDriven = mock(AITestDriven.class);
+        when(testDriven.coverageGoal()).thenReturn(90);
+        when(testDriven.testLocation()).thenReturn("src/test");
+        when(testDriven.framework()).thenReturn(new AITestDriven.Framework[]{AITestDriven.Framework.JUNIT_5});
+        when(testDriven.mockPolicy()).thenReturn("mock external calls");
+        wire(re, AITestDriven.class, namedElement("com.example.TestDriven"), testDriven);
+
+        AIThreadSafe threadSafe = mock(AIThreadSafe.class);
+        when(threadSafe.strategy()).thenReturn(AIThreadSafe.Strategy.LOCK_FREE);
+        when(threadSafe.note()).thenReturn("CAS-based");
+        wire(re, AIThreadSafe.class, namedElement("com.example.ThreadSafe"), threadSafe);
+
+        AIImmutable immutable = mock(AIImmutable.class);
+        when(immutable.note()).thenReturn("shared across threads");
+        wire(re, AIImmutable.class, namedElement("com.example.Immutable"), immutable);
+
+        AIDeprecated deprecated = mock(AIDeprecated.class);
+        when(deprecated.replacedBy()).thenReturn("com.example.New");
+        when(deprecated.migrationGuide()).thenReturn("switch to New.charge()");
+        when(deprecated.deadline()).thenReturn("v2.0");
+        wire(re, AIDeprecated.class, namedElement("com.example.Deprecated"), deprecated);
+
+        AIObservability observability = mock(AIObservability.class);
+        when(observability.metrics()).thenReturn(new String[]{"orders.placed"});
+        when(observability.traces()).thenReturn(new String[]{"order.place"});
+        when(observability.logs()).thenReturn(new String[]{"OrderPlaced"});
+        when(observability.note()).thenReturn("watched by SLO dashboard");
+        wire(re, AIObservability.class, namedElement("com.example.Observability"), observability);
+
+        AIRegulation regulation = mock(AIRegulation.class);
+        when(regulation.standard()).thenReturn("GDPR");
+        when(regulation.clause()).thenReturn("Art. 17");
+        when(regulation.description()).thenReturn("right to erasure");
+        wire(re, AIRegulation.class, namedElement("com.example.Regulation"), regulation);
+
+        AIParallelTests parallelTests = mock(AIParallelTests.class);
+        wire(re, AIParallelTests.class, namedElement("com.example.ParallelTests"), parallelTests);
+
+        AILegacyBridge legacyBridge = mock(AILegacyBridge.class);
+        wire(re, AILegacyBridge.class, namedElement("com.example.LegacyBridge"), legacyBridge);
+
+        AIArchitecture architecture = mock(AIArchitecture.class);
+        when(architecture.belongsTo()).thenReturn("domain");
+        when(architecture.cannotReference()).thenReturn(new String[]{"infrastructure"});
+        wire(re, AIArchitecture.class, namedElement("com.example.Architecture"), architecture);
+
+        AIPublicAPI publicApi = mock(AIPublicAPI.class);
+        wire(re, AIPublicAPI.class, namedElement("com.example.PublicApi"), publicApi);
+
+        AIStrictExceptions strictExceptions = mock(AIStrictExceptions.class);
+        wire(re, AIStrictExceptions.class, namedElement("com.example.StrictExceptions"), strictExceptions);
+
+        AIStrictTypes strictTypes = mock(AIStrictTypes.class);
+        wire(re, AIStrictTypes.class, namedElement("com.example.StrictTypes"), strictTypes);
+
+        AIInternationalized internationalized = mock(AIInternationalized.class);
+        wire(re, AIInternationalized.class, namedElement("com.example.Internationalized"), internationalized);
+
+        AIStrictClasspath strictClasspath = mock(AIStrictClasspath.class);
+        wire(re, AIStrictClasspath.class, namedElement("com.example.StrictClasspath"), strictClasspath);
+
+        AISchemaSafe schemaSafe = mock(AISchemaSafe.class);
+        wire(re, AISchemaSafe.class, namedElement("com.example.SchemaSafe"), schemaSafe);
+
+        AIIdempotent idempotent = mock(AIIdempotent.class);
+        when(idempotent.reason()).thenReturn("deletion must not double-fire");
+        wire(re, AIIdempotent.class, namedElement("com.example.Idempotent"), idempotent);
+
+        AIFeatureFlag featureFlag = mock(AIFeatureFlag.class);
+        when(featureFlag.flag()).thenReturn("inventory.push-alerts.enabled");
+        when(featureFlag.defaultValue()).thenReturn(false);
+        wire(re, AIFeatureFlag.class, namedElement("com.example.FeatureFlag"), featureFlag);
+
+        AISecure secure = mock(AISecure.class);
+        when(secure.aspect()).thenReturn("authentication");
+        wire(re, AISecure.class, namedElement("com.example.Secure"), secure);
+
+        AICallersOnly callersOnly = mock(AICallersOnly.class);
+        when(callersOnly.value()).thenReturn(new String[]{"com.example.PricingService"});
+        wire(re, AICallersOnly.class, namedElement("com.example.CallersOnly"), callersOnly);
+
+        AISandboxOnly sandboxOnly = mock(AISandboxOnly.class);
+        wire(re, AISandboxOnly.class, namedElement("com.example.SandboxOnly"), sandboxOnly);
+
+        AIMemoryBudget memoryBudget = mock(AIMemoryBudget.class);
+        when(memoryBudget.value()).thenReturn(AIMemoryBudget.AllocationPolicy.ZERO_ALLOCATION);
+        wire(re, AIMemoryBudget.class, namedElement("com.example.MemoryBudget"), memoryBudget);
+
+        AIPure pure = mock(AIPure.class);
+        wire(re, AIPure.class, namedElement("com.example.Pure"), pure);
+
+        AIDomainModel domainModel = mock(AIDomainModel.class);
+        when(domainModel.allow()).thenReturn(new String[]{"java.math.BigDecimal"});
+        wire(re, AIDomainModel.class, namedElement("com.example.DomainModel"), domainModel);
+
+        AIExtensible extensible = mock(AIExtensible.class);
+        when(extensible.value()).thenReturn(AIExtensible.Strategy.STRATEGY_PATTERN);
+        wire(re, AIExtensible.class, namedElement("com.example.Extensible"), extensible);
+
+        AIInputSanitized inputSanitized = mock(AIInputSanitized.class);
+        when(inputSanitized.value()).thenReturn(new AIInputSanitized.SanitizerType[]{AIInputSanitized.SanitizerType.SQL_INJECTION});
+        wire(re, AIInputSanitized.class, namedElement("com.example.InputSanitized"), inputSanitized);
+
+        AISecureLogging secureLogging = mock(AISecureLogging.class);
+        when(secureLogging.value()).thenReturn(AISecureLogging.MaskingPolicy.HASH);
+        wire(re, AISecureLogging.class, namedElement("com.example.SecureLogging"), secureLogging);
+
+        AIExplain explain = mock(AIExplain.class);
+        when(explain.value()).thenReturn(AIExplain.ComplexityLevel.HIGH);
+        wire(re, AIExplain.class, namedElement("com.example.Explain"), explain);
+
+        AIPrototype prototype = mock(AIPrototype.class);
+        wire(re, AIPrototype.class, namedElement("com.example.Prototype"), prototype);
+
+        AISunset sunset = mock(AISunset.class);
+        when(sunset.jira()).thenReturn("DEBT-742");
+        doReturn(Object.class).when(sunset).replacement();
+        wire(re, AISunset.class, namedElement("com.example.Sunset"), sunset);
+
+        AITemporary temporary = mock(AITemporary.class);
+        when(temporary.expiresOn()).thenReturn("2028-12-31");
+        when(temporary.reason()).thenReturn("upstream hotfix");
+        wire(re, AITemporary.class, namedElement("com.example.Temporary"), temporary);
+
+        collector.collect(re);
+        return collector;
+    }
+
+    /** Maps each annotation's collector bucket name (for failure messages) to its INTERPRETER-platform tag. */
+    private static Map<String, String> tagsByType() {
+        Map<String, String> tags = new LinkedHashMap<>();
+        tags.put("locked", "(locked): ");
+        tags.put("context", "(context): ");
+        tags.put("ignore", "(excluded): ");
+        tags.put("audit", "(audit): ");
+        tags.put("draft", "(draft): ");
+        tags.put("privacy", "(privacy): ");
+        tags.put("core", "(core, sensitivity: ");
+        tags.put("performance", "(performance): ");
+        tags.put("contract", "(contract): ");
+        tags.put("testDriven", "(test-driven): ");
+        tags.put("threadSafe", "(thread-safe): ");
+        tags.put("immutable", "(immutable)");
+        tags.put("deprecated", "(deprecated): ");
+        tags.put("observability", "(observability): ");
+        tags.put("regulation", "(regulation): ");
+        tags.put("parallelTests", "(test-isolation): ");
+        tags.put("legacyBridge", "(legacy-bridge): ");
+        tags.put("architecture", "(architecture): ");
+        tags.put("publicApi", "(public-api): ");
+        tags.put("strictExceptions", "(strict-exceptions): ");
+        tags.put("strictTypes", "(strict-types): ");
+        tags.put("internationalized", "(i18n): ");
+        tags.put("strictClasspath", "(strict-classpath): ");
+        tags.put("schemaSafe", "(schema-safe): ");
+        tags.put("idempotent", "(idempotent): ");
+        tags.put("featureFlag", "(feature-flag): ");
+        tags.put("secure", "(security-critical): ");
+        tags.put("callersOnly", "(callers limited): ");
+        tags.put("sandboxOnly", "(sandbox-only): ");
+        tags.put("memoryBudget", "(memory-budget): ");
+        tags.put("pure", "(pure): ");
+        tags.put("domainModel", "(domain model): ");
+        tags.put("extensible", "(extensible): ");
+        tags.put("inputSanitized", "(sanitized): ");
+        tags.put("secureLogging", "(secure-logging): ");
+        tags.put("explain", "(explain): ");
+        tags.put("prototype", "(prototype): ");
+        tags.put("sunset", "(sunset): ");
+        tags.put("temporary", "(temporary): ");
+        return tags;
+    }
+
+    @Test
+    void build_everyAnnotationType_producesItsDistinctiveTag() {
+        AnnotationCollector collector = buildFullCollector();
+
+        String output = GuardrailInstructionBlock.build(collector);
+
+        for (Map.Entry<String, String> entry : tagsByType().entrySet()) {
+            assertTrue(output.contains(entry.getValue()),
+                "GuardrailInstructionBlock.build() output must contain the '" + entry.getKey()
+                    + "' formatter's tag '" + entry.getValue() + "' — missing means "
+                    + "FormatterRegistry." + entry.getKey() + "().format(...) was never invoked");
+        }
+    }
+
+    @Test
+    void lines_everyAnnotationType_isNonBlankAndTagged() {
+        AnnotationCollector collector = buildFullCollector();
+
+        var lines = GuardrailInstructionBlock.lines(collector);
+
+        assertTrue(lines.size() >= tagsByType().size(),
+            "lines() must return at least one line per annotation type (" + tagsByType().size()
+                + " expected, got " + lines.size() + ")");
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #275 (PIT badge + threads). Analyzed the last mutation report (`mutations.xml`, 1928 mutants, 56% killed) to find where PIT coverage could actually be improved, not just made faster.

One dominant root cause explained the majority of the 803 survived mutants: several classes contain "one call/branch per annotation type" dispatch code across the 39 `@AI*` annotations, but the test suite grew incrementally as annotations were added across releases — so only a subset of types gets exercised through each shared dispatch point. A "middle batch" of ~13-18 types added in v0.9.x falls through the cracks in each affected test file, and PIT can delete the call or flip the branch for any of those types with nothing noticing. This explains the two largest mutator categories: `VoidMethodCallMutator` (373 survivors) and `NegateConditionalsMutator` (213 survivors) — 73% of all survivors combined.

(Also checked: PIT is already on the latest release, `1.25.7`, per Maven Central's `maven-metadata.xml` — no version bump needed.)

## Changes — test-only, no production code touched

- **New `GuardrailInstructionBlockTest.java`** (package-private test, same-package as its target per the existing `EscapeTest.java` precedent) — targets the single worst offender: `GuardrailInstructionBlock.build()` had 46/47 mutants survive (97.9%). Every one of its 39 `FormatterRegistry.X().format(...)` calls could be deleted individually undetected. One comprehensive fixture test now asserts each type's distinctive tag is present.
- **`BuildFingerprintUnitTest`** — extends the existing per-type "does this bucket affect the fingerprint" test pattern to the 13 buckets it never covered.
- **`AnnotationCollectorUnitTest`** — extends the existing `collect_onlyXAnnotation_returnsTrue()` pattern to the 18 types it never covered.
- **`GuardrailContentBuilderUnitTest`** — extends its `buildAllAnnotationTypes()` helper from 15/39 to a true all-39 fixture, then adds two new tests asserting every type's distinctive marker (XML tag for `ClaudeRenderer`, markdown heading for `LlmsRenderer`) reaches each renderer's output — neither renderer uses the declarative `AnnotationSections` mechanism `CursorRenderer` does, so nothing else verified them per-type.

## Test plan

- [x] `mvn test` — full suite green: 1115/1115 (up from 1092)
- [x] Sanity-checked the tests are load-bearing, not vacuous: temporarily commented out the `idempotent` bucket's `appendAnnotationSet` call in `BuildFingerprint.compute()` — the new test failed exactly as expected, then reverted (confirmed clean diff afterward)
- [ ] Re-run PIT in CI (with #275's `<threads>4</threads>`) to measure the actual mutation-score improvement against the 56% baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014o5qFzPMQYSg3bA6JHmst7