### PR TITLE
fix(ci): stop the release workflow reporting failed deploys as successful

### DIFF
--- a/.github/scripts/deploy-to-central.sh
+++ b/.github/scripts/deploy-to-central.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Deploy one module to Maven Central, and exit non-zero when that genuinely failed.
+#
+# This replaces three inline copies of the same block, all of which shared one bug:
+#
+#     if mvn clean deploy ... 2>&1 | tee "$log"; then echo "deployed."
+#
+# `if` tests the exit status of the *pipeline*, which is tee's, and tee always
+# succeeds — so Maven's status was never read, and neither the "already exists"
+# branch nor the failure branch could ever be reached. A transient
+# central.sonatype.com timeout on 2026-08-01 therefore published
+# vibetags-processor and vibetags-bom 1.0.0-RC8 but not vibetags-annotations,
+# while the run reported success. Any consumer pinning 1.0.0-RC8 could not resolve.
+#
+# Usage: deploy-to-central.sh <module-dir> <artifact-name> [extra mvn args...]
+
+set -uo pipefail
+
+module="${1:?module directory required}"
+name="${2:?artifact name required}"
+shift 2
+
+# Overridable so the retry path can be exercised without waiting on real backoff.
+attempts="${CENTRAL_DEPLOY_ATTEMPTS:-3}"
+backoff_step="${CENTRAL_DEPLOY_BACKOFF_SECONDS:-30}"
+
+cd "$module" || exit 1
+
+for attempt in $(seq 1 "$attempts"); do
+  log="$(mktemp)"
+
+  mvn clean deploy -P central-publish,sign-artifacts -B "$@" 2>&1 | tee "$log"
+  status="${PIPESTATUS[0]}"
+
+  if [ "$status" -eq 0 ]; then
+    echo "$name: deployed."
+    exit 0
+  fi
+
+  # Re-publishing an unchanged version is not a failure — the release workflow is
+  # expected to be re-runnable.
+  if grep -q "already exists" "$log"; then
+    echo "::warning title=Already published::$name already exists on Maven Central — treating as success (idempotent re-publish)."
+    exit 0
+  fi
+
+  # Transport failures reaching the portal say nothing about the artifact, so
+  # retry them rather than leaving the release half-published.
+  if [ "$attempt" -lt "$attempts" ] &&
+     grep -qiE "Connection timed out|Connection reset|Read timed out|connect timed out|502 Bad Gateway|503 Service Unavailable|504 Gateway" "$log"; then
+    backoff=$((attempt * backoff_step))
+    echo "::warning title=Transient failure::$name deploy attempt ${attempt}/${attempts} failed on a transport error; retrying in ${backoff}s."
+    sleep "$backoff"
+    continue
+  fi
+
+  echo "::error title=Deploy failed::$name deploy failed (mvn exit ${status}) on attempt ${attempt}/${attempts} — see the Maven output above."
+  exit 1
+done
+
+echo "::error title=Deploy failed::$name deploy failed after ${attempts} attempts."
+exit 1

--- a/.github/scripts/deploy-to-central.test.sh
+++ b/.github/scripts/deploy-to-central.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Exercise deploy-to-central.sh against stub `mvn` behaviours.
+#
+# The case that matters is "hard failure -> exit 1". The inline blocks this script
+# replaced piped Maven into tee and tested the pipeline's status, so a failed
+# deploy was reported as a successful one — which is how 1.0.0-RC8 shipped without
+# vibetags-annotations while the release run showed green. Run against the old
+# code, this suite fails 3 of 5.
+#
+# Usage: deploy-to-central.test.sh [path-to-deploy-to-central.sh]
+set -u
+
+SCRIPT="${1:-$(cd "$(dirname "$0")" && pwd)/deploy-to-central.sh}"
+case "$SCRIPT" in
+  /*) ;;
+  *) SCRIPT="$(cd "$(dirname "$SCRIPT")" && pwd)/$(basename "$SCRIPT")" ;;
+esac
+
+TMP="$(mktemp -d)"
+mkdir -p "$TMP/bin" "$TMP/modA"
+export PATH="$TMP/bin:$PATH"
+export CENTRAL_DEPLOY_ATTEMPTS=3
+export CENTRAL_DEPLOY_BACKOFF_SECONDS=0
+
+pass=0
+fail=0
+
+check() { # name expected_exit expected_grep
+  local name="$1" want="$2" needle="$3"
+  local out rc
+  out="$(cd "$TMP" && bash "$SCRIPT" modA test-artifact 2>&1)"; rc=$?
+  if [ "$rc" -eq "$want" ] && printf '%s' "$out" | grep -q "$needle"; then
+    echo "PASS  $name (exit $rc)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  $name — exit=$rc want=$want; output:"
+    printf '%s\n' "$out" | sed 's/^/        /'
+    fail=$((fail + 1))
+  fi
+}
+
+# 1. clean success
+cat > "$TMP/bin/mvn" <<'EOF'
+#!/usr/bin/env bash
+echo "[INFO] BUILD SUCCESS"
+exit 0
+EOF
+chmod +x "$TMP/bin/mvn"
+check "success -> deployed" 0 "test-artifact: deployed."
+
+# 2. a real failure must NOT be reported as success (the bug this script fixes)
+cat > "$TMP/bin/mvn" <<'EOF'
+#!/usr/bin/env bash
+echo "[ERROR] Deployment failed while publishing"
+echo "[INFO] BUILD FAILURE"
+exit 1
+EOF
+check "hard failure -> exit 1" 1 "::error title=Deploy failed"
+
+# 3. re-publishing an already-published version stays green
+cat > "$TMP/bin/mvn" <<'EOF'
+#!/usr/bin/env bash
+echo "[ERROR] component already exists in the repository"
+exit 1
+EOF
+check "already exists -> success" 0 "::warning title=Already published"
+
+# 4. a transient transport error is retried rather than half-publishing the release
+cat > "$TMP/bin/mvn" <<'EOF'
+#!/usr/bin/env bash
+n_file="${TMPDIR:-/tmp}/deploy-attempt-count"
+n=$(cat "$n_file" 2>/dev/null || echo 0)
+n=$((n + 1)); echo "$n" > "$n_file"
+if [ "$n" -lt 2 ]; then
+  echo "java.lang.RuntimeException: Invalid request. Connect to https://central.sonatype.com:443 failed: Connection timed out"
+  exit 1
+fi
+echo "[INFO] BUILD SUCCESS"
+exit 0
+EOF
+rm -f "${TMPDIR:-/tmp}/deploy-attempt-count"
+check "transient -> retry -> deployed" 0 "test-artifact: deployed."
+
+# 5. a permanently unreachable portal fails instead of looping
+cat > "$TMP/bin/mvn" <<'EOF'
+#!/usr/bin/env bash
+echo "Connection timed out"
+exit 1
+EOF
+check "persistent transient -> exit 1" 1 "::error title=Deploy failed"
+
+echo
+echo "passed=$pass failed=$fail"
+[ "$fail" -eq 0 ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,6 +239,10 @@ jobs:
         with:
           working-directory: example
 
+      - name: Verify the Central deploy script reports failures
+        if: matrix.java == '21'
+        run: bash .github/scripts/deploy-to-central.test.sh
+
       - name: Upload coverage to Codecov
         if: matrix.java == '21'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,48 +41,24 @@ jobs:
 
       - name: Sign and deploy annotations to Maven Central
         run: |
-          cd vibetags-annotations
-          log="$(mktemp)"
-          if mvn clean deploy -P central-publish,sign-artifacts -B -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}" 2>&1 | tee "$log"; then
-            echo "annotations: deployed."
-          elif grep -q "already exists" "$log"; then
-            echo "::warning title=Already published::vibetags-annotations already exists on Maven Central — treating as success (idempotent re-publish)."
-          else
-            echo "::error title=Deploy failed::annotations deploy failed for a reason other than an already-published component."
-            exit 1
-          fi
+          bash .github/scripts/deploy-to-central.sh vibetags-annotations vibetags-annotations \
+            -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
         env:
           CENTRAL_TOKEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
           CENTRAL_TOKEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
 
       - name: Build, sign, and deploy processor to Maven Central
         run: |
-          cd vibetags
-          log="$(mktemp)"
-          if mvn clean deploy -P central-publish,sign-artifacts -B -DskipTests -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}" 2>&1 | tee "$log"; then
-            echo "processor: deployed."
-          elif grep -q "already exists" "$log"; then
-            echo "::warning title=Already published::vibetags-processor already exists on Maven Central — treating as success (idempotent re-publish)."
-          else
-            echo "::error title=Deploy failed::processor deploy failed for a reason other than an already-published component."
-            exit 1
-          fi
+          bash .github/scripts/deploy-to-central.sh vibetags vibetags-processor -DskipTests \
+            -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
         env:
           CENTRAL_TOKEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
           CENTRAL_TOKEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
 
       - name: Sign and deploy BOM to Maven Central
         run: |
-          cd vibetags-bom
-          log="$(mktemp)"
-          if mvn clean deploy -P central-publish,sign-artifacts -B -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}" 2>&1 | tee "$log"; then
-            echo "bom: deployed."
-          elif grep -q "already exists" "$log"; then
-            echo "::warning title=Already published::vibetags-bom already exists on Maven Central — treating as success (idempotent re-publish)."
-          else
-            echo "::error title=Deploy failed::bom deploy failed for a reason other than an already-published component."
-            exit 1
-          fi
+          bash .github/scripts/deploy-to-central.sh vibetags-bom vibetags-bom \
+            -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
         env:
           CENTRAL_TOKEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
           CENTRAL_TOKEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The release workflow reported a failed deploy as a successful one.** Each of the three deploy
+  steps ran `if mvn clean deploy ... 2>&1 | tee "$log"; then echo "deployed."`, and `if` tests the
+  exit status of the *pipeline* — which is tee's, and tee always succeeds. Maven's status was never
+  read, so neither the `already exists` branch nor the failure branch could be reached by anything.
+  On 2026-08-01 a transient `Connection timed out` to `central.sonatype.com` killed the annotations
+  deploy after a nine-minute upload; the run went green and 1.0.0-RC8 published `vibetags-processor`
+  and `vibetags-bom` but not `vibetags-annotations`, so every consumer pinning that version failed to
+  resolve. The three copies are now one `.github/scripts/deploy-to-central.sh`, which reads Maven's
+  status via `PIPESTATUS`, still tolerates an already-published component, and retries transport
+  errors with backoff instead of leaving a release half-published.
+  `.github/scripts/deploy-to-central.test.sh` covers all five outcomes against a stub `mvn` and runs
+  in CI; against the old inline code it fails three of them.
+
 ## [1.0.0-RC8] - 2026-08-01
 
 ### Added


### PR DESCRIPTION
## What happened

`v1.0.0-RC8` is **half-published**. `vibetags-processor` and `vibetags-bom` are on Maven Central; `vibetags-annotations` is not — its metadata still reads `<release>1.0.0-RC7</release>`. Any consumer pinning `1.0.0-RC8` fails to resolve, because annotations is a `compileOnly`/`provided` dependency.

The publish run reported **success**.

## Why

All three deploy steps shared one line:

```bash
if mvn clean deploy -P central-publish,sign-artifacts -B ... 2>&1 | tee "$log"; then
  echo "annotations: deployed."
```

`if` tests the exit status of the *pipeline*, which is `tee`'s — and `tee` always succeeds. Maven's status was never read, so neither the `elif grep -q "already exists"` branch nor the `else` failure branch could be reached by anything at all.

The actual failure was transient, and would have been fine on a retry:

```
[ERROR] Unable to upload bundle for deployment: Deployment
java.lang.RuntimeException: Invalid request. Connect to https://central.sonatype.com:443 ... failed: Connection timed out
[INFO] BUILD FAILURE   (Total time: 09:14 min)
annotations: deployed.          <- printed anyway
```

## The fix

The three identical copies become one `.github/scripts/deploy-to-central.sh`, which:

- reads Maven's real status via `PIPESTATUS` while still teeing the log;
- keeps the already-published tolerance, so the workflow stays re-runnable;
- retries transport errors (timeouts, resets, 502/503/504) with backoff, rather than leaving a release half-published;
- fails loudly otherwise.

Three copies of one block is also how a single bug came to exist in three places, so collapsing them is part of the fix.

## Verification

`.github/scripts/deploy-to-central.test.sh` drives the script against a stub `mvn` covering all five outcomes, and runs in CI on the JDK 21 matrix leg:

```
PASS  success -> deployed (exit 0)
PASS  hard failure -> exit 1 (exit 1)
PASS  already exists -> success (exit 0)
PASS  transient -> retry -> deployed (exit 0)
PASS  persistent transient -> exit 1 (exit 1)
passed=5 failed=0
```

Run against the **old** inline block, the same suite fails 3 of 5 — so it genuinely pins the bug rather than passing for the wrong reason.

## Still to do, separately

`vibetags-annotations:1.0.0-RC8` still needs to land on Central. A re-run of the release workflow is in flight; this PR does not itself republish anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153QiTQsRQEikh9pHa5zrpC