### PR TITLE
chore: prepare release v1.0.0-RC6

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary annotations, or wants to control how AI tools interact with Java code.
-version: 1.0.0-RC5
+version: 1.0.0-RC6
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.0-RC5</version>
+    <version>1.0.0-RC6</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.0-RC5'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC5'
+compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.0-RC6'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC6'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.0-RC5</version>
+            <version>1.0.0-RC6</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -72,7 +72,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.0-RC5</version>
+                        <version>1.0.0-RC6</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -113,8 +113,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC5')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC5')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC6')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC6')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -351,7 +351,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.0-RC5</version>
+            <version>1.0.0-RC6</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -376,7 +376,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.0-RC5</version>
+                        <version>1.0.0-RC6</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -390,8 +390,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC5')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC5')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC6')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC6')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -405,15 +405,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.0-RC5</version>
+    <version>1.0.0-RC6</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC5'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC5'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC6'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC6'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-RC6] - 2026-07-22
+
+### Added
+- **Lean indexed root aggregate for multi-module reactors (`.vibetags-root-index`).** By default the
+  reactor-root aggregate files (`CLAUDE.md`, `.cursorrules`, `.windsurfrules`,
+  `.github/copilot-instructions.md`) embed a full verbatim copy of every module's guardrails via the
+  sidecar merge. In a reactor where each module already carries its own scoped rules (`.claude/rules/`,
+  `.cursor/rules/`, …), that root block is a second copy of content the AI tool already auto-loads from
+  the module files. Touch `.vibetags-root-index` at the reactor root to opt into a **lean index**: for
+  the four aggregates that have a granular sibling, the merge replaces each module's embedded body with
+  a short pointer to that module's own scoped rules (and/or its own aggregate file), still wrapped in
+  the `VIBETAGS-MODULE` sub-markers. The root module's own body stays inline, and aggregates without a
+  granular sibling (`GEMINI.md`, `AGENTS.md`, `llms.txt`, `.vibetags-locks`, …) keep the full merge.
+  A losslessness guard links a module only when it actually emits its own per-module output for that
+  service, so a module with no output of its own keeps its embedded body and nothing is dropped. The
+  opt-in registers as the `root_index` service and folds into the build fingerprint, so toggling it
+  reliably regenerates; check mode mirrors it automatically. (#298, #304)
+
 ## [1.0.0-RC5] - 2026-07-21
 
 ### Added
@@ -1016,7 +1034,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC5...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC6...HEAD
+[1.0.0-RC6]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC5...v1.0.0-RC6
 [1.0.0-RC5]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC4...v1.0.0-RC5
 [1.0.0-RC4]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC3...v1.0.0-RC4
 [1.0.0-RC3]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC2...v1.0.0-RC3

--- a/example-multimodule-indexed/pom.xml
+++ b/example-multimodule-indexed/pom.xml
@@ -30,7 +30,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.0.0-RC6-SNAPSHOT</vibetags.bom.version>
+    <vibetags.bom.version>1.0.0-RC6</vibetags.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/example-multimodule/pom.xml
+++ b/example-multimodule/pom.xml
@@ -27,7 +27,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.0.0-RC5</vibetags.bom.version>
+    <vibetags.bom.version>1.0.0-RC6</vibetags.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC5')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC5')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC6')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC6')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.0.0-RC5</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0-RC6</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
     </properties>
 

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.0.0-RC5</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0-RC6</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.0-RC6-SNAPSHOT'
+version = '1.0.0-RC6'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.0.0-RC6-SNAPSHOT'
+            version = '1.0.0-RC6'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.0-RC6-SNAPSHOT</version>
+    <version>1.0.0-RC6</version>
     <packaging>jar</packaging>
 
     <name>VibeTags Annotations</name>
@@ -23,12 +23,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.0.0-RC5&lt;/version&gt;
+                &lt;version&gt;1.0.0-RC6&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC5'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC5'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC6'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC6'
     </description>
     <url>https://github.com/PIsberg/vibetags</url>
 

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-bom</artifactId>
-    <version>1.0.0-RC6-SNAPSHOT</version>
+    <version>1.0.0-RC6</version>
     <packaging>pom</packaging>
 
     <name>VibeTags BOM</name>
@@ -25,7 +25,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.0.0-RC5&lt;/version&gt;
+                        &lt;version&gt;1.0.0-RC6&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -33,8 +33,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC5')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC5')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC6')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC6')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>
@@ -66,7 +66,7 @@
         <!-- Single source of truth for the VibeTags artifact set. Bump this when releasing
              a new processor version; all consumers that import this BOM track the bump
              without further changes. -->
-        <vibetags.version>1.0.0-RC6-SNAPSHOT</vibetags.version>
+        <vibetags.version>1.0.0-RC6</vibetags.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.0-RC6-SNAPSHOT'
+version = '1.0.0-RC6'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.0.0-RC6-SNAPSHOT'
+            version = '1.0.0-RC6'
             from components.java
 
             pom {
@@ -77,7 +77,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC6-SNAPSHOT'
+    api 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC6'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.0'

--- a/vibetags/pom.xml
+++ b/vibetags/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.0-RC6-SNAPSHOT</version>
+    <version>1.0.0-RC6</version>
     <packaging>jar</packaging>
 
     <name>VibeTags Processor</name>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-annotations</artifactId>
-            <version>1.0.0-RC6-SNAPSHOT</version>
+            <version>1.0.0-RC6</version>
         </dependency>
 
         <!-- JSpecify null annotations (@NullMarked, @Nullable, @NonNull).


### PR DESCRIPTION
Prepares the **v1.0.0-RC6** release.

## Version bump
`1.0.0-RC6-SNAPSHOT` → `1.0.0-RC6` across the three core modules (`vibetags-annotations`, `vibetags-processor`, `vibetags-bom`) and all BOM consumers (`example`, `example-multimodule`, `tools/demo`, `README.md`, usage skill, and the install snippets in the annotations/BOM POM descriptions). `load-tests` is intentionally left pinned.

## Changelog — Added
- **Lean indexed root aggregate for multi-module reactors (`.vibetags-root-index`).** By default the reactor-root aggregate files (`CLAUDE.md`, `.cursorrules`, `.windsurfrules`, `.github/copilot-instructions.md`) embed a full verbatim copy of every module's guardrails via the sidecar merge. In a reactor where each module already carries its own scoped rules (`.claude/rules/`, `.cursor/rules/`, …), that root block is a second copy of content the AI tool already auto-loads from the module files. Touch `.vibetags-root-index` at the reactor root to opt into a **lean index**: for the four aggregates that have a granular sibling, the merge replaces each module's embedded body with a short pointer to that module's own scoped rules (and/or its own aggregate file), still wrapped in the `VIBETAGS-MODULE` sub-markers. Aggregates without a granular sibling (`GEMINI.md`, `AGENTS.md`, `llms.txt`, `.vibetags-locks`, …) keep the full merge. A losslessness guard links a module only when it actually emits its own per-module output, so nothing is dropped. Registers as the `root_index` service and folds into the build fingerprint; check mode mirrors it automatically. (#298, #304)

## Verification
- Build chain green: `vibetags-annotations` → `vibetags` → `vibetags-bom` installed, `example` compiles end-to-end against the freshly installed RC6 BOM (processor runs, guardrail files regenerate).
- pre-commit: gitleaks / end-of-file-fixer / trailing-whitespace pass on the changed files (Checkstyle skipped locally — Docker unavailable; no `.java` files changed).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
