### PR TITLE
Add Find Security Bugs to the SpotBugs gate, and keep vibetags.log to one event per line

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 [![PMD](https://img.shields.io/badge/PMD-passing-brightgreen)](https://pmd.github.io/)
 [![Analyzed with codekoll](https://img.shields.io/badge/analyzed%20with-codekoll-brightgreen?logo=java&logoColor=white)](https://github.com/PIsberg/codekoll)
 [![SpotBugs](https://img.shields.io/badge/SpotBugs-passing-brightgreen)](https://spotbugs.github.io/)
+[![Find Security Bugs](https://img.shields.io/badge/Find%20Security%20Bugs-passing-brightgreen)](https://find-sec-bugs.github.io/)
 [![Error Prone](https://img.shields.io/badge/Error%20Prone-passing-brightgreen)](https://errorprone.info/)
 [![NullAway](https://img.shields.io/badge/NullAway-passing-brightgreen)](https://github.com/uber/NullAway)
 [![Checkstyle](https://img.shields.io/badge/Checkstyle-passing-brightgreen)](https://checkstyle.org/)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -78,7 +78,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the code they pin — marker handling disabled, and `save()` writing non-atomically to the live
   target.
 
+- **Find Security Bugs joins the SpotBugs gate.** `findsecbugs-plugin` 1.14.0 adds its security
+  detectors to the existing `spotbugs-maven-plugin` run. The first run reported 94 findings, 60 of
+  them `POTENTIAL_XML_INJECTION` on formatter lines that already call `Escape.xml` — the taint
+  analysis had no way to know that method sanitizes. Rather than excluding the package, the four
+  escapers (`Escape.xml`, `Escape.json`, `Escape.tomlMultiline`,
+  `CommonFormatterHelper.claudeReason`) are declared `SAFE` in `vibetags/findsecbugs-taint-config.txt`,
+  loaded through the plugin's `<jvmArgs>`. That leaves the detector live: deleting the `Escape.xml`
+  call from `AILockedFormatter`'s Claude branch was confirmed to fail the build with exactly one
+  `POTENTIAL_XML_INJECTION` at that line.
+
+  The remaining 12 findings are excluded per method in `spotbugs-exclude.xml`, each with the
+  reason: `PATH_TRAVERSAL_IN` on the six sites that resolve `-Avibetags.root` / `-Avibetags.log.path`
+  or a path composed from them (redirecting output is the documented feature, and setting a
+  compiler option already means controlling the compilation), and `IMPROPER_UNICODE` on the four
+  that parse `"true"` / `"false"` / `"OFF"` build options and lower-case config keys, none of which
+  is an authorization decision. Listing them per method rather than per pattern keeps a *new*
+  path-from-input or case-insensitive comparison reportable.
+
 ### Fixed
+- **A line break in a logged value split one event into several lines in `vibetags.log`.**
+  The log is meant to be read with grep — `domain.event key=value`, one event per line — but the
+  values interpolated into it come from outside the processor: module ids and roots taken from
+  compiler options, paths read back out of sidecar and baseline files. Any CR or LF in one of them
+  ended the line early, and the tail was indistinguishable from a separate event (`CRLF_INJECTION_LOGS`,
+  22 call sites). Fixed once in the Logback encoder rather than at each call site: the pattern in
+  `VibeTagsLogger.forRoot` now wraps `%msg` in `%replace(...){'[\r\n]+', ' '}`, so the value still
+  appears in full and the event stays on one line whatever it contains.
+  `VibeTagsLoggerUnitTest#logMessageWithLineBreaks_staysOnOneLine` pins it and was confirmed red
+  before the change (3 lines written for one event).
 - **Generated output depended on the order javac enumerated the sources in.**
   `RoundEnvironment.getElementsAnnotatedWith` returns a `Set` with no specified iteration order;
   javac fills it by walking the round's root elements, which is the order the file manager handed

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -93,6 +93,30 @@ mvnd -o test -Dtest=WriteCacheProcessorIntegrationTest -Djacoco.skip=true
 
 `mvnd` is purely a local convenience; CI and the published build still use `mvn`.
 
+### The security gate
+
+SpotBugs runs with [Find Security Bugs](https://find-sec-bugs.github.io/) attached
+(`vibetags/pom.xml`), at `verify`. Run it on its own with:
+
+```bash
+cd vibetags && mvn -o compile spotbugs:check
+```
+
+Two files govern what it says:
+
+- `vibetags/findsecbugs-taint-config.txt` declares the escapers (`Escape.xml`, `Escape.json`,
+  `Escape.tomlMultiline`, `CommonFormatterHelper.claudeReason`) as sanitizers, so escaped
+  interpolation is not reported. The format is one `class/Name.method(sig)ret:SAFE` per line and
+  **comments are not supported** — a `#` line aborts the analysis with `Line format is not 'type
+  signature:config info'` (blank lines are fine). Rename or move one of those methods and the entry
+  has to move with it.
+- `vibetags/spotbugs-exclude.xml` holds the exclusions, each with the reason it is not a bug.
+
+`POTENTIAL_XML_INJECTION` on a formatter means a value reaches the `CLAUDE.md` XML block without
+`Escape.xml` — that is the detector working, so escape the value rather than excluding the class.
+When an exclusion really is right, scope it to the method, so the next occurrence elsewhere is
+still reported.
+
 ## How to Contribute
 
 ### Reporting Bugs

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -30,7 +30,7 @@ Matrix over **JDK 21, 25, 26** (Temurin distribution, Maven dependency cache). J
 2. **Checkout**.
 3. **Set up JDK** — installs Temurin and primes the `~/.m2/repository` cache keyed on `pom.xml`.
 4. **Install VibeTags Annotations** — `cd vibetags-annotations && mvn install -B`. Installs the zero-dependency annotations jar into the local Maven repo first, because `vibetags/pom.xml` declares it as a regular `<dependency>`.
-5. **Build VibeTags Library** — `cd vibetags && mvn clean install -B`. Compiles the annotation processor, runs unit tests, and installs the artifact into the local Maven repo so the example project can resolve it. PMD, SpotBugs and CPD are JDK-independent, so they run only on the JDK 21 leg (`-Dmaven.pmd.skip=true -Dspotbugs.skip=true` is passed on the other JDKs) to avoid repeating identical analysis ~4×. Error Prone still runs on every JDK because it is a compiler plugin and is JDK-sensitive, and it
+5. **Build VibeTags Library** — `cd vibetags && mvn clean install -B`. Compiles the annotation processor, runs unit tests, and installs the artifact into the local Maven repo so the example project can resolve it. PMD, SpotBugs (with the Find Security Bugs detectors attached) and CPD are JDK-independent, so they run only on the JDK 21 leg (`-Dmaven.pmd.skip=true -Dspotbugs.skip=true` is passed on the other JDKs) to avoid repeating identical analysis ~4×. Error Prone still runs on every JDK because it is a compiler plugin and is JDK-sensitive, and it
 carries NullAway with it — nullability is checked at `ERROR` on every matrix JDK, so a
 `@Nullable` that stops being honoured fails the build rather than producing a warning nobody reads.
 

--- a/vibetags/findsecbugs-taint-config.txt
+++ b/vibetags/findsecbugs-taint-config.txt
@@ -1,0 +1,4 @@
+se/deversity/vibetags/processor/internal/content/Escape.xml(Ljava/lang/String;)Ljava/lang/String;:SAFE
+se/deversity/vibetags/processor/internal/content/Escape.json(Ljava/lang/String;)Ljava/lang/String;:SAFE
+se/deversity/vibetags/processor/internal/content/Escape.tomlMultiline(Ljava/lang/String;)Ljava/lang/String;:SAFE
+se/deversity/vibetags/processor/internal/content/annotations/CommonFormatterHelper.claudeReason(Ljava/lang/String;)Ljava/lang/String;:SAFE

--- a/vibetags/pom.xml
+++ b/vibetags/pom.xml
@@ -321,6 +321,19 @@
                     <includeTests>false</includeTests>
                     <failOnError>true</failOnError>
                     <excludeFilterFile>${project.basedir}/spotbugs-exclude.xml</excludeFilterFile>
+                    <!-- Find Security Bugs: adds ~140 security detectors (injection, crypto,
+                         path traversal, XXE, deserialization) on top of the SpotBugs core set. -->
+                    <plugins>
+                        <plugin>
+                            <groupId>com.h3xstream.findsecbugs</groupId>
+                            <artifactId>findsecbugs-plugin</artifactId>
+                            <version>1.14.0</version>
+                        </plugin>
+                    </plugins>
+                    <!-- Teaches the taint analysis that Escape.xml/json/tomlMultiline sanitize.
+                         Without it every escaped interpolation is reported as an injection, and
+                         the detector stops being able to point at a genuinely unescaped one. -->
+                    <jvmArgs>-Dfindsecbugs.taint.customconfigfile=${project.basedir}/findsecbugs-taint-config.txt</jvmArgs>
                 </configuration>
                 <executions>
                     <execution>

--- a/vibetags/spotbugs-exclude.xml
+++ b/vibetags/spotbugs-exclude.xml
@@ -81,4 +81,85 @@
     <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
   </Match>
 
+  <!-- ==================================================================================
+       Find Security Bugs (findsecbugs-plugin). Escaped interpolation is NOT excluded here:
+       Escape.xml / Escape.json / Escape.tomlMultiline and CommonFormatterHelper.claudeReason
+       are declared as sanitizers in findsecbugs-taint-config.txt, so POTENTIAL_XML_INJECTION
+       stays live and an unescaped append into the CLAUDE.md XML block still fails the build.
+       ================================================================================== -->
+
+  <!-- CRLF_INJECTION_LOGS: mitigated centrally rather than per call site. The Logback
+       encoder in VibeTagsLogger.forRoot wraps %msg in %replace(...){'[\r\n]+', ' '}, so no
+       interpolated value can split an event across lines whatever it contains. The detector
+       reads the SLF4J call sites and cannot see the layout that neutralises them.
+       Pinned by VibeTagsLoggerUnitTest#logMessageWithLineBreaks_staysOnOneLine — if that
+       test is deleted, this exclusion is no longer earned. -->
+  <Match>
+    <Bug pattern="CRLF_INJECTION_LOGS"/>
+  </Match>
+
+  <!-- PATH_TRAVERSAL_IN: listed per method, not project-wide, so a NEW path built from
+       input is still reported. Every site below is the processor going where the build told
+       it to go: -Avibetags.root and -Avibetags.log.path are documented as absolute-capable
+       (redirecting output is the feature), and the remaining three resolve paths the
+       processor itself composed from that root plus a constant file name. Whoever sets a
+       compiler option already controls the compilation. -->
+  <Match>
+    <Class name="se.deversity.vibetags.processor.AIGuardrailProcessor"/>
+    <Method name="init"/>
+    <Bug pattern="PATH_TRAVERSAL_IN"/>
+  </Match>
+  <Match>
+    <Class name="se.deversity.vibetags.processor.AIGuardrailProcessor"/>
+    <Method name="checkFiles"/>
+    <Bug pattern="PATH_TRAVERSAL_IN"/>
+  </Match>
+  <Match>
+    <Class name="se.deversity.vibetags.processor.VibeTagsLogger"/>
+    <Method name="resolveLogFile"/>
+    <Bug pattern="PATH_TRAVERSAL_IN"/>
+  </Match>
+  <Match>
+    <Class name="se.deversity.vibetags.processor.internal.GuardrailFileWriter"/>
+    <Method name="writeFileIfChanged"/>
+    <Bug pattern="PATH_TRAVERSAL_IN"/>
+  </Match>
+  <Match>
+    <Class name="se.deversity.vibetags.processor.internal.ModuleRootResolver"/>
+    <Method name="directoryOf"/>
+    <Bug pattern="PATH_TRAVERSAL_IN"/>
+  </Match>
+  <Match>
+    <Class name="se.deversity.vibetags.processor.internal.WriteCache"/>
+    <Method name="loadIfNeeded"/>
+    <Bug pattern="PATH_TRAVERSAL_IN"/>
+  </Match>
+
+  <!-- IMPROPER_UNICODE: the flagged comparisons parse build configuration — the "true" /
+       "false" / "OFF" processor options and the lower-cased keys of .vibetags-mirror and
+       the enforce-families option. None of them is an authorization decision, so Unicode
+       case-folding collisions can only make somebody's own build flag parse the way they
+       spelled it. Case folding that does matter already passes Locale.ROOT explicitly.
+       Listed per method so a new case-insensitive comparison is still reported. -->
+  <Match>
+    <Class name="se.deversity.vibetags.processor.AIGuardrailProcessor"/>
+    <Method name="init"/>
+    <Bug pattern="IMPROPER_UNICODE"/>
+  </Match>
+  <Match>
+    <Class name="se.deversity.vibetags.processor.VibeTagsLogger"/>
+    <Method name="forRoot"/>
+    <Bug pattern="IMPROPER_UNICODE"/>
+  </Match>
+  <Match>
+    <Class name="se.deversity.vibetags.processor.internal.GuardrailEnforcer"/>
+    <Method name="parseFamilies"/>
+    <Bug pattern="IMPROPER_UNICODE"/>
+  </Match>
+  <Match>
+    <Class name="se.deversity.vibetags.processor.internal.MirrorConfig"/>
+    <Method name="stripGlobKey"/>
+    <Bug pattern="IMPROPER_UNICODE"/>
+  </Match>
+
 </FindBugsFilter>

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/VibeTagsLogger.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/VibeTagsLogger.java
@@ -188,7 +188,13 @@ public final class VibeTagsLogger {
 
             PatternLayoutEncoder encoder = new PatternLayoutEncoder();
             encoder.setContext(context);
-            encoder.setPattern("%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %msg%n");
+            // %replace collapses CR/LF inside the formatted message: the log is an event
+            // stream read with grep, one event per line, and values interpolated into it come
+            // from outside (compiler options, module ids, paths read back out of sidecar and
+            // baseline files). A line break in one of those would split an event in two and
+            // let the tail masquerade as a separate event. Pinned by
+            // VibeTagsLoggerUnitTest#logMessageWithLineBreaks_staysOnOneLine.
+            encoder.setPattern("%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %replace(%msg){'[\\r\\n]+', ' '}%n");
             encoder.start();
 
             FileAppender<ILoggingEvent> appender = new FileAppender<>();

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/Escape.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/Escape.java
@@ -7,6 +7,11 @@ package se.deversity.vibetags.processor.internal.content;
  *
  * <p>Markdown / plain-text platforms (e.g. {@code .cursorrules}) intentionally do <em>not</em> use
  * these — their content is free text and there is no structure to break.
+ *
+ * <p>These three methods are declared as taint sanitizers in
+ * {@code vibetags/findsecbugs-taint-config.txt}, which is what keeps Find Security Bugs reporting
+ * an <em>unescaped</em> interpolation instead of all of them. Renaming or moving one means editing
+ * that file in the same change — its entries are matched by fully qualified name and signature.
  */
 public final class Escape {
 

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/VibeTagsLoggerUnitTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/VibeTagsLoggerUnitTest.java
@@ -89,6 +89,27 @@ class VibeTagsLoggerUnitTest {
             "OFF for root B must not detach root A's appender — root A's messages were silently lost");
     }
 
+    // --- one event per line ---
+
+    @Test
+    void logMessageWithLineBreaks_staysOnOneLine() throws Exception {
+        // The log is a machine-greppable event stream: `domain.event key=value`, one event
+        // per line. A value carrying CR/LF (a module id or root path taken from a compiler
+        // option, a path read out of .vibetags-baseline) would otherwise split one event
+        // across several lines and could forge an entry that looks like a separate event.
+        Logger logger = VibeTagsLogger.forRoot(tempDir, null, "INFO");
+
+        logger.info("write.skip file={} reason=cache-unchanged", "a\nERROR forged.event injected=true\nb");
+
+        VibeTagsLogger.shutdown(tempDir);
+        java.util.List<String> lines = Files.readAllLines(tempDir.resolve(VibeTagsLogger.DEFAULT_LOG_FILE));
+
+        assertEquals(1, lines.size(),
+            "a value containing CR/LF must not split the event across lines, got: " + lines);
+        assertTrue(lines.get(0).contains("forged.event"),
+            "sanity: the value itself must survive, only its line breaks are collapsed");
+    }
+
     // --- resolveLogFile: relative path ---
 
     @Test


### PR DESCRIPTION
`findsecbugs-plugin` 1.14.0 attaches its security detectors to the SpotBugs run that already gates the build. First run: **94 findings**.

## 60 × POTENTIAL_XML_INJECTION — false positives, resolved without an exclusion

Every one landed on a formatter line that already calls `Escape.xml`; the taint analysis had no way to know that method sanitizes. Excluding the package would have bought a green build at the cost of the detector — it would then also stay quiet about a genuinely unescaped append into the `CLAUDE.md` XML block, which is the one thing worth catching there.

Instead the four escapers (`Escape.xml`, `Escape.json`, `Escape.tomlMultiline`, `CommonFormatterHelper.claudeReason`) are declared `SAFE` in `vibetags/findsecbugs-taint-config.txt`, loaded through the plugin's `<jvmArgs>`.

**Verified the gate still bites:** deleting the `Escape.xml` call from `AILockedFormatter`'s Claude branch fails the build with exactly one `POTENTIAL_XML_INJECTION` at that line. Reverted after the check.

## 22 × CRLF_INJECTION_LOGS — a real defect, fixed

`vibetags.log` is meant to be read with grep (`domain.event key=value`, one event per line), but the values interpolated into it come from outside the processor: module ids and roots taken from compiler options, paths read back out of sidecar and baseline files. A CR or LF in any of them ended the line early, and the tail was indistinguishable from a separate event.

Fixed once in the Logback encoder rather than at 22 call sites — `VibeTagsLogger.forRoot` now wraps `%msg` in `%replace(...){'[\r\n]+', ' '}`, so the value still appears in full and the event stays on one line.

`VibeTagsLoggerUnitTest#logMessageWithLineBreaks_staysOnOneLine` pins it, and was **confirmed red before the change** (3 lines written for one event).

## 12 × PATH_TRAVERSAL_IN / IMPROPER_UNICODE — excluded per method, with reasons

They resolve `-Avibetags.root` / `-Avibetags.log.path` (or a path composed from them), and parse the `"true"` / `"false"` / `"OFF"` build options and lower-cased config keys. None is an authorization decision, and whoever sets a compiler option already controls the compilation. Scoped per method rather than per pattern, so a *new* path-from-input or case-insensitive comparison is still reported.

## Docs

CHANGELOG (Added + Fixed), a "The security gate" section in `docs/CONTRIBUTING.md` (including that the taint-config format accepts no `#` comments — it aborts the analysis), the CI note in `docs/WORKFLOW.md`, a README badge, and a pointer in `Escape`'s javadoc so a rename takes the taint-config entry with it.

## Verification

- `mvn clean install` in `vibetags/`: 1365 tests, checkstyle, PMD, SpotBugs + FSB all green, 0 unexcluded findings.
- `pre-commit` was **not run** — not installed on this machine. `git diff --check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XFeu3yhCcKzW1jxBiYCAn