### PR TITLE
fix: honour .vibetags-root-index when only one module contributes

### DIFF
--- a/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
@@ -353,7 +353,11 @@ public class AIGuardrailProcessor extends AbstractProcessor {
 
         // Read all sidecars (this module + any siblings that have already compiled).
         List<ModuleSidecar> allSidecars = ModuleSidecar.readAll(root);
-        boolean multiModule = allSidecars.size() > 1;
+        // The merge path also owns lean-index pointer substitution, so a root that opted into the
+        // lean index must take it even with a single sidecar — a reactor where one module holds all
+        // the annotations produces exactly one, and gating purely on size would silently ignore the
+        // opt-in — it would be read, reported as an active service, and then do nothing.
+        boolean multiModule = allSidecars.size() > 1 || ModuleSidecar.isRootIndexMode(allSidecars);
 
         // Merge per-service content: in multi-module builds, combine every sibling's contribution
         // into the shared output files using module sub-markers.
@@ -519,7 +523,7 @@ public class AIGuardrailProcessor extends AbstractProcessor {
         // CPD-OFF — intentional mirror of the merge block in generateFiles(): a check verdict
         // is only trustworthy if it reproduces generation exactly, and generateFiles() is
         // @AILocked (its step order is load-bearing), so the shared block cannot be extracted.
-        boolean multiModule = allSidecars.size() > 1;
+        boolean multiModule = allSidecars.size() > 1 || ModuleSidecar.isRootIndexMode(allSidecars);
 
         final Map<String, String> effectiveContent;
         if (multiModule) {

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
@@ -281,8 +281,16 @@ public final class ModuleSidecar {
         }
     }
 
-    /** True when at least one sidecar carries the reactor-root lean-index opt-in. */
-    private static boolean isRootIndexMode(List<ModuleSidecar> sidecars) {
+    /**
+     * True when at least one sidecar carries the reactor-root lean-index opt-in.
+     *
+     * <p>Public because the merge path is otherwise gated on there being more than one sidecar, and
+     * a reactor can legitimately have exactly one: a module contributes a sidecar only when it has
+     * annotations, so a project where a single module holds all of them produces one. Without this
+     * the opt-in would be read, reported as an active service, and then silently skipped — see
+     * {@code AIGuardrailProcessor.generateFiles}.
+     */
+    public static boolean isRootIndexMode(List<ModuleSidecar> sidecars) {
         for (ModuleSidecar s : sidecars) {
             if (s.rootIndexMode) return true;
         }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/LeanIndexedRootEndToEndTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/LeanIndexedRootEndToEndTest.java
@@ -142,6 +142,52 @@ class LeanIndexedRootEndToEndTest {
         assertTrue(claude.contains("com.example.cli.KartaCli"), "without opt-in, root embeds module-cli fully");
     }
 
+    /**
+     * Regression: the opt-in must engage when only ONE module contributes a sidecar.
+     *
+     * <p>A module writes a sidecar only when its compilation actually saw annotations, so a reactor
+     * whose annotations all live in one module produces exactly one. The merge path — which owns
+     * pointer substitution — used to be gated on {@code allSidecars.size() > 1}, so for those
+     * projects {@code .vibetags-root-index} was read, logged as an active service, and then had no
+     * effect at all. Real-world case: async-test-lib, where only the library module is annotated
+     * and the agent/analysis modules are not.
+     */
+    @Test
+    void indexedRoot_collapsesWhenOnlyOneModuleContributes() throws IOException {
+        setUpIndexedReactor();
+        // module-cli is part of the reactor but has no annotated sources, so it writes no sidecar.
+        compileModule("module-core", "com.example.core.IrNode", CORE_SOURCE);
+
+        String claude = Files.readString(reactorRoot.resolve("CLAUDE.md"));
+        assertTrue(claude.contains("module-core/.claude/rules/"),
+            "the sole contributing module must still be linked, not embedded");
+        assertFalse(claude.contains("com.example.core.IrNode"),
+            "the lean root must not embed the sole module's guardrails verbatim");
+        assertTrue(claude.contains("<!-- VIBETAGS-MODULE: module-core -->"),
+            "the pointer keeps its owning-module sub-marker even when it is the only one");
+
+        // The module's own scoped rules remain the source of truth.
+        assertTrue(moduleRulesContain(reactorRoot.resolve("module-core/.claude/rules"), "Core IR node"),
+            "module-core's own scoped rules must still carry its @AILocked guardrail");
+    }
+
+    /**
+     * The single-sidecar case with NO opt-in must keep the historical shape: one contribution is
+     * returned verbatim and without sub-markers, exactly as a single-module project always was.
+     */
+    @Test
+    void singleModuleWithoutOptIn_staysVerbatimAndUnmarked() throws IOException {
+        Files.createDirectories(reactorRoot.resolve("module-core").resolve(".claude/rules"));
+        Files.createFile(reactorRoot.resolve("CLAUDE.md"));
+        compileModule("module-core", "com.example.core.IrNode", CORE_SOURCE);
+
+        String claude = Files.readString(reactorRoot.resolve("CLAUDE.md"));
+        assertTrue(claude.contains("com.example.core.IrNode"),
+            "without the opt-in a lone module is embedded as before");
+        assertFalse(claude.contains("<!-- VIBETAGS-MODULE:"),
+            "a lone contribution must not gain module sub-markers");
+    }
+
     private static boolean moduleRulesContain(Path rulesDir, String needle) throws IOException {
         if (!Files.isDirectory(rulesDir)) return false;
         try (Stream<Path> files = Files.walk(rulesDir)) {


### PR DESCRIPTION
## The bug

A module writes a sidecar only when its compilation actually saw annotations. So a reactor whose annotations all live in **one** module produces exactly one sidecar — which is a common shape, not an edge case: a library with a couple of thin satellite modules around it.

The merge path owns lean-index pointer substitution, and it was gated on `allSidecars.size() > 1`. For those projects `.vibetags-root-index` was read, resolved, reported in the log as an active service —

```
INFO  Active services (4): claude, claude_granular, claude_ignore, root_index
INFO  CLAUDE.md — no changes
```

— and then had no effect whatsoever.

The root kept a byte-identical copy of the module's full guardrail block, which is exactly what the opt-in exists to remove. And because the copy is *identical*, editing anything inside the module loads the same index twice: once from the root aggregate, once from the module's own file.

## The fix

Gate on `size > 1 || isRootIndexMode(...)` at both call sites — `generateFiles()` and the deliberately mirrored block in `checkFiles()`, so `--check` keeps reproducing generation exactly. `isRootIndexMode` is promoted from private to public for that, with a comment explaining why it is part of the gate.

```diff
-        boolean multiModule = allSidecars.size() > 1;
+        boolean multiModule = allSidecars.size() > 1 || ModuleSidecar.isRootIndexMode(allSidecars);
```

## Nothing changes without the opt-in

`mergeFor()` already returns a lone contribution verbatim and unmarked whenever no pointer applies (`if (!anyPointer && contributions.size() < MULTI_MODULE_THRESHOLD)`), so a single-module project that has not opted in takes exactly the path it always did. That is pinned by the second test added here rather than left to inspection.

## Tests

Two added to `LeanIndexedRootEndToEndTest`:

| test | pins |
|---|---|
| `indexedRoot_collapsesWhenOnlyOneModuleContributes` | the opt-in engages with a single contributing sidecar; the module is linked, not embedded, and keeps its sub-marker |
| `singleModuleWithoutOptIn_staysVerbatimAndUnmarked` | no opt-in → lone contribution stays verbatim and gains no sub-markers |

Verified the first one is a real regression test, not a tautology — on the unpatched processor it fails with exactly the reported symptom:

```
LeanIndexedRootEndToEndTest.indexedRoot_collapsesWhenOnlyOneModuleContributes:162
  the sole contributing module must still be linked, not embedded ==> expected: <true> but was: <false>
```

The other four tests in the class pass both with and without the fix, confirming the change is scoped to the previously-dead path.

Full suite: **1268 tests, 0 failures, 0 errors, 0 skipped.**

## Context

Found while reorganising [async-test-lib](https://github.com/PIsberg/async-test-lib/pull/179)'s context layout, where the library module carries every annotation and the agent and analysis modules carry none. That repo currently works around this by annotating the two satellite modules; with this fix the workaround is no longer required for the opt-in to function.

Related: #296 ("Warn when an annotated reactor module contributes nothing to the merged root") is the same blind spot approached from the other side — worth deciding whether a warning is still wanted once the silent no-op is gone. #319 is a separate lean-index gap (`.github/copilot-instructions.md` not collapsing) and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eYCEBnv3mygp6VDzL9uY6
