### PR TITLE
fix(writer): make file regeneration idempotent across line endings (#282)

### DIFF
--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailFileWriter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailFileWriter.java
@@ -131,8 +131,6 @@ public final class GuardrailFileWriter {
             }
             byte[] contentBytes = content.getBytes(StandardCharsets.UTF_8);
             int contentByteLen = contentBytes.length;
-            boolean nonMarkerSizeMismatch = !supportsMarkers && fileExists
-                && Math.abs(existingSize - contentByteLen) > 64;
 
             // Phase-2 streaming fast path: for non-marker files where the on-disk size matches
             // the new content size exactly, stream-compare bytes with early-exit on first
@@ -155,14 +153,18 @@ public final class GuardrailFileWriter {
                 return true;
             }
 
-            String existing = (fileExists && !nonMarkerSizeMismatch)
+            // Read the existing file whenever it exists so the compare-before-write below can treat
+            // a line-ending-only difference (LF vs CRLF, e.g. a git core.autocrlf checkout on
+            // Windows) as a no-op instead of rewriting the file — see issue #282. The common
+            // unchanged case is already handled allocation-free by the exact-size byte fast path above.
+            String existing = fileExists
                 ? Files.readString(filePath, StandardCharsets.UTF_8)
                 : "";
 
             if (supportsMarkers) {
                 return writeWithMarkers(filePath, fileName, path, content, existing, hasNewRules, markers);
             }
-            return writeWithoutMarkers(filePath, fileName, content, existing, fileExists, existingSize, nonMarkerSizeMismatch, hasNewRules);
+            return writeWithoutMarkers(filePath, fileName, content, existing, fileExists, existingSize, hasNewRules);
         } catch (IOException e) {
             messager.printMessage(Diagnostic.Kind.WARNING,
                 "VibeTags: Failed to write AI rules file: " + path + " - " + e.getMessage());
@@ -208,7 +210,7 @@ public final class GuardrailFileWriter {
                     "VibeTags: malformed markers in " + path + " (no end marker). Preserving content before start marker.");
                 String before = stripLegacyVibeTagsBlock(existing.substring(0, start).stripTrailing());
                 String finalContent = (!before.isEmpty() ? before + "\n\n" : "") + wrappedBody + "\n";
-                if (existing.strip().equals(finalContent.strip())) return false;
+                if (contentMatches(existing, finalContent)) return false;
                 writeAndCache(filePath, finalContent, content);
                 return true;
             }
@@ -222,7 +224,7 @@ public final class GuardrailFileWriter {
             if (!after.isEmpty()) sb.append("\n\n").append(after);
             String finalContent = sb.toString().trim() + "\n";
 
-            if (existing.strip().equals(finalContent.strip())) return false;
+            if (contentMatches(existing, finalContent)) return false;
 
             if (!hasNewRules && !existing.isEmpty()) {
                 skipUpdateMsg(fileName);
@@ -235,7 +237,7 @@ public final class GuardrailFileWriter {
         } else if (!existing.isEmpty() && existing.contains(generatedHeaderTrim)) {
             // Legacy file (no markers but has VibeTags header): upgrade to markers
             String finalContent = (frontMatter.isEmpty() ? "" : frontMatter + "\n\n") + wrappedBody + "\n";
-            if (existing.strip().equals(finalContent.strip())) return false;
+            if (contentMatches(existing, finalContent)) return false;
 
             if (!hasNewRules) {
                 skipUpdateMsg(fileName);
@@ -250,7 +252,7 @@ public final class GuardrailFileWriter {
             String updated = existing.isEmpty()
                 ? (frontMatter.isEmpty() ? "" : frontMatter + "\n\n") + wrappedBody + "\n"
                 : existing.stripTrailing() + "\n\n" + wrappedBody + "\n";
-            if (existing.strip().equals(updated.strip())) return false;
+            if (contentMatches(existing, updated)) return false;
 
             if (!hasNewRules && !existing.isEmpty()) {
                 skipUpdateMsg(fileName);
@@ -265,9 +267,9 @@ public final class GuardrailFileWriter {
     }
 
     private boolean writeWithoutMarkers(Path filePath, String fileName, String content, String existing,
-                                        boolean fileExists, long existingSize, boolean nonMarkerSizeMismatch,
+                                        boolean fileExists, long existingSize,
                                         boolean hasNewRules) throws IOException {
-        if (!nonMarkerSizeMismatch && existing.strip().equals(content.strip())) return false;
+        if (contentMatches(existing, content)) return false;
 
         if (!hasNewRules && fileExists && existingSize > 0) {
             skipUpdateMsg(fileName);
@@ -277,6 +279,26 @@ public final class GuardrailFileWriter {
         writeAndCache(filePath, content, content);
         messager.printMessage(Diagnostic.Kind.NOTE, "VibeTags: Updated " + fileName);
         return true;
+    }
+
+    /**
+     * Compares two rendered documents for equality, ignoring line-ending differences
+     * (CRLF or lone CR vs LF) in addition to outer whitespace.
+     *
+     * <p>VibeTags always emits LF. A file that git checked out with CRLF (the default
+     * {@code core.autocrlf} on Windows) is byte-different from the freshly rendered LF body yet
+     * semantically identical — rewriting it would flip CRLF→LF and dirty the working tree with
+     * line-ending-only churn on every build. Treating that as unchanged makes regeneration a true
+     * no-op. See issue #282.
+     */
+    static boolean contentMatches(String a, String b) {
+        return normaliseLineEndings(a).strip().equals(normaliseLineEndings(b).strip());
+    }
+
+    /** Collapses CRLF and lone CR to LF. Returns the argument unchanged when it contains no CR. */
+    private static String normaliseLineEndings(String s) {
+        if (s.indexOf('\r') < 0) return s;
+        return s.replace("\r\n", "\n").replace('\r', '\n');
     }
 
     /**

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/CrlfLineEndingIdempotenceTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/CrlfLineEndingIdempotenceTest.java
@@ -1,0 +1,93 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import se.deversity.vibetags.processor.internal.GuardrailFileWriter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for issue #282: a regenerated file whose only difference from disk is line
+ * endings (LF vs CRLF, e.g. after a git {@code core.autocrlf} checkout on Windows) must be a true
+ * no-op — no rewrite, no CRLF→LF flip, no dirtied working tree.
+ *
+ * <p>VibeTags always emits LF, so the fix lives in the compare-before-write step: it normalises
+ * line endings before deciding whether the content changed. When the on-disk file is byte-different
+ * only because of CRLF, the writer leaves it untouched.
+ */
+class CrlfLineEndingIdempotenceTest {
+
+    private static GuardrailFileWriter writer() {
+        return new GuardrailFileWriter("# VibeTags\n", null, null, null);
+    }
+
+    /**
+     * Marker file (CLAUDE.md) whose managed block is on disk with CRLF endings. The freshly
+     * rendered LF body is identical modulo line endings → no write, and the file keeps its CRLF
+     * bytes (proving it was not rewritten to LF).
+     */
+    @Test
+    void markerFileWithCrlf_identicalModuloEol_isNotRewritten(@TempDir Path tmp) throws IOException {
+        Path file = tmp.resolve("CLAUDE.md");
+        String crlf = "<!-- VIBETAGS-START -->\r\nsome generated rules\r\n<!-- VIBETAGS-END -->\r\n";
+        Files.writeString(file, crlf, StandardCharsets.UTF_8);
+        byte[] before = Files.readAllBytes(file);
+
+        // The body the processor would render this round (LF, unwrapped) — the writer wraps it.
+        boolean changed = writer().writeFileIfChanged(file.toString(), "some generated rules", true);
+
+        assertFalse(changed, "CRLF-vs-LF-only difference must not count as a change");
+        byte[] after = Files.readAllBytes(file);
+        assertArrayEquals(before, after, "file must be left byte-for-byte untouched");
+        assertTrue(new String(after, StandardCharsets.UTF_8).contains("\r\n"),
+            "CRLF endings must be preserved, not flipped to LF");
+    }
+
+    /**
+     * Non-marker file (JSON, full overwrite) with many CRLF lines so the on-disk byte size differs
+     * from the LF render by far more than the old 64-byte size-mismatch tolerance. Must still be
+     * recognised as unchanged and left alone.
+     */
+    @Test
+    void nonMarkerJsonWithCrlf_largeFile_identicalModuloEol_isNotRewritten(@TempDir Path tmp) throws IOException {
+        Path file = tmp.resolve("config.json");
+        StringBuilder body = new StringBuilder("{\n");
+        for (int i = 0; i < 100; i++) {
+            body.append("  \"key").append(i).append("\": ").append(i).append(",\n");
+        }
+        body.append("  \"last\": true\n}\n");
+        String lf = body.toString();
+        String crlf = lf.replace("\n", "\r\n");
+
+        Files.writeString(file, crlf, StandardCharsets.UTF_8);
+        byte[] before = Files.readAllBytes(file);
+        assertTrue(before.length - lf.getBytes(StandardCharsets.UTF_8).length > 64,
+            "sanity: CRLF size must exceed LF size by more than the old 64-byte tolerance");
+
+        boolean changed = writer().writeFileIfChanged(file.toString(), lf, true);
+
+        assertFalse(changed, "line-ending-only difference in a large non-marker file must be a no-op");
+        assertArrayEquals(before, Files.readAllBytes(file), "file must be left byte-for-byte untouched");
+    }
+
+    /**
+     * Guard against over-normalisation: a genuine content change (beyond line endings) must still
+     * be written, even when the existing file uses CRLF.
+     */
+    @Test
+    void markerFileWithCrlf_realContentChange_isRewritten(@TempDir Path tmp) throws IOException {
+        Path file = tmp.resolve("CLAUDE.md");
+        Files.writeString(file, "<!-- VIBETAGS-START -->\r\nold rules\r\n<!-- VIBETAGS-END -->\r\n",
+            StandardCharsets.UTF_8);
+
+        boolean changed = writer().writeFileIfChanged(file.toString(), "brand new rules", true);
+
+        assertTrue(changed, "a real content change must be written despite CRLF on disk");
+        assertTrue(Files.readString(file, StandardCharsets.UTF_8).contains("brand new rules"));
+    }
+}


### PR DESCRIPTION
Fixes #282.

## Problem

On Windows with git's default `core.autocrlf`, every build left a spurious `M CLAUDE.md` (and any other regenerated file) in `git status` **with an empty content diff** — only line-ending churn (LF ↔ CRLF).

VibeTags already renders LF everywhere, but the compare-before-write step used `existing.strip().equals(candidate.strip())`, which normalises only *outer* whitespace. A file git checked out with CRLF is byte-different from the LF render, so it never compared equal → the writer rewrote it → CRLF flipped to LF → dirty working tree, on every build.

## Fix (issue's option 2: idempotent compare-before-write)

`GuardrailFileWriter` now compares content ignoring line-ending differences, so regeneration is a true no-op when only EOLs differ:

- **`contentMatches` / `normaliseLineEndings`** — collapse CRLF and lone CR to LF before comparing; early-return when there is no `\r`, so LF-only strings (the common case) allocate nothing.
- All **5** compare-before-write sites routed through it (4 in `writeWithMarkers`, 1 in `writeWithoutMarkers`).
- **Non-marker files (JSON/TOML) fixed too.** The old `nonMarkerSizeMismatch > 64` heuristic skipped reading the existing file when sizes differed — but CRLF inflates size by one byte per line, force-rewriting any file over 64 lines. The existing file is now always read when present (the allocation-free exact-size byte fast path still short-circuits the common unchanged case first); the dead heuristic is removed.

No documented hot path (`BuildFingerprint.fingerprint`, `WriteCache.isUnchanged`) is touched, and `writeFileIfChanged`'s public contract signature is unchanged.

## Testing

- New `CrlfLineEndingIdempotenceTest` (3 tests): CRLF marker file identical-modulo-EOL → not rewritten (bytes preserved, CRLF not flipped to LF); large (>64-line) CRLF JSON → not rewritten; genuine content change → still written (guards against over-normalisation).
- Full `vibetags` suite: **1149 tests, 0 failures/errors**.
- Checkstyle: **0 violations**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)