### PR TITLE
fix: emit guardrails in a deterministic order

### DIFF
--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/GranularSections.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/GranularSections.java
@@ -1,6 +1,7 @@
 package se.deversity.vibetags.processor.internal.content;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -51,6 +52,15 @@ public final class GranularSections {
         Map<String, List<GranularBody.Entry>> byTitle = new LinkedHashMap<>();
         for (GranularBody.Entry e : entries) {
             byTitle.computeIfAbsent(e.title(), k -> new ArrayList<>()).add(e);
+        }
+        // Order each section by the element's stable path identity. Stanzas arrive in
+        // annotation-processing order, which the JLS does not constrain and which differs between
+        // Maven and Gradle, so identical sources would otherwise emit byte-different files —
+        // notably the multi-target "Applies to" list (issue #325). Sorting here covers every
+        // layout below. Section order itself is left alone: it follows the fixed annotation-type
+        // order the collector walks, not a round-dependent one.
+        for (List<GranularBody.Entry> group : byTitle.values()) {
+            group.sort(Comparator.comparing(e -> e.element().path()));
         }
         StringBuilder out = new StringBuilder();
         for (Map.Entry<String, List<GranularBody.Entry>> section : byTitle.entrySet()) {

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/RenderingContext.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/RenderingContext.java
@@ -1,6 +1,7 @@
 package se.deversity.vibetags.processor.internal.content;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import se.deversity.vibetags.processor.model.TaggedElement;
@@ -55,7 +56,18 @@ public final class RenderingContext {
         // Defensive copy: prevent callers from mutating the set through the stored reference.
         this.activeServices = Collections.unmodifiableSet(new LinkedHashSet<>(activeServices));
         this.estimatedContentSize = Math.max(256, estimatedContentSize);
-        this.granularOwners = Collections.unmodifiableSet(new LinkedHashSet<>(granularOwners));
+        // Sorted by the stable path identity, so the scoped-rules index is a pure function of the
+        // source. Owners arrive in annotation-processing round order, which the JLS does not
+        // constrain and which differs between Maven and Gradle; leaving it as-collected made two
+        // builds of identical sources emit byte-different index lines (issue #325). Sorting here
+        // rather than at each emit site means every current and future consumer of granularOwners()
+        // is deterministic by construction.
+        LinkedHashSet<TaggedElement> sortedOwners = new LinkedHashSet<>();
+        granularOwners.stream()
+                .sorted(Comparator.comparing(TaggedElement::path)
+                                  .thenComparing(o -> String.valueOf(o.kind())))
+                .forEach(sortedOwners::add);
+        this.granularOwners = Collections.unmodifiableSet(sortedOwners);
         this.roles = roles;
     }
 

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/RenderingContext.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/RenderingContext.java
@@ -62,7 +62,7 @@ public final class RenderingContext {
         // builds of identical sources emit byte-different index lines (issue #325). Sorting here
         // rather than at each emit site means every current and future consumer of granularOwners()
         // is deterministic by construction.
-        LinkedHashSet<TaggedElement> sortedOwners = new LinkedHashSet<>();
+        Set<TaggedElement> sortedOwners = new LinkedHashSet<>();
         granularOwners.stream()
                 .sorted(Comparator.comparing(TaggedElement::path)
                                   .thenComparing(o -> String.valueOf(o.kind())))

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/GranularIndexEndToEndTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/GranularIndexEndToEndTest.java
@@ -26,6 +26,56 @@ class GranularIndexEndToEndTest {
         VibeTagsLogger.shutdown();
     }
 
+    /**
+     * The index lists owners in a stable order regardless of the order they were collected in
+     * (issue #325).
+     *
+     * <p>Owners reach {@code RenderingContext} in annotation-processing round order, which the JLS
+     * does not constrain and which differs between Maven and Gradle. Two builds of identical
+     * sources previously emitted the same {@code <element>} lines in a different sequence, so a
+     * project kept in lockstep across both build systems got a spurious diff every alternate build.
+     */
+    @Test
+    void granularOwnersAreOrderIndependent() {
+        var preset = owner("se.deversity.asynctest.Preset");
+        var site = owner("se.deversity.asynctest.diagnostics.SiteCapture.Site");
+        var junitXml = owner("se.deversity.asynctest.report.JUnitXmlReportListener");
+
+        java.util.List<String> collectedOneWay =
+            new java.util.ArrayList<>(orderOf(preset, site, junitXml));
+        java.util.List<String> collectedAnother =
+            new java.util.ArrayList<>(orderOf(junitXml, preset, site));
+
+        assertEquals(collectedOneWay, collectedAnother,
+            "the scoped-rules index must not depend on annotation-processing round order");
+        assertEquals(java.util.List.of(
+                "se.deversity.asynctest.Preset",
+                "se.deversity.asynctest.diagnostics.SiteCapture.Site",
+                "se.deversity.asynctest.report.JUnitXmlReportListener"),
+            collectedOneWay,
+            "owners are ordered by their stable path identity");
+    }
+
+    /** A minimal owner-level TaggedElement identified by {@code path}. */
+    private static se.deversity.vibetags.processor.model.TaggedElement owner(String path) {
+        String simple = path.substring(path.lastIndexOf('.') + 1);
+        return se.deversity.vibetags.processor.model.TaggedElement.builder(path)
+            .names(path, simple, simple, path.replace('.', '-'))
+            .kind(se.deversity.vibetags.processor.model.ElementTag.CLASS)
+            .build();
+    }
+
+    /** Paths of a RenderingContext's granular owners, in the order the index would emit them. */
+    private static java.util.List<String> orderOf(
+            se.deversity.vibetags.processor.model.TaggedElement... owners) {
+        var ctx = new se.deversity.vibetags.processor.internal.content.RenderingContext(
+            "P", "h", java.util.Set.of("claude", "claude_granular"), 1024,
+            new java.util.LinkedHashSet<>(java.util.Arrays.asList(owners)));
+        return ctx.granularOwners().stream()
+            .map(se.deversity.vibetags.processor.model.TaggedElement::path)
+            .toList();
+    }
+
     /** Two owners covering an always-inline bucket (locked, privacy) and an indexed one (context, contract). */
     private static void addMixedSources(ProcessorTestHarness h) {
         h.addSource("com.example.Gateway",

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/GranularSectionsTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/GranularSectionsTest.java
@@ -191,6 +191,47 @@ class GranularSectionsTest {
             "a sentence with no singular self-reference must pass through untouched");
     }
 
+    // ------------------------------------------------------------------
+    // Determinism: output must not depend on the order stanzas arrive in (issue #325)
+    // ------------------------------------------------------------------
+
+    /**
+     * Stanzas arrive in annotation-processing round order, which the JLS does not constrain and
+     * which differs between Maven and Gradle. Rendering the same set in two different arrival
+     * orders must produce byte-identical output, or a project that builds with both gets a
+     * spurious diff on every alternate build.
+     */
+    @Test
+    void renderIsIndependentOfStanzaArrivalOrder() {
+        Element owner = type("com.example.Reports");
+        TaggedElement junitXml = field(owner, "JUnitXmlReportListener");
+        TaggedElement json = field(owner, "JsonReportListener");
+
+        String forwards = GranularSections.render(
+            List.of(privacy(owner, junitXml, "same"), privacy(owner, json, "same")), false);
+        String backwards = GranularSections.render(
+            List.of(privacy(owner, json, "same"), privacy(owner, junitXml, "same")), false);
+
+        assertEquals(forwards, backwards,
+            "identical stanzas in a different arrival order must render byte-identically");
+    }
+
+    /** The same guarantee for the qualified (role/topic) layout, whose headings carry full paths. */
+    @Test
+    void qualifiedRenderIsIndependentOfStanzaArrivalOrder() {
+        Element owner = type("com.example.Reports");
+        TaggedElement junitXml = field(owner, "JUnitXmlReportListener");
+        TaggedElement json = field(owner, "JsonReportListener");
+
+        String forwards = GranularSections.render(
+            List.of(privacy(owner, junitXml, "one"), privacy(owner, json, "two")), true);
+        String backwards = GranularSections.render(
+            List.of(privacy(owner, json, "two"), privacy(owner, junitXml, "one")), true);
+
+        assertEquals(forwards, backwards,
+            "qualified layout must also be a pure function of the stanza set, not its order");
+    }
+
     private static int count(String haystack, String needle) {
         int n = 0;
         for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) {


### PR DESCRIPTION
Closes #325.

## The cause

Both emitters iterated elements in the order the processor accumulated them, which follows javac's annotation-processing round order. That order is not constrained by the JLS and differs between build systems — `maven-compiler-plugin` and Gradle's worker-based compilation feed javac different source orderings — so Maven and Gradle produced **byte-different files from identical sources**.

In a project that keeps both builds in lockstep, running one after the other dirtied the working tree with a diff containing no actual change, only reordered lines. That isn't free: these files are committed and read by humans and agents, so recurring no-op churn trains reviewers to skim guardrail diffs — exactly the diffs that should not be skimmed.

## The fix

Two places, both fixed **at the source** rather than at each call site.

**`RenderingContext`** now stores `granularOwners` sorted by the stable `path()` identity, with `kind()` as a tiebreak since equality is `path + kind`:

```diff
-        this.granularOwners = Collections.unmodifiableSet(new LinkedHashSet<>(granularOwners));
+        LinkedHashSet<TaggedElement> sortedOwners = new LinkedHashSet<>();
+        granularOwners.stream()
+                .sorted(Comparator.comparing(TaggedElement::path)
+                                  .thenComparing(o -> String.valueOf(o.kind())))
+                .forEach(sortedOwners::add);
+        this.granularOwners = Collections.unmodifiableSet(sortedOwners);
```

Sorting in the constructor rather than inside `GranularIndexSection` means every current and future consumer of `granularOwners()` is deterministic by construction — the `<element>` lines of the `<scoped_rules>` index are only the first of them.

**`GranularSections.render`** sorts each section's stanzas by element path immediately after grouping by title:

```diff
+        for (List<GranularBody.Entry> group : byTitle.values()) {
+            group.sort(Comparator.comparing(e -> e.element().path()));
+        }
```

One sort covers all three layouts it dispatches to, so the multi-target `Applies to` list, the qualified role/topic headings and the plain per-class blocks all become order-independent together — rather than fixing only the one shape the issue happened to show.

**Section order is deliberately left alone.** It follows the fixed annotation-type order the collector walks, not a round-dependent one, so sorting it would churn output without fixing anything.

## Tests

Three added, each verified to **fail on the unpatched code** and pass with the fix:

| test | pins |
|---|---|
| `GranularSectionsTest.renderIsIndependentOfStanzaArrivalOrder` | same stanzas, different arrival order → byte-identical render |
| `GranularSectionsTest.qualifiedRenderIsIndependentOfStanzaArrivalOrder` | the same for the qualified role/topic layout |
| `GranularIndexEndToEndTest.granularOwnersAreOrderIndependent` | a `RenderingContext` exposes the same owner sequence however owners were collected, and that sequence is sorted by path |

Reverting just the two production files and re-running:

```
GranularSectionsTest.qualifiedRenderIsIndependentOfStanzaArrivalOrder  <<< FAILURE!
GranularSectionsTest.renderIsIndependentOfStanzaArrivalOrder           <<< FAILURE!
GranularIndexEndToEndTest.granularOwnersAreOrderIndependent            <<< FAILURE!
```

Full suite with the fix: **1269 tests, 0 failures, 0 errors, 0 skipped.**

## Note for downstream

async-test-lib currently documents this as "known cosmetic churn" in its root `CLAUDE.md`, pointing at #325. Once this ships, that note can be deleted — tracked alongside [async-test-lib#179](https://github.com/PIsberg/async-test-lib/pull/179).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eYCEBnv3mygp6VDzL9uY6
