### PR TITLE
chore: prepare release v1.0.0-RC7

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.0.0-RC6
+version: 1.0.0-RC7
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.0-RC6</version>
+    <version>1.0.0-RC7</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.0-RC6'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC6'
+compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.0-RC7'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC7'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
           # Tier-3 detail lives in per-module scoped rules, grouped by each module's .vibetags-roles.
           test -f core/.claude/rules/domain-model.md || { echo "MISSING core/.claude/rules/domain-model.md"; exit 1; }
           test -f app/.claude/rules/services.md || { echo "MISSING app/.claude/rules/services.md"; exit 1; }
-          echo "Indexed root points at per-module rules; GEMINI.md still merges; Tier-3 topics present." 
+          echo "Indexed root points at per-module rules; GEMINI.md still merges; Tier-3 topics present."
       - name: Run Unit Tests (VibeTags Library)
         run: |
           cd vibetags

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.0-RC6</version>
+            <version>1.0.0-RC7</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -72,7 +72,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.0-RC6</version>
+                        <version>1.0.0-RC7</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -113,8 +113,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC6')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC6')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC7')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC7')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -356,7 +356,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.0-RC6</version>
+            <version>1.0.0-RC7</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -381,7 +381,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.0-RC6</version>
+                        <version>1.0.0-RC7</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -395,8 +395,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC6')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC6')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC7')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC7')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -410,15 +410,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.0-RC6</version>
+    <version>1.0.0-RC7</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC6'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC6'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC7'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC7'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-RC7] - 2026-07-29
+
 ### Added
 - **Five evidence-based annotations (39 → 44).** Reverse-engineered from guardrails real maintainers
   wrote *by hand* across 225 open-source `CLAUDE.md` files: a hand-written AI rule is a constraint
@@ -1079,7 +1081,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC6...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC7...HEAD
+[1.0.0-RC7]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC6...v1.0.0-RC7
 [1.0.0-RC6]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC5...v1.0.0-RC6
 [1.0.0-RC5]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC4...v1.0.0-RC5
 [1.0.0-RC4]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC3...v1.0.0-RC4

--- a/example-multimodule-indexed/pom.xml
+++ b/example-multimodule-indexed/pom.xml
@@ -30,7 +30,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.0.0-RC6</vibetags.bom.version>
+    <vibetags.bom.version>1.0.0-RC7</vibetags.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/example-multimodule/pom.xml
+++ b/example-multimodule/pom.xml
@@ -27,7 +27,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.0.0-RC6</vibetags.bom.version>
+    <vibetags.bom.version>1.0.0-RC7</vibetags.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC6')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC6')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC7')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC7')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.0.0-RC6</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0-RC7</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
     </properties>
 

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.0.0-RC6</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0-RC7</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.0-RC6'
+version = '1.0.0-RC7'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.0.0-RC6'
+            version = '1.0.0-RC7'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.0-RC6</version>
+    <version>1.0.0-RC7</version>
     <packaging>jar</packaging>
 
     <name>VibeTags Annotations</name>
@@ -23,12 +23,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.0.0-RC6&lt;/version&gt;
+                &lt;version&gt;1.0.0-RC7&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC6'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC6'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC7'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC7'
     </description>
     <url>https://github.com/PIsberg/vibetags</url>
 

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-bom</artifactId>
-    <version>1.0.0-RC6</version>
+    <version>1.0.0-RC7</version>
     <packaging>pom</packaging>
 
     <name>VibeTags BOM</name>
@@ -25,7 +25,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.0.0-RC6&lt;/version&gt;
+                        &lt;version&gt;1.0.0-RC7&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -33,8 +33,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC6')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC6')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC7')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC7')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>
@@ -66,7 +66,7 @@
         <!-- Single source of truth for the VibeTags artifact set. Bump this when releasing
              a new processor version; all consumers that import this BOM track the bump
              without further changes. -->
-        <vibetags.version>1.0.0-RC6</vibetags.version>
+        <vibetags.version>1.0.0-RC7</vibetags.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.0-RC6'
+version = '1.0.0-RC7'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.0.0-RC6'
+            version = '1.0.0-RC7'
             from components.java
 
             pom {
@@ -77,7 +77,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC6'
+    api 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC7'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.0'

--- a/vibetags/pom.xml
+++ b/vibetags/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.0-RC6</version>
+    <version>1.0.0-RC7</version>
     <packaging>jar</packaging>
 
     <name>VibeTags Processor</name>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-annotations</artifactId>
-            <version>1.0.0-RC6</version>
+            <version>1.0.0-RC7</version>
         </dependency>
 
         <!-- JSpecify null annotations (@NullMarked, @Nullable, @NonNull).


### PR DESCRIPTION
Prepares release **v1.0.0-RC7** (from v1.0.0-RC6).

## Release contents

### Added
- **Five evidence-based annotations (39 → 44).** Reverse-engineered from guardrails real maintainers
  wrote *by hand* across 225 open-source `CLAUDE.md` files. Four of the five close the same
  structural hole — VibeTags owned the *positive* pole of an axis and was missing the *negative*
  one. Evidence and rejected candidates: `docs/proposed-annotations.md`.
  - `@AIGenerated(from, regenerateWith, editInstead)` — machine-generated code whose hand edits are
    silently overwritten, plus where the change actually belongs (35 repos).
  - `@AILoadBearing(invariant, breaksIf, suppressAudit)` — code that looks wrong/redundant and is
    deliberate; edits welcome while the invariant survives (31 repos).
  - `@AIBannedApi(forbidden, useInstead, reason)` — named symbols forbidden at this element even
    though they compile (27 repos).
  - `@AIThreadAffinity(value, thread, marshalVia, symptomIfViolated)` — safe on *exactly one*
    thread, the inverse of `@AIThreadSafe` (12 repos).
  - `@AIKeepInSync(mirrors, reason, enforcedBy)` — duplicated at named sites that must move
    together; the most-written rule in the corpus (41 repos).

  All five are wired through every dispatch point: collector, build fingerprint, formatter registry,
  aggregate renderers, granular rule files, `llms.txt`/`llms-full.txt`, Aider, Sweep and Open
  Interpreter — plus 15 new compile-time validation warnings.

### Changed
- **`AGENTS.md` can now opt in explicitly via VibeTags markers.** An `AGENTS.md` that already
  contains a `VIBETAGS-START` / `VIBETAGS-END` pair is treated as an active write target regardless
  of how many other AI config files exist; unmarked pointer files stay byte-for-byte untouched.

## Release mechanics

- `scripts/set-version.sh 1.0.0-RC7` — `vibetags-annotations` (pom + gradle), `vibetags` (pom +
  gradle), `vibetags-bom`.
- Consumers bumped by hand to the released BOM: `example/` (pom + gradle), `tools/demo/pom.xml`,
  `example-multimodule/pom.xml`, `example-multimodule-indexed/pom.xml`, `README.md`,
  `.claude/skills/vibetags-usage/SKILL.md`.
- `load-tests/` left pinned on purpose (cross-version benchmark comparison).
- CHANGELOG: `[Unreleased]` → `[1.0.0-RC7] - 2026-07-29`, fresh empty `[Unreleased]`, comparison
  links updated.
- One stray trailing space removed from `.github/workflows/build.yml` by the pre-commit hook.

## Verification

- Built in order: `vibetags-annotations` → `vibetags` (clean install, full test suite) →
  `vibetags-bom` → `example` (clean compile, real end-to-end annotation processing). All green.
- `pre-commit run --all-files`: gitleaks, end-of-file-fixer, trailing-whitespace pass. The
  Docker-backed `checkstyle` hook could not run locally (Docker daemon down), so Checkstyle was
  verified directly with `mvn checkstyle:check` in both `vibetags/` and `vibetags-annotations/` —
  both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuNqa9ACQC6FSZ1ktSQTEE
