### PR TITLE
ci(publish): tolerate already-published components on Maven Central

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,19 +40,49 @@ jobs:
           GPG_TTY: /dev/tty
 
       - name: Sign and deploy annotations to Maven Central
-        run: cd vibetags-annotations && mvn clean deploy -P central-publish,sign-artifacts -B -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
+        run: |
+          cd vibetags-annotations
+          log="$(mktemp)"
+          if mvn clean deploy -P central-publish,sign-artifacts -B -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}" 2>&1 | tee "$log"; then
+            echo "annotations: deployed."
+          elif grep -q "already exists" "$log"; then
+            echo "::warning title=Already published::vibetags-annotations already exists on Maven Central — treating as success (idempotent re-publish)."
+          else
+            echo "::error title=Deploy failed::annotations deploy failed for a reason other than an already-published component."
+            exit 1
+          fi
         env:
           CENTRAL_TOKEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
           CENTRAL_TOKEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
 
       - name: Build, sign, and deploy processor to Maven Central
-        run: cd vibetags && mvn clean deploy -P central-publish,sign-artifacts -B -DskipTests -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
+        run: |
+          cd vibetags
+          log="$(mktemp)"
+          if mvn clean deploy -P central-publish,sign-artifacts -B -DskipTests -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}" 2>&1 | tee "$log"; then
+            echo "processor: deployed."
+          elif grep -q "already exists" "$log"; then
+            echo "::warning title=Already published::vibetags-processor already exists on Maven Central — treating as success (idempotent re-publish)."
+          else
+            echo "::error title=Deploy failed::processor deploy failed for a reason other than an already-published component."
+            exit 1
+          fi
         env:
           CENTRAL_TOKEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
           CENTRAL_TOKEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
 
       - name: Sign and deploy BOM to Maven Central
-        run: cd vibetags-bom && mvn clean deploy -P central-publish,sign-artifacts -B -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
+        run: |
+          cd vibetags-bom
+          log="$(mktemp)"
+          if mvn clean deploy -P central-publish,sign-artifacts -B -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}" 2>&1 | tee "$log"; then
+            echo "bom: deployed."
+          elif grep -q "already exists" "$log"; then
+            echo "::warning title=Already published::vibetags-bom already exists on Maven Central — treating as success (idempotent re-publish)."
+          else
+            echo "::error title=Deploy failed::bom deploy failed for a reason other than an already-published component."
+            exit 1
+          fi
         env:
           CENTRAL_TOKEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
           CENTRAL_TOKEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}


### PR DESCRIPTION
## What

Make the Maven Central publish steps **idempotent**: if a component version already exists on Central, treat the deploy as a successful no-op instead of failing the job. Any other failure still fails the build.

## Why

Maven Central coordinates are immutable — you cannot re-upload a version that already exists. During the `v1.0.0-RC5` release, a Maven Central publishing incident caused the annotations deploy to report failure *after the artifact had actually published server-side*. `vibetags-annotations:1.0.0-RC5` went live, but `vibetags-processor` and `vibetags-bom` never uploaded (their steps were skipped after the annotations step "failed"). Re-running then failed permanently with:

```
Component with package url: 'pkg:maven/se.deversity.vibetags/vibetags-annotations@1.0.0-RC5' already exists
```

...which blocked the processor and BOM from ever publishing under RC5.

With this guard, the annotations "already exists" rejection is tolerated, so the run proceeds to publish the processor and BOM and complete RC5. It also protects every future release from the same partial-publish trap.

## Change

Each of the three deploy steps (annotations, processor, BOM) now wraps `mvn deploy`: on failure it greps the log for `already exists` → warns and continues; otherwise → fails as before. No change to what gets built, signed, or the version deployed.

## Follow-up

After merge: force-move tag `v1.0.0-RC5` onto the merged commit and recreate the release to re-trigger publish; the processor and BOM will then deploy while annotations is tolerated as already-present.
