### PR TITLE
fix: scoped-rules index must point at the role-grouped file, not the per-class default

### DIFF
--- a/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
@@ -316,7 +316,7 @@ public class AIGuardrailProcessor extends AbstractProcessor {
 
         // Build all per-platform content in one pass (current module only).
         GuardrailContentBuilder.Result built =
-            new GuardrailContentBuilder(collector, activeServices, projectName, GENERATED_HEADER).build();
+            new GuardrailContentBuilder(collector, activeServices, projectName, GENERATED_HEADER, rootRoles).build();
         Map<String, String> contentByService = built.contentByService;
         this.elementRules = built.elementRules;
 
@@ -467,9 +467,10 @@ public class AIGuardrailProcessor extends AbstractProcessor {
 
         Map<String, Path> serviceFiles = ServiceRegistry.buildServiceFileMap(root);
         Set<String> activeServices = ServiceRegistry.resolveActiveServices(processingEnv.getMessager(), serviceFiles);
+        RoleConfig checkRootRoles = RoleConfig.load(root);
 
         GuardrailContentBuilder.Result built =
-            new GuardrailContentBuilder(collector, activeServices, projectName, GENERATED_HEADER).build();
+            new GuardrailContentBuilder(collector, activeServices, projectName, GENERATED_HEADER, checkRootRoles).build();
         Map<String, String> contentByService = built.contentByService;
 
         // Simulate this module's sidecar save in memory: the merge below must reflect the
@@ -545,7 +546,6 @@ public class AIGuardrailProcessor extends AbstractProcessor {
                 : collector.anyAnnotationsFound();
             checkWriter.writeFileIfChanged(filePath.toString(), entry.getValue(), anyContributed || isIgnoreFile);
         }
-        RoleConfig checkRootRoles = RoleConfig.load(root);
         GranularRulesWriter checkGranular = new GranularRulesWriter(checkWriter);
         Set<String> writtenQNames = checkGranular.writeAll(built.elementRules, serviceFiles, activeServices, checkRootRoles);
         checkGranular.cleanupAll(serviceFiles, activeServices, writtenQNames);

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GranularRulesWriter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GranularRulesWriter.java
@@ -99,7 +99,7 @@ public final class GranularRulesWriter {
 
         // Role members → one grouped, human-named file per role.
         roleMembers.forEach((roleName, members) -> {
-            String stem = sanitize(roleName);
+            String stem = RoleConfig.sanitize(roleName);
             writtenQNames.add(stem);
             List<String> globs = roles.globsFor(roleName);
             if (globs.isEmpty()) {
@@ -134,11 +134,6 @@ public final class GranularRulesWriter {
         return owner.getKind() == ElementKind.PACKAGE
             ? "**/" + simpleName + "/**/*.java"
             : "**/" + simpleName + ".java";
-    }
-
-    /** Role names are user-authored; keep filenames to filesystem-safe characters. */
-    private static String sanitize(String roleName) {
-        return roleName.replaceAll("[^a-zA-Z0-9._-]", "-");
     }
 
     private static String arr(List<String> globs) {

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailContentBuilder.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailContentBuilder.java
@@ -17,17 +17,27 @@ public final class GuardrailContentBuilder {
     private final Set<String> activeServices;
     private final String projectName;
     private final String generatedHeader;
+    private final RoleConfig roles;
 
     public GuardrailContentBuilder(AnnotationCollector collector,
                                    Set<String> activeServices,
                                    String projectName,
                                    String generatedHeader) {
+        this(collector, activeServices, projectName, generatedHeader, null);
+    }
+
+    public GuardrailContentBuilder(AnnotationCollector collector,
+                                   Set<String> activeServices,
+                                   String projectName,
+                                   String generatedHeader,
+                                   RoleConfig roles) {
         this.collector = collector;
         // Defensive copy: callers must not be able to mutate the active-services set
         // through the reference they passed in.
         this.activeServices = new java.util.LinkedHashSet<>(activeServices);
         this.projectName = projectName;
         this.generatedHeader = generatedHeader;
+        this.roles = roles;
     }
 
     /**
@@ -60,7 +70,7 @@ public final class GuardrailContentBuilder {
                 : new java.util.LinkedHashMap<>();
 
         RenderingContext context = new RenderingContext(projectName, generatedHeader, activeServices,
-                estimatedContentSize, elementRules.keySet());
+                estimatedContentSize, elementRules.keySet(), roles);
         Map<String, String> contentByService = new java.util.LinkedHashMap<>();
 
         // Render each active service (excluding granular directories and special-case exclusions)

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleOutputWriter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleOutputWriter.java
@@ -53,7 +53,7 @@ public final class ModuleOutputWriter {
         }
 
         GuardrailContentBuilder.Result built =
-            new GuardrailContentBuilder(collector, moduleActive, projectName, generatedHeader).build();
+            new GuardrailContentBuilder(collector, moduleActive, projectName, generatedHeader, roles).build();
 
         boolean hasAnnotations = collector.anyAnnotationsFound();
         int written = 0;

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/RoleConfig.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/RoleConfig.java
@@ -137,6 +137,21 @@ public final class RoleConfig {
         return List.of();
     }
 
+    /**
+     * The rule-file stem that {@link GranularRulesWriter} writes for {@code owner}: the sanitized
+     * role name when the element matches a role, otherwise the per-class granular qName. The single
+     * source of truth so a scoped-rules index pointer can never drift from the file it references
+     * (see {@code GranularIndexSection}).
+     */
+    public String granularStemFor(Element owner) {
+        return roleFor(owner).map(RoleConfig::sanitize).orElseGet(() -> ElementNaming.granularQName(owner));
+    }
+
+    /** Role names are user-authored; keep filenames to filesystem-safe characters. */
+    public static String sanitize(String roleName) {
+        return roleName.replaceAll("[^a-zA-Z0-9._-]", "-");
+    }
+
     /** A token is a glob (not an FQN) if it contains any glob metacharacter or a path separator. */
     private static boolean isGlob(String token) {
         return token.indexOf('*') >= 0 || token.indexOf('?') >= 0

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/RenderingContext.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/RenderingContext.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.lang.model.element.Element;
+import se.deversity.vibetags.processor.internal.RoleConfig;
 
 /**
  * Context containing metadata and configuration options for the current rendering run.
@@ -14,6 +15,7 @@ public final class RenderingContext {
     private final Set<String> activeServices;
     private final int estimatedContentSize;
     private final Set<Element> granularOwners;
+    private final RoleConfig roles;
 
     public RenderingContext(String projectName, String generatedHeader, Set<String> activeServices) {
         this(projectName, generatedHeader, activeServices, 4096);
@@ -38,12 +40,23 @@ public final class RenderingContext {
      */
     public RenderingContext(String projectName, String generatedHeader, Set<String> activeServices,
                             int estimatedContentSize, Set<Element> granularOwners) {
+        this(projectName, generatedHeader, activeServices, estimatedContentSize, granularOwners, null);
+    }
+
+    /**
+     * @param roles the role routing in effect for this run (a {@code .vibetags-roles} config), or
+     *        {@code null} when roles are off. Used by the scoped-rules index so its pointers name the
+     *        same files {@code GranularRulesWriter} writes (role-grouped or per-class).
+     */
+    public RenderingContext(String projectName, String generatedHeader, Set<String> activeServices,
+                            int estimatedContentSize, Set<Element> granularOwners, RoleConfig roles) {
         this.projectName = projectName;
         this.generatedHeader = generatedHeader;
         // Defensive copy: prevent callers from mutating the set through the stored reference.
         this.activeServices = Collections.unmodifiableSet(new LinkedHashSet<>(activeServices));
         this.estimatedContentSize = Math.max(256, estimatedContentSize);
         this.granularOwners = Collections.unmodifiableSet(new LinkedHashSet<>(granularOwners));
+        this.roles = roles;
     }
 
     /** Capacity hint (bytes) for an O(N) renderer's top-level StringBuilder. */
@@ -71,6 +84,11 @@ public final class RenderingContext {
      */
     public Set<Element> granularOwners() {
         return granularOwners;
+    }
+
+    /** The role routing for this run (a {@code .vibetags-roles} config), or {@code null} when off. */
+    public RoleConfig roles() {
+        return roles;
     }
 
     public boolean isActive(Platform platform) {

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/platforms/GranularIndexSection.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/platforms/GranularIndexSection.java
@@ -93,8 +93,14 @@ final class GranularIndexSection {
     }
 
     /** Relative path to the scoped rule file for {@code owner} under {@code platform}'s granular directory. */
-    private static String scopedPath(Platform platform, Element owner) {
-        return scopedDir(platform) + "/" + ElementNaming.granularQName(owner) + scopedSuffix(platform);
+    private static String scopedPath(Platform platform, Element owner, RenderingContext context) {
+        // Name the file GranularRulesWriter actually wrote: the role-grouped stem when a
+        // .vibetags-roles config routes this element, else the per-class qName. Resolving through
+        // the same RoleConfig keeps the pointer from dangling to a file that was never written.
+        String stem = context.roles() != null
+            ? context.roles().granularStemFor(owner)
+            : ElementNaming.granularQName(owner);
+        return scopedDir(platform) + "/" + stem + scopedSuffix(platform);
     }
 
     /**
@@ -111,7 +117,7 @@ final class GranularIndexSection {
         sb.append("    <note>Detailed per-element guardrails for the elements below live in scoped rule files that load automatically when the matching source file is opened. Consult the referenced file before modifying an element.</note>\n");
         for (Element owner : owners) {
             sb.append("    <element path=\"").append(Escape.xml(owner.toString()))
-              .append("\" rules=\"").append(Escape.xml(scopedPath(platform, owner))).append("\"/>\n");
+              .append("\" rules=\"").append(Escape.xml(scopedPath(platform, owner, context))).append("\"/>\n");
         }
         sb.append("  </scoped_rules>\n");
         sb.append("\n<rule>When you work on any element listed in <scoped_rules>, open its referenced rule file and apply the guardrails there. The rule files are the authoritative source for those elements.</rule>\n");
@@ -130,7 +136,7 @@ final class GranularIndexSection {
         sb.append("\n## Scoped Rules Index\n");
         sb.append("Detailed per-element guardrails live in scoped rule files that load automatically when you open the matching source file. Consult the referenced file before modifying an element:\n\n");
         for (Element owner : owners) {
-            sb.append("- `").append(owner.toString()).append("` → `").append(scopedPath(platform, owner)).append("`\n");
+            sb.append("- `").append(owner.toString()).append("` → `").append(scopedPath(platform, owner, context)).append("`\n");
         }
     }
 }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/GranularIndexEndToEndTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/GranularIndexEndToEndTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -81,6 +83,30 @@ class GranularIndexEndToEndTest {
         // The scoped file carries the detail that left the aggregate.
         assertTrue(h.readFile(".claude/rules/com-example-Gateway.md").contains("charge"),
             "per-method contract detail lives in the scoped file");
+    }
+
+    @Test
+    void claudeDualOptIn_withRoles_indexPointsAtRoleFile(@TempDir Path dir) throws IOException {
+        ProcessorTestHarness h = new ProcessorTestHarness(dir, false);
+        h.touchOptIn("CLAUDE.md");
+        h.touchOptIn(".claude/rules/.vibetags");
+        // A .vibetags-roles config groups the Gateway into a human-named role file. The scoped-rules
+        // index in CLAUDE.md must reference the role-grouped filename that GranularRulesWriter
+        // actually wrote — not the per-class default — or the pointer dangles (issue #295 follow-up).
+        Files.writeString(dir.resolve(".vibetags-roles"), "gateways = **/Gateway.java\n", StandardCharsets.UTF_8);
+        addMixedSources(h);
+        h.compile();
+
+        String claude = h.readFile("CLAUDE.md");
+        assertTrue(claude.contains("<scoped_rules>"), "scoped-rules index present");
+        assertTrue(claude.contains("rules=\".claude/rules/gateways.md\""),
+            "index must point at the role-grouped file when .vibetags-roles routes the element");
+        assertFalse(claude.contains("com-example-Gateway.md"),
+            "index must NOT use the per-class default name once a role remaps the file");
+        assertTrue(h.fileExists(".claude/rules/gateways.md"),
+            "the role-grouped file the index points at must exist");
+        assertFalse(h.fileExists(".claude/rules/com-example-Gateway.md"),
+            "no per-class file once the element is grouped into a role");
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #295/#298. When a directory opts into **both** an aggregate file and its granular sibling, the aggregate collapses to a `<scoped_rules>` index of pointers. But the pointer was derived from `ElementNaming.granularQName` (the per-class default), so when a `.vibetags-roles` config routed the element into a role-grouped file, **the pointer dangled** to a file that was never written.

### Repro (before)
Module with `CLAUDE.md` + `.claude/rules/` + `.vibetags-roles` (`domain-model = **/core/*.java`):
- File written: `.claude/rules/domain-model.md`
- Index pointer: `rules=".claude/rules/com-example-…-DocumentModel.md"` ❌ (does not exist)

### Fix
Thread the active `RoleConfig` through `GuardrailContentBuilder` → `RenderingContext` so the index resolves each element's **actual** rule file via a new `RoleConfig.granularStemFor(owner)` — the single source of truth now shared with `GranularRulesWriter` (its `sanitize` is promoted to the canonical `RoleConfig.sanitize`). Applied to all three build paths: root generate, check mode, and per-module (`ModuleOutputWriter`).

After: pointer is `rules=".claude/rules/domain-model.md"` ✅ and the file exists. Safety guardrails still inline; no verbose duplication.

### Files
- `RoleConfig` — `granularStemFor` + public `sanitize`
- `RenderingContext` — carries nullable `RoleConfig` (`roles()`)
- `GuardrailContentBuilder` — accepts/forwards `RoleConfig` (4-arg overload kept)
- `AIGuardrailProcessor` (generate + check), `ModuleOutputWriter` — pass the loaded config
- `GranularIndexSection` — pointer uses `granularStemFor`
- `GranularIndexEndToEndTest` — regression test (index → role file, which exists; per-class name/file absent)

### Verification
- Full processor suite: **1193 tests, 0 failures**.
- `example-multimodule-indexed` with a module `CLAUDE.md` + `.vibetags-roles`: pointer now valid.

Targets `feat/issue-298-lean-indexed-root` so it's in before RC6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)