### PR TITLE
feat(codex): let AGENTS.md opt in explicitly via VibeTags markers

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -83,6 +83,18 @@ To remove a platform: delete its file — VibeTags will never recreate it.
 > tool's file (e.g. `CLAUDE.md`), VibeTags leaves it untouched whenever any other AI config file
 > is present (this also disables the `.codex/` sidecar). Opt in to *only* `AGENTS.md` to have it
 > managed.
+>
+> **Escape hatch (marker opt-in):** if you *want* a generated `AGENTS.md` alongside `CLAUDE.md`
+> — a Claude + Codex project, say — paste a marker pair into it:
+>
+> ```markdown
+> <!-- VIBETAGS-START -->
+> <!-- VIBETAGS-END -->
+> ```
+>
+> A file carrying the markers was written by VibeTags in the first place, and only the region
+> between them is ever replaced, so refreshing it cannot clobber your prose. Marked files stay
+> managed no matter how many other AI config files are present.
 
 ### 3. Annotate your Java code
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`AGENTS.md` can now opt in explicitly via VibeTags markers.** `AGENTS.md` is still only
+  generated when it is the sole AI config file present, because it is so often kept as a
+  hand-written pointer to another tool's file and clobbering that would be destructive. That rule
+  meant a project using both Claude and Codex could not have a generated `AGENTS.md` at all. An
+  `AGENTS.md` that already contains a `VIBETAGS-START` / `VIBETAGS-END` pair is now treated as an
+  active write target regardless of how many other AI config files exist: the markers prove
+  VibeTags authored the block, and `GuardrailFileWriter` only ever replaces the region between
+  them, so hand-authored content outside the markers is still preserved. Unmarked pointers are
+  left byte-for-byte untouched exactly as before, and the skipped-file NOTE now names the escape
+  hatch.
+
 ## [1.0.0-RC6] - 2026-07-22
 
 ### Added

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ServiceRegistry.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ServiceRegistry.java
@@ -3,6 +3,7 @@ package se.deversity.vibetags.processor.internal;
 import se.deversity.vibetags.annotations.AIContext;
 import javax.annotation.processing.Messager;
 import javax.tools.Diagnostic;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
@@ -147,6 +148,16 @@ public final class ServiceRegistry {
      * To avoid clobbering such a pointer, {@code AGENTS.md} is treated as a write target only when
      * it is the <em>sole</em> AI config file present. If any other service opted in, {@code codex}
      * is dropped here, which also disables the Codex sidecar config it would otherwise drive.
+     *
+     * <p><strong>Marker escape hatch.</strong> The sole-file rule exists to protect hand-authored
+     * pointers, not to forbid a generated {@code AGENTS.md} outright — a Claude + Codex project
+     * could not have one at all. A file that already contains a VibeTags block
+     * ({@link GuardrailFileWriter#MARKER_START_MD}) was written by VibeTags in the first place, and
+     * {@code GuardrailFileWriter} only ever replaces the region between the markers, so refreshing
+     * it cannot destroy anything the user wrote by hand. Such a file therefore stays an active
+     * write target even alongside {@code CLAUDE.md}, {@code GEMINI.md} and friends. Paste a
+     * {@code VIBETAGS-START} / {@code VIBETAGS-END} comment pair into {@code AGENTS.md} to opt a
+     * multi-tool project into a generated Codex file.
      */
     public static Set<String> resolveActiveServices(Messager messager, Map<String, Path> allServiceFiles) {
         boolean codexOptedIn = allServiceFiles.containsKey("codex") && Files.exists(allServiceFiles.get("codex"));
@@ -158,7 +169,9 @@ public final class ServiceRegistry {
             messager.printMessage(Diagnostic.Kind.NOTE,
                 "VibeTags: AGENTS.md left untouched because other AI config files are present; "
                 + "it is treated as a pointer rather than a generated file. Keep only AGENTS.md "
-                + "(remove the other AI config files) to have VibeTags manage it.");
+                + "(remove the other AI config files), or paste a "
+                + GuardrailFileWriter.MARKER_START_MD + " / <!-- VIBETAGS-END --> pair into it, "
+                + "to have VibeTags manage it.");
         }
 
         if (active.isEmpty()) {
@@ -187,10 +200,28 @@ public final class ServiceRegistry {
                 active.add(key);
             }
         });
-        // AGENTS.md is only managed when it is the only AI config file present (see Javadoc).
-        if (active.contains("codex") && active.size() > 1) {
+        // AGENTS.md is only managed when it is the only AI config file present (see Javadoc),
+        // unless it already carries a VibeTags block — a marked file is one VibeTags generated,
+        // so refreshing it cannot clobber a hand-authored pointer.
+        if (active.contains("codex") && active.size() > 1
+                && !carriesGeneratedBlock(allServiceFiles.get("codex"))) {
             active.remove("codex");
         }
         return active;
+    }
+
+    /**
+     * True when {@code path} already contains a VibeTags-generated markdown block. Unreadable
+     * files fall back to {@code false}, i.e. to the conservative sole-file rule.
+     */
+    private static boolean carriesGeneratedBlock(Path path) {
+        if (path == null) {
+            return false;
+        }
+        try {
+            return Files.readString(path).contains(GuardrailFileWriter.MARKER_START_MD);
+        } catch (IOException | RuntimeException e) {
+            return false;
+        }
     }
 }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/AgentsMdSoleFallbackTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/AgentsMdSoleFallbackTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -18,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.*;
  *   <li><b>Coexisting</b> — when {@code AGENTS.md} sits alongside another AI config file
  *       (e.g. {@code CLAUDE.md}), it is treated as a likely pointer and left untouched, while the
  *       other file is still generated.</li>
+ *   <li><b>Marker escape hatch</b> — unless the coexisting {@code AGENTS.md} already carries a
+ *       VibeTags marker pair, which means VibeTags wrote it and can safely refresh it.</li>
  * </ul>
  */
 class AgentsMdSoleFallbackTest {
@@ -32,6 +35,18 @@ class AgentsMdSoleFallbackTest {
         "import se.deversity.vibetags.annotations.AILocked;\n" +
         "@AILocked(reason = \"Core payment logic - do not refactor\")\n" +
         "public class PaymentProcessor {}\n";
+
+    /** Hand-authored text that must survive every regeneration. */
+    private static final String HAND_WRITTEN = "Hand-written preamble that must survive.";
+
+    private static final String MARKED_AGENTS_MD =
+        "# AGENTS.md\n\n"
+        + HAND_WRITTEN + "\n\n"
+        + "<!-- VIBETAGS-START -->\n"
+        + "<!-- VIBETAGS-END -->\n";
+
+    private static final String POINTER_AGENTS_MD =
+        "# AGENTS.md\n\nRead CLAUDE.md — this file is intentionally a pointer.\n";
 
     // -----------------------------------------------------------------------
     // Sole file → AGENTS.md IS written
@@ -86,6 +101,43 @@ class AgentsMdSoleFallbackTest {
             "AGENTS.md must be skipped whenever any other AI config file opts in");
         assertFalse(h.readFile(".cursorrules").isBlank(),
             ".cursorrules must still be generated");
+    }
+
+    /**
+     * Regression guard for the marker escape hatch: a hand-authored pointer with real prose but
+     * <em>no</em> markers must still be protected. Only the marker pair opts a file in.
+     */
+    @Test
+    void handWrittenPointerWithoutMarkersIsStillProtected(@TempDir Path tempDir) throws IOException {
+        ProcessorTestHarness h = new ProcessorTestHarness(tempDir, false);
+        Files.writeString(h.root().resolve("AGENTS.md"), POINTER_AGENTS_MD);
+        h.touchOptIn("CLAUDE.md");
+        h.addSource("com.example.payment.PaymentProcessor", LOCKED_SOURCE);
+        h.compile();
+
+        assertEquals(POINTER_AGENTS_MD, h.readFile("AGENTS.md"),
+            "An unmarked AGENTS.md pointer must be left byte-for-byte untouched");
+        assertFalse(h.readFile("CLAUDE.md").isBlank(), "CLAUDE.md must still be generated");
+    }
+
+    // -----------------------------------------------------------------------
+    // Marker escape hatch → a marked AGENTS.md is managed even alongside CLAUDE.md
+    // -----------------------------------------------------------------------
+
+    @Test
+    void markedAgentsMdIsWrittenAlongsideClaude(@TempDir Path tempDir) throws IOException {
+        ProcessorTestHarness h = new ProcessorTestHarness(tempDir, false);
+        Files.writeString(h.root().resolve("AGENTS.md"), MARKED_AGENTS_MD);
+        h.touchOptIn("CLAUDE.md");
+        h.addSource("com.example.payment.PaymentProcessor", LOCKED_SOURCE);
+        h.compile();
+
+        String agents = h.readFile("AGENTS.md");
+        assertTrue(agents.contains("PaymentProcessor"),
+            "A marked AGENTS.md must be regenerated even when CLAUDE.md is also present");
+        assertTrue(agents.contains(HAND_WRITTEN),
+            "Hand-authored content outside the markers must survive regeneration");
+        assertFalse(h.readFile("CLAUDE.md").isBlank(), "CLAUDE.md must still be generated");
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
AGENTS.md is only written when it is the sole AI config file present, so a hand-written pointer to CLAUDE.md is never clobbered. The protection is right, but the test is too coarse: it conflates "AGENTS.md exists as a pointer" with "AGENTS.md exists at all", so a project using both Claude and Codex cannot have a generated AGENTS.md under any circumstances — Codex readers get a redirect and no guardrails.

Key on marker presence instead. An AGENTS.md already containing a VIBETAGS-START/END pair was written by VibeTags in the first place, and GuardrailFileWriter only ever replaces the region between the markers, so refreshing it cannot destroy hand-authored content. Such a file now stays an active write target however many other AI config files exist; everything without markers keeps the existing sole-file rule untouched.

The skipped-file NOTE now names the escape hatch so the fix is discoverable from the build output rather than only from the source.

Tests: two added to AgentsMdSoleFallbackTest — a marked AGENTS.md is regenerated alongside CLAUDE.md while its prose outside the markers survives, and a hand-written pointer *without* markers is still left byte-for-byte untouched (the regression guard that the escape hatch did not loosen the default). Full suite green: 1195 tests, 0 failures; checkstyle, PMD and SpotBugs clean.


Claude-Session: https://claude.ai/code/session_01St3u5TbDRe3JAfHePqqjww