### PR TITLE
fix(content): coalesce identical @AITestDriven stanzas in CLAUDE.md (…

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -324,6 +324,17 @@ for (Element element : roundEnv.getElementsAnnotatedWith(AIPrivacy.class)) {
 <rule>Never propose edits to locked files.</rule>
 ```
 
+**Stanza coalescing (`ClaudeTestDrivenSection`).** To keep the file's signal-to-noise
+ratio high (issue #283), the `<test_driven_requirements>` section collapses two or more
+`@AITestDriven` elements that share identical guardrail values into a single
+`<test_driven_default coverage_goal="…" frameworks="…" [test_location="…"] [mock_policy="…"]>`
+block with an `<applies-to>` member list, instead of repeating a full `<element>` stanza
+per class. A mirror-convention `testLocation` (`src/test/java/<pkg>/<Class>Test.java` on a
+TYPE) is rendered as the `test_location="src/test/java/{path}Test.java"` template; empty
+locations omit the attribute. Elements whose values diverge — or any set smaller than the
+threshold — keep their individual stanza. Grouping follows the collector's insertion order,
+so the output stays deterministic (byte-stable) for the fingerprint short-circuit.
+
 **Cursor (.cursorrules)** - Markdown with Emoji:
 ```markdown
 # AUTO-GENERATED AI RULES

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Generated `CLAUDE.md` coalesces repeated identical `@AITestDriven` stanzas.**
+  ([#283](https://github.com/PIsberg/vibetags/issues/283)) When two or more `@AITestDriven`
+  elements share the same guardrail values, the `<test_driven_requirements>` section now emits a
+  single `<test_driven_default …>` block plus an `<applies-to>` member list instead of one full
+  `<element>` stanza per class. Mirror-convention test locations render as a
+  `test_location="src/test/java/{path}Test.java"` template; elements whose values diverge keep
+  their individual stanza. Same guardrail semantics, far fewer tokens spent on boilerplate — so
+  the high-value guardrails aren't diluted in the AI's context window.
+
 ## [1.0.0-RC4] - 2026-07-18
 
 ### Fixed

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/platforms/ClaudeRenderer.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/platforms/ClaudeRenderer.java
@@ -97,12 +97,10 @@ public final class ClaudeRenderer implements PlatformRenderer {
 
         if (!collector.testDriven().isEmpty()) {
             StringBuilder sec = new StringBuilder("  <test_driven_requirements>\n");
-            for (Element e : collector.testDriven()) {
-                FormatterRegistry.testDriven().format(e, sec, Platform.CLAUDE);
-            }
+            ClaudeTestDrivenSection.render(collector.testDriven(), sec);
             sec.append("  </test_driven_requirements>\n");
             sb.append(sec);
-            sb.append("\n<rule>For any element listed in <test_driven_requirements>, you MUST provide both the implementation change AND the corresponding test code update in a single response. Changes without tests are incomplete and must not be proposed.</rule>\n");
+            sb.append("\n<rule>For any element listed in <test_driven_requirements>, you MUST provide both the implementation change AND the corresponding test code update in a single response. Changes without tests are incomplete and must not be proposed. Every name under <applies-to> in a <test_driven_default> block inherits that block's coverage goal, frameworks, and test-location convention (with {path} standing for the element's package path).</rule>\n");
         }
 
         if (!collector.threadSafe().isEmpty()) {

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/platforms/ClaudeTestDrivenSection.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/platforms/ClaudeTestDrivenSection.java
@@ -1,0 +1,155 @@
+package se.deversity.vibetags.processor.internal.content.platforms;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import se.deversity.vibetags.annotations.AITestDriven;
+import se.deversity.vibetags.processor.internal.ElementNaming;
+import se.deversity.vibetags.processor.internal.content.Escape;
+import se.deversity.vibetags.processor.internal.content.FormatterRegistry;
+import se.deversity.vibetags.processor.internal.content.Platform;
+
+/**
+ * Renders the body of the {@code CLAUDE.md} {@code <test_driven_requirements>} section,
+ * coalescing {@code @AITestDriven} elements that share identical guardrail values into a
+ * single {@code <test_driven_default>} block plus an {@code <applies-to>} member list
+ * (issue #283). Elements whose values diverge — or a set too small to benefit — keep their
+ * per-element {@code <element>} stanza, rendered by {@link AITestDrivenFormatter} exactly as
+ * before.
+ *
+ * <p>The section wrapper tags and the trailing {@code <rule>} stay in {@link ClaudeRenderer};
+ * this class only produces the inner body. Grouping and member order follow the collector's
+ * insertion order, so the output is deterministic across recompiles.
+ */
+final class ClaudeTestDrivenSection {
+
+    /** Placeholder for the Maven mirror-convention test path, expanded per member by the reader. */
+    private static final String TEMPLATE_LOCATION = "src/test/java/{path}Test.java";
+
+    /** Minimum members before a group collapses into a {@code <test_driven_default>} block. */
+    private static final int MIN_COALESCE = 2;
+
+    private ClaudeTestDrivenSection() {
+    }
+
+    /** How a group's {@code testLocation} is represented in the coalesced default block. */
+    private enum LocationKind { EMPTY, TEMPLATE, LITERAL }
+
+    /** The value tuple that makes two {@code @AITestDriven} stanzas identical for CLAUDE output. */
+    private record Signature(int coverageGoal, String frameworks, String mockPolicy,
+                             LocationKind locationKind, String locationLiteral) {
+    }
+
+    /**
+     * Appends the section body — the coalesced default block (when a group of {@value #MIN_COALESCE}+
+     * value-identical elements exists) followed by individual stanzas for every remaining element —
+     * to {@code sb}.
+     *
+     * @param elements the {@code @AITestDriven} elements, in collector insertion order
+     * @param sb       the destination buffer
+     */
+    static void render(Collection<Element> elements, StringBuilder sb) {
+        Map<Signature, List<Element>> groups = new LinkedHashMap<>();
+        for (Element e : elements) {
+            AITestDriven td = e.getAnnotation(AITestDriven.class);
+            if (td == null) {
+                continue;
+            }
+            groups.computeIfAbsent(signature(e, td), k -> new ArrayList<>()).add(e);
+        }
+
+        // Largest group becomes the default; ties resolve to the first-seen group (LinkedHashMap
+        // iteration order) via the strict > comparison, keeping the choice deterministic.
+        Signature defaultSig = null;
+        int best = 0;
+        for (Map.Entry<Signature, List<Element>> entry : groups.entrySet()) {
+            if (entry.getValue().size() > best) {
+                best = entry.getValue().size();
+                defaultSig = entry.getKey();
+            }
+        }
+
+        boolean coalesce = best >= MIN_COALESCE;
+        if (coalesce) {
+            appendDefaultBlock(defaultSig, groups.get(defaultSig), sb);
+        }
+
+        for (Element e : elements) {
+            AITestDriven td = e.getAnnotation(AITestDriven.class);
+            if (td == null) {
+                continue;
+            }
+            if (coalesce && signature(e, td).equals(defaultSig)) {
+                continue;
+            }
+            FormatterRegistry.testDriven().format(e, sb, Platform.CLAUDE);
+        }
+    }
+
+    private static void appendDefaultBlock(Signature sig, List<Element> members, StringBuilder sb) {
+        sb.append("    <test_driven_default coverage_goal=\"").append(sig.coverageGoal())
+          .append("\" frameworks=\"").append(Escape.xml(sig.frameworks())).append('"');
+
+        if (sig.locationKind() == LocationKind.TEMPLATE) {
+            sb.append(" test_location=\"").append(TEMPLATE_LOCATION).append('"');
+        } else if (sig.locationKind() == LocationKind.LITERAL) {
+            sb.append(" test_location=\"").append(Escape.xml(sig.locationLiteral())).append('"');
+        }
+        if (!sig.mockPolicy().isEmpty()) {
+            sb.append(" mock_policy=\"").append(Escape.xml(sig.mockPolicy())).append('"');
+        }
+        sb.append(">\n");
+
+        sb.append("      <applies-to>\n");
+        for (int i = 0; i < members.size(); i++) {
+            sb.append("        ").append(Escape.xml(ElementNaming.elementPath(members.get(i))));
+            if (i < members.size() - 1) {
+                sb.append(',');
+            }
+            sb.append('\n');
+        }
+        sb.append("      </applies-to>\n");
+        sb.append("    </test_driven_default>\n");
+    }
+
+    private static Signature signature(Element e, AITestDriven td) {
+        String loc = td.testLocation();
+        LocationKind kind;
+        String literal = "";
+        if (loc.isEmpty()) {
+            kind = LocationKind.EMPTY;
+        } else if (isConventionPath(e, loc)) {
+            kind = LocationKind.TEMPLATE;
+        } else {
+            kind = LocationKind.LITERAL;
+            literal = loc;
+        }
+        return new Signature(td.coverageGoal(), frameworks(td), td.mockPolicy(), kind, literal);
+    }
+
+    /** Frameworks joined with {@code ", "}, matching {@link AITestDrivenFormatter}. */
+    private static String frameworks(AITestDriven td) {
+        StringBuilder f = new StringBuilder();
+        for (AITestDriven.Framework fw : td.framework()) {
+            if (f.length() > 0) {
+                f.append(", ");
+            }
+            f.append(fw.name());
+        }
+        return f.toString();
+    }
+
+    /** True when {@code loc} is the Maven mirror-convention test path for a TYPE element. */
+    private static boolean isConventionPath(Element e, String loc) {
+        ElementKind kind = e.getKind();
+        if (!kind.isClass() && !kind.isInterface()) {
+            return false;
+        }
+        String fqnPath = ElementNaming.elementPath(e).replace('.', '/');
+        return loc.equals("src/test/java/" + fqnPath + "Test.java");
+    }
+}

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/AITestDrivenProcessorTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/AITestDrivenProcessorTest.java
@@ -11,6 +11,7 @@ import javax.lang.model.element.Name;
 import javax.tools.Diagnostic;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -541,6 +542,43 @@ class AITestDrivenProcessorTest {
             String content = processor.contentFor(".cursorrules");
             assertTrue(content.contains("com.example.OrderService.calculateDiscount"), "Must list first element");
             assertTrue(content.contains("com.example.BillingService.invoice"), "Must list second element");
+        });
+    }
+
+    @Test
+    void process_multipleIdenticalTestDrivenElements_coalescedInClaudeMd() throws Exception {
+        withCwdSignalFiles(List.of("CLAUDE.md"), () -> {
+            Element el1 = testDrivenElement("com.example.diag.AlphaDetector", 80, "");
+            Element el2 = testDrivenElement("com.example.diag.BetaDetector", 80, "");
+            Element el3 = testDrivenElement("com.example.diag.GammaDetector", 80, "");
+
+            RoundEnvironment roundEnv = mock(RoundEnvironment.class);
+            when(roundEnv.processingOver()).thenReturn(false);
+            doReturn(new LinkedHashSet<>(List.of(el1, el2, el3)))
+                .when(roundEnv).getElementsAnnotatedWith(AITestDriven.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AILocked.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIContext.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIIgnore.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIAudit.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIDraft.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIPrivacy.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AICore.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIPerformance.class);
+            doReturn(Set.of()).when(roundEnv).getElementsAnnotatedWith(AIContract.class);
+
+            CapturingProcessor processor = makeCapturingProcessor();
+            processor.process(Set.of(), roundEnv);
+            triggerGeneration(processor);
+
+            String content = processor.contentFor("CLAUDE.md");
+            assertTrue(content.contains("<test_driven_default coverage_goal=\"80\" frameworks=\"JUNIT_5\">"),
+                "identical elements collapse into a single <test_driven_default> block");
+            assertTrue(content.contains("com.example.diag.AlphaDetector")
+                    && content.contains("com.example.diag.BetaDetector")
+                    && content.contains("com.example.diag.GammaDetector"),
+                "every element is named under <applies-to>");
+            assertFalse(content.contains("<coverage_goal>"),
+                "coalesced members must not each repeat the per-element coverage_goal stanza");
         });
     }
 

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/internal/content/platforms/ClaudeTestDrivenSectionTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/internal/content/platforms/ClaudeTestDrivenSectionTest.java
@@ -1,0 +1,194 @@
+package se.deversity.vibetags.processor.internal.content.platforms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Name;
+import org.junit.jupiter.api.Test;
+import se.deversity.vibetags.annotations.AITestDriven;
+
+/**
+ * Unit tests for {@link ClaudeTestDrivenSection} — the CLAUDE.md coalescing of homogeneous
+ * {@code @AITestDriven} elements into a {@code <test_driven_default>} block plus an
+ * {@code <applies-to>} member list (issue #283).
+ */
+class ClaudeTestDrivenSectionTest {
+
+    private static String render(List<Element> elements) {
+        StringBuilder sb = new StringBuilder();
+        ClaudeTestDrivenSection.render(elements, sb);
+        return sb.toString();
+    }
+
+    private static String conventionPath(String fqn) {
+        return "src/test/java/" + fqn.replace('.', '/') + "Test.java";
+    }
+
+    private static Element td(String fqn, ElementKind kind, int coverage, String mockPolicy,
+                              String testLocation, AITestDriven.Framework... frameworks) {
+        Element e = mock(Element.class);
+        when(e.toString()).thenReturn(fqn);
+        when(e.getKind()).thenReturn(kind);
+        Name simpleName = mock(Name.class);
+        when(simpleName.toString()).thenReturn(fqn.substring(fqn.lastIndexOf('.') + 1));
+        when(e.getSimpleName()).thenReturn(simpleName);
+
+        AITestDriven a = mock(AITestDriven.class);
+        when(a.coverageGoal()).thenReturn(coverage);
+        when(a.mockPolicy()).thenReturn(mockPolicy);
+        when(a.testLocation()).thenReturn(testLocation);
+        AITestDriven.Framework[] fw = frameworks.length == 0
+            ? new AITestDriven.Framework[]{AITestDriven.Framework.JUNIT_5}
+            : frameworks;
+        doReturn(fw).when(a).framework();
+        when(e.getAnnotation(AITestDriven.class)).thenReturn(a);
+        return e;
+    }
+
+    /** Convenience: a TYPE element with the default JUnit-5 framework and no explicit location. */
+    private static Element type(String fqn, int coverage) {
+        return td(fqn, ElementKind.CLASS, coverage, "", "");
+    }
+
+    @Test
+    void identicalEmptyLocations_collapseIntoOneDefaultBlock() {
+        String out = render(List.of(
+            type("com.example.A", 80),
+            type("com.example.B", 80),
+            type("com.example.C", 80)));
+
+        assertTrue(out.contains("<test_driven_default coverage_goal=\"80\" frameworks=\"JUNIT_5\">"),
+            "the shared values render as a single default block");
+        // No per-member stanza — the child-tag form appears only in individual <element> stanzas.
+        assertFalse(out.contains("<coverage_goal>"), "coalesced members must not repeat child stanzas");
+        assertFalse(out.contains("<element path="), "coalesced members must not emit individual stanzas");
+        assertTrue(out.contains("<applies-to>"), "members are listed under applies-to");
+        assertTrue(out.contains("com.example.A") && out.contains("com.example.B") && out.contains("com.example.C"),
+            "every member is named in applies-to");
+        // Empty locations mean the attribute is omitted (the AI infers the path).
+        assertFalse(out.contains("test_location="), "empty locations omit the test_location attribute");
+    }
+
+    @Test
+    void conventionLocations_renderAsPathTemplate() {
+        String fqnA = "com.example.diag.AlphaDetector";
+        String fqnB = "com.example.diag.BetaDetector";
+        String out = render(List.of(
+            td(fqnA, ElementKind.CLASS, 80, "", conventionPath(fqnA)),
+            td(fqnB, ElementKind.CLASS, 80, "", conventionPath(fqnB))));
+
+        assertTrue(out.contains("test_location=\"src/test/java/{path}Test.java\""),
+            "mirror-convention locations collapse to the {path} template");
+        assertTrue(out.contains(fqnA) && out.contains(fqnB), "both members listed");
+    }
+
+    @Test
+    void mockPolicy_appearsAsAttributeWhenShared() {
+        String out = render(List.of(
+            td("com.example.A", ElementKind.CLASS, 90, "Mock Stripe", ""),
+            td("com.example.B", ElementKind.CLASS, 90, "Mock Stripe", "")));
+
+        assertTrue(out.contains("mock_policy=\"Mock Stripe\""), "shared mock policy renders as an attribute");
+    }
+
+    @Test
+    void divergentElement_keepsIndividualStanza() {
+        String out = render(List.of(
+            type("com.example.A", 80),
+            type("com.example.B", 80),
+            type("com.example.Outlier", 95)));
+
+        assertTrue(out.contains("<test_driven_default coverage_goal=\"80\" frameworks=\"JUNIT_5\">"),
+            "the majority collapses into the default block");
+        assertTrue(out.contains("<element path=\"com.example.Outlier\">"),
+            "the divergent element keeps its own stanza");
+        assertTrue(out.contains("<coverage_goal>95</coverage_goal>"),
+            "the divergent element renders its own values");
+    }
+
+    @Test
+    void bespokeLocation_isNotFoldedIntoTemplate() {
+        String fqnA = "com.example.diag.AlphaDetector";
+        String fqnB = "com.example.diag.BetaDetector";
+        String out = render(List.of(
+            td(fqnA, ElementKind.CLASS, 80, "", conventionPath(fqnA)),
+            td(fqnB, ElementKind.CLASS, 80, "", conventionPath(fqnB)),
+            td("com.example.Custom", ElementKind.CLASS, 80, "", "it/custom/CustomIT.java")));
+
+        assertTrue(out.contains("test_location=\"src/test/java/{path}Test.java\""),
+            "convention members still template");
+        assertTrue(out.contains("<element path=\"com.example.Custom\">"),
+            "the bespoke-location element stays individual");
+        assertTrue(out.contains("<test_location>it/custom/CustomIT.java</test_location>"),
+            "the bespoke location is rendered verbatim in its own stanza");
+    }
+
+    @Test
+    void singleElement_belowThreshold_staysIndividual() {
+        String out = render(List.of(type("com.example.Solo", 100)));
+
+        assertFalse(out.contains("<test_driven_default"), "a lone element is not coalesced");
+        assertTrue(out.contains("<element path=\"com.example.Solo\">"), "it renders as an individual stanza");
+        assertTrue(out.contains("<coverage_goal>100</coverage_goal>"), "with its own values");
+    }
+
+    @Test
+    void allDistinctValues_noCoalescing() {
+        String out = render(List.of(
+            type("com.example.A", 70),
+            type("com.example.B", 80),
+            type("com.example.C", 90)));
+
+        assertFalse(out.contains("<test_driven_default"), "no group reaches the coalesce threshold");
+        assertTrue(out.contains("<element path=\"com.example.A\">")
+            && out.contains("<element path=\"com.example.B\">")
+            && out.contains("<element path=\"com.example.C\">"),
+            "each element renders individually");
+    }
+
+    @Test
+    void tiedGroups_firstSeenBecomesDefault() {
+        // Two groups of two; group with coverage 80 is inserted first and wins the default slot.
+        String out = render(List.of(
+            type("com.example.A", 80),
+            type("com.example.B", 80),
+            type("com.example.C", 95),
+            type("com.example.D", 95)));
+
+        assertTrue(out.contains("<test_driven_default coverage_goal=\"80\" frameworks=\"JUNIT_5\">"),
+            "the first-seen group becomes the default block");
+        assertTrue(out.contains("<element path=\"com.example.C\">")
+            && out.contains("<element path=\"com.example.D\">"),
+            "the runner-up group stays as individual stanzas");
+    }
+
+    @Test
+    void appliesToOrder_followsInsertionOrder() {
+        String out = render(List.of(
+            type("com.example.First", 80),
+            type("com.example.Second", 80),
+            type("com.example.Third", 80)));
+
+        int first = out.indexOf("com.example.First");
+        int second = out.indexOf("com.example.Second");
+        int third = out.indexOf("com.example.Third");
+        assertTrue(first < second && second < third, "applies-to preserves insertion order");
+    }
+
+    @Test
+    void render_isDeterministic() {
+        List<Element> elements = List.of(
+            type("com.example.A", 80),
+            type("com.example.B", 80),
+            type("com.example.Outlier", 95));
+
+        assertEquals(render(elements), render(elements), "same input yields identical output");
+    }
+}


### PR DESCRIPTION
…#283)

The generated <test_driven_requirements> section emitted one full <element> stanza per @AITestDriven element, so projects with many uniformly-annotated classes produced 100+ byte-identical stanzas (same coverage goal, framework, mirror-convention test path). That boilerplate diluted the high-value guardrails and wasted the AI agent's limited context budget.

When two or more elements share identical guardrail values, the section now emits a single <test_driven_default coverage_goal=... frameworks=... [test_location=...] [mock_policy=...]> block plus an <applies-to> member list. Mirror-convention test locations render as the test_location="src/test/java/{path}Test.java" template; empty locations omit the attribute. Elements whose values diverge — or any set below the threshold of two — keep their individual stanza, rendered by the existing AITestDrivenFormatter. Grouping follows the collector's insertion order, so output stays deterministic (byte-stable) for the fingerprint short-circuit.

Scope: CLAUDE.md only; other platforms already render one compact line per element. New ClaudeTestDrivenSection helper with 10 unit tests + one end-to-end test; ARCHITECTURE.md and CHANGELOG.md updated.