### PR TITLE
chore: prepare release v1.0.0-RC5

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary annotations, or wants to control how AI tools interact with Java code.
-version: 1.0.0-RC4
+version: 1.0.0-RC5
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.0-RC4</version>
+    <version>1.0.0-RC5</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.0-RC4'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC4'
+compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.0-RC5'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC5'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.0-RC4</version>
+            <version>1.0.0-RC5</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -72,7 +72,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.0-RC4</version>
+                        <version>1.0.0-RC5</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -113,8 +113,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC4')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC4')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC5')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC5')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -351,7 +351,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.0-RC4</version>
+            <version>1.0.0-RC5</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -376,7 +376,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.0-RC4</version>
+                        <version>1.0.0-RC5</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -390,8 +390,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC4')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC4')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC5')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC5')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -405,15 +405,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.0-RC4</version>
+    <version>1.0.0-RC5</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC4'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC4'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC5'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC5'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-RC5] - 2026-07-21
+
 ### Added
 - **Role/topic-based granular rules (`.vibetags-roles`).** By default VibeTags writes one scoped
   rule file per annotated class (FQN-named, single-class glob). Drop a `.vibetags-roles` config at
@@ -1014,7 +1016,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC4...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC5...HEAD
+[1.0.0-RC5]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC4...v1.0.0-RC5
 [1.0.0-RC4]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC3...v1.0.0-RC4
 [1.0.0-RC3]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC2...v1.0.0-RC3
 [1.0.0-RC2]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC1...v1.0.0-RC2

--- a/example-multimodule/pom.xml
+++ b/example-multimodule/pom.xml
@@ -27,7 +27,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.0.0-RC4</vibetags.bom.version>
+    <vibetags.bom.version>1.0.0-RC5</vibetags.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC4')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC4')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC5')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC5')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.0.0-RC4</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0-RC5</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
     </properties>
 

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.0.0-RC4</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0-RC5</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.0-RC4'
+version = '1.0.0-RC5'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.0.0-RC4'
+            version = '1.0.0-RC5'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.0-RC4</version>
+    <version>1.0.0-RC5</version>
     <packaging>jar</packaging>
 
     <name>VibeTags Annotations</name>
@@ -23,12 +23,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.0.0-RC4&lt;/version&gt;
+                &lt;version&gt;1.0.0-RC5&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC4'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC4'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC5'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC5'
     </description>
     <url>https://github.com/PIsberg/vibetags</url>
 

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-bom</artifactId>
-    <version>1.0.0-RC4</version>
+    <version>1.0.0-RC5</version>
     <packaging>pom</packaging>
 
     <name>VibeTags BOM</name>
@@ -25,7 +25,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.0.0-RC4&lt;/version&gt;
+                        &lt;version&gt;1.0.0-RC5&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -33,8 +33,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC4')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC4')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC5')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC5')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>
@@ -66,7 +66,7 @@
         <!-- Single source of truth for the VibeTags artifact set. Bump this when releasing
              a new processor version; all consumers that import this BOM track the bump
              without further changes. -->
-        <vibetags.version>1.0.0-RC4</vibetags.version>
+        <vibetags.version>1.0.0-RC5</vibetags.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.0-RC4'
+version = '1.0.0-RC5'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.0.0-RC4'
+            version = '1.0.0-RC5'
             from components.java
 
             pom {
@@ -77,7 +77,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC4'
+    api 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC5'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.0'

--- a/vibetags/pom.xml
+++ b/vibetags/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.0-RC4</version>
+    <version>1.0.0-RC5</version>
     <packaging>jar</packaging>
 
     <name>VibeTags Processor</name>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-annotations</artifactId>
-            <version>1.0.0-RC4</version>
+            <version>1.0.0-RC5</version>
         </dependency>
 
         <!-- JSpecify null annotations (@NullMarked, @Nullable, @NonNull).


### PR DESCRIPTION
Prepares the `v1.0.0-RC5` release: version bump across the core modules, BOM, and consumers, plus the CHANGELOG.

## Highlights (from CHANGELOG `[1.0.0-RC5]`)

### Added
- **Role/topic-based granular rules (`.vibetags-roles`).** Group annotated classes into a few human-named topic files (e.g. `api-endpoints.md` scoping `**/*Controller.java`) via a root/module `.vibetags-roles` config. First-match-wins; unmatched elements keep their per-class file (non-lossy). When absent, granular output is byte-for-byte unchanged.
- **Per-module (nested) output for multi-module reactor builds.** Opt into a guardrail file/granular dir *inside a module's own directory* and VibeTags writes that module's own guardrails there, scoped to its annotations, alongside the merged reactor-root file. Reactor-root files and the sidecar aggregation are unchanged and orthogonal.
- **Aggregate files collapse to a scoped-rules index when their granular sibling is also opted in.** Under dual opt-in the aggregate keeps only always-loaded safety guardrails inline and emits one pointer line per element to its scoped rule file. Opting into only the aggregate (the common case) is byte-for-byte unchanged.

### Changed
- **Generated `CLAUDE.md` coalesces repeated identical `@AITestDriven` stanzas** (#283) into a single `<test_driven_default>` block plus an `<applies-to>` member list — same semantics, fewer tokens.

## Release mechanics
- Bumped `vibetags-annotations`, `vibetags-processor`, and `vibetags-bom` to `1.0.0-RC5`; updated consumers (`example/`, `example-multimodule/`, `tools/demo/`, `README.md`, usage skill). `load-tests/` intentionally left pinned.
- Built in order (annotations → processor → BOM) and verified the `example` end-to-end compile.

Merge once CI is green; the GitHub release will tag `main` afterward.
