### PR TITLE
chore: prepare release v1.0.0-RC9

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.0.0-RC8
+version: 1.0.0-RC9
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.0-RC8</version>
+    <version>1.0.0-RC9</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.0-RC8'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC8'
+compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.0-RC9'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC9'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.0-RC8</version>
+            <version>1.0.0-RC9</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.0-RC8</version>
+                        <version>1.0.0-RC9</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -117,8 +117,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC8')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC8')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC9')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC9')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -360,7 +360,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.0-RC8</version>
+            <version>1.0.0-RC9</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -385,7 +385,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.0-RC8</version>
+                        <version>1.0.0-RC9</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -399,8 +399,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC8')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC8')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC9')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC9')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -414,15 +414,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.0-RC8</version>
+    <version>1.0.0-RC9</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC8'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC8'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC9'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC9'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-RC9] - 2026-08-02
+
 ### Added
 - **NullAway joins the static-analysis gate, at ERROR.** The codebase already annotated with
   JSpecify `@Nullable`; nothing checked it, so the annotations documented an intention rather than
@@ -130,6 +132,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mode (`-Dvibetags.selfcheck=true`) on the JDK 21 leg, so a stale committed guardrail file is a
   red build rather than something the next person to run the profile by hand discovers. Verified in
   both directions: the step passes on a clean tree and exits 1 on a deliberately edited `CLAUDE.md`.
+- **A sidecar that could not be read was deleted as if it were corrupt.** `load()` returned `null`
+  both for content that failed to parse and for a file it never managed to open, and `readAll()`
+  deletes on `null`. On Windows a sibling module's `save()` renames its sidecar into place, and a
+  concurrent reader's open fails with `AccessDeniedException` while that rename is in flight — so
+  the reader deleted a valid sibling's sidecar and took that module out of the merged output until
+  it recompiled. Failing to read a file is never evidence about its content: `load()` now returns
+  an `UNREADABLE` sentinel, which `readAll()` skips exactly as it already skips a future-version
+  sidecar, and only genuinely undecodable content is pruned. This is what
+  `ModuleSidecarAsyncTest` caught on the Windows CI runner after the save-side retry below was
+  already in place.
+- **A parallel reactor build on Windows could drop a whole module's guardrails.**
+  `ModuleSidecar.save()` writes a temp file and renames it over the live sidecar; Windows refuses
+  that rename while another process holds the target open, and `readAll()` in a sibling module's
+  compilation opens exactly that file. Under `mvn -T` or `gradle --parallel` the collision is
+  reachable, and it arrived as an `AccessDeniedException` that aborted the save — so the module's
+  entire contribution was missing from the merged output for that build, which is the failure the
+  sidecar exists to prevent. The rename now retries with a short backoff (10 attempts, ≈275 ms
+  worst case) before failing, since the reader's handle is open for microseconds. Found by the new
+  `ModuleSidecarAsyncTest`, which reproduces it in under a second on Windows; with the retry
+  removed it fails again.
+- **The release workflow reported a failed deploy as a successful one.** Each of the three deploy
+  steps ran `if mvn clean deploy ... 2>&1 | tee "$log"; then echo "deployed."`, and `if` tests the
+  exit status of the *pipeline* — which is tee's, and tee always succeeds. Maven's status was never
+  read, so neither the `already exists` branch nor the failure branch could be reached by anything.
+  On 2026-08-01 a transient `Connection timed out` to `central.sonatype.com` killed the annotations
+  deploy after a nine-minute upload; the run went green and 1.0.0-RC8 published `vibetags-processor`
+  and `vibetags-bom` but not `vibetags-annotations`, so every consumer pinning that version failed to
+  resolve. The three copies are now one `.github/scripts/deploy-to-central.sh`, which reads Maven's
+  status via `PIPESTATUS`, still tolerates an already-published component, and retries transport
+  errors with backoff instead of leaving a release half-published.
+  `.github/scripts/deploy-to-central.test.sh` covers all five outcomes against a stub `mvn` and runs
+  in CI; against the old inline code it fails three of them.
 
 ### Changed
 - **The build emits zero Error Prone warnings, and every silence is a decision.** It emitted 75.
@@ -181,40 +215,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `github.com/PIsberg/async-test-lib`, so the four `git clone --branch` steps in `build.yml`, the
   `pom.xml` pin, and the `build.gradle` pin all move together. Verified by building the artifact
   from that tag on JDK 21 (the version CI uses) and running the suite against it.
-
-### Fixed
-- **A sidecar that could not be read was deleted as if it were corrupt.** `load()` returned `null`
-  both for content that failed to parse and for a file it never managed to open, and `readAll()`
-  deletes on `null`. On Windows a sibling module's `save()` renames its sidecar into place, and a
-  concurrent reader's open fails with `AccessDeniedException` while that rename is in flight — so
-  the reader deleted a valid sibling's sidecar and took that module out of the merged output until
-  it recompiled. Failing to read a file is never evidence about its content: `load()` now returns
-  an `UNREADABLE` sentinel, which `readAll()` skips exactly as it already skips a future-version
-  sidecar, and only genuinely undecodable content is pruned. This is what
-  `ModuleSidecarAsyncTest` caught on the Windows CI runner after the save-side retry below was
-  already in place.
-- **A parallel reactor build on Windows could drop a whole module's guardrails.**
-  `ModuleSidecar.save()` writes a temp file and renames it over the live sidecar; Windows refuses
-  that rename while another process holds the target open, and `readAll()` in a sibling module's
-  compilation opens exactly that file. Under `mvn -T` or `gradle --parallel` the collision is
-  reachable, and it arrived as an `AccessDeniedException` that aborted the save — so the module's
-  entire contribution was missing from the merged output for that build, which is the failure the
-  sidecar exists to prevent. The rename now retries with a short backoff (10 attempts, ≈275 ms
-  worst case) before failing, since the reader's handle is open for microseconds. Found by the new
-  `ModuleSidecarAsyncTest`, which reproduces it in under a second on Windows; with the retry
-  removed it fails again.
-- **The release workflow reported a failed deploy as a successful one.** Each of the three deploy
-  steps ran `if mvn clean deploy ... 2>&1 | tee "$log"; then echo "deployed."`, and `if` tests the
-  exit status of the *pipeline* — which is tee's, and tee always succeeds. Maven's status was never
-  read, so neither the `already exists` branch nor the failure branch could be reached by anything.
-  On 2026-08-01 a transient `Connection timed out` to `central.sonatype.com` killed the annotations
-  deploy after a nine-minute upload; the run went green and 1.0.0-RC8 published `vibetags-processor`
-  and `vibetags-bom` but not `vibetags-annotations`, so every consumer pinning that version failed to
-  resolve. The three copies are now one `.github/scripts/deploy-to-central.sh`, which reads Maven's
-  status via `PIPESTATUS`, still tolerates an already-published component, and retries transport
-  errors with backoff instead of leaving a release half-published.
-  `.github/scripts/deploy-to-central.test.sh` covers all five outcomes against a stub `mvn` and runs
-  in CI; against the old inline code it fails three of them.
 
 ## [1.0.0-RC8] - 2026-08-01
 
@@ -1417,7 +1417,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC8...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC9...HEAD
+[1.0.0-RC9]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC8...v1.0.0-RC9
 [1.0.0-RC8]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC7...v1.0.0-RC8
 [1.0.0-RC7]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC6...v1.0.0-RC7
 [1.0.0-RC6]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC5...v1.0.0-RC6

--- a/example-multimodule-indexed/pom.xml
+++ b/example-multimodule-indexed/pom.xml
@@ -30,7 +30,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.0.0-RC8</vibetags.bom.version>
+    <vibetags.bom.version>1.0.0-RC9</vibetags.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/example-multimodule/pom.xml
+++ b/example-multimodule/pom.xml
@@ -29,7 +29,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.0.0-RC8</vibetags.bom.version>
+    <vibetags.bom.version>1.0.0-RC9</vibetags.bom.version>
   </properties>
 
   <dependencyManagement>

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC8')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC8')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC9')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC9')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.0.0-RC8</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0-RC9</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
     </properties>
 

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.0.0-RC8</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0-RC9</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.0-RC8'
+version = '1.0.0-RC9'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.0.0-RC8'
+            version = '1.0.0-RC9'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.0-RC8</version>
+    <version>1.0.0-RC9</version>
     <packaging>jar</packaging>
 
     <name>VibeTags Annotations</name>
@@ -23,12 +23,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.0.0-RC8&lt;/version&gt;
+                &lt;version&gt;1.0.0-RC9&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC8'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC8'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC9'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC9'
     </description>
     <url>https://github.com/PIsberg/vibetags</url>
 

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-bom</artifactId>
-    <version>1.0.0-RC8</version>
+    <version>1.0.0-RC9</version>
     <packaging>pom</packaging>
 
     <name>VibeTags BOM</name>
@@ -25,7 +25,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.0.0-RC8&lt;/version&gt;
+                        &lt;version&gt;1.0.0-RC9&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -33,8 +33,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC8')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC8')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC9')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC9')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>
@@ -66,7 +66,7 @@
         <!-- Single source of truth for the VibeTags artifact set. Bump this when releasing
              a new processor version; all consumers that import this BOM track the bump
              without further changes. -->
-        <vibetags.version>1.0.0-RC8</vibetags.version>
+        <vibetags.version>1.0.0-RC9</vibetags.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.0-RC8'
+version = '1.0.0-RC9'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.0.0-RC8'
+            version = '1.0.0-RC9'
             from components.java
 
             pom {
@@ -77,7 +77,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC8'
+    api 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC9'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.1'

--- a/vibetags/pom.xml
+++ b/vibetags/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.0-RC8</version>
+    <version>1.0.0-RC9</version>
     <packaging>jar</packaging>
 
     <name>VibeTags Processor</name>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-annotations</artifactId>
-            <version>1.0.0-RC8</version>
+            <version>1.0.0-RC9</version>
         </dependency>
 
         <!-- JSpecify null annotations (@NullMarked, @Nullable, @NonNull).


### PR DESCRIPTION
Prepares the `v1.0.0-RC9` release. Merging this does not publish anything — the GitHub release created afterwards against `main` is what triggers `publish.yml` and the Maven Central deploy.

## What this changes

`scripts/set-version.sh 1.0.0-RC9` bumped the three core modules (`vibetags-annotations`, `vibetags`, `vibetags-bom`). The consumers were updated by hand, because they track a *released* BOM version that only exists once this ships: `example/`, `example-multimodule/`, `example-multimodule-indexed/`, `tools/demo/`, `README.md`, and `.claude/skills/vibetags-usage/SKILL.md`.

Two things were deliberately **not** bumped:

- `load-tests/pom.xml` keeps its independent `<processor.version>` pin. The benchmarks exist to compare across versions; force-bumping it destroys the comparison.
- The two `Pre-1.0.0-RC8 processor` rows in the usage skill's troubleshooting table. They state when a fix landed, so rewriting them to `RC9` would make them false.

`docs/vibetags-in-practice.md` was also left alone: the versions in it are observations of other repositories from a field study, not pins.

## Changelog

`[Unreleased]` became `## [1.0.0-RC9] - 2026-08-02`, with a fresh empty `[Unreleased]` above it and the comparison links updated.

The section had accumulated **two separate `### Fixed` headings** across merges, which would have rendered as two Fixed blocks on the release page. They are merged into one. All 17 entries survive — verified by diffing the section before and after the move, which shows the block relocated and nothing else.

The release covers: NullAway at ERROR across the whole codebase including `@AILocked` code, seven new modern-Java detectors in `ModernJavaRules`, Find Security Bugs added to the SpotBugs gate, deterministic output regardless of javac's source enumeration order, the `AnnotationValidator` rewrite to a rule registry that costs one round query per annotation type, the sidecar `UNREADABLE` sentinel and rename retry that fix two Windows parallel-reactor data-loss paths, and the release workflow no longer reporting a failed deploy as a successful one.

## Verification

| Step | Result |
|---|---|
| `vibetags-annotations` install | pass |
| `vibetags` clean install (full suite + Error Prone, NullAway, SpotBugs, Find Security Bugs) | pass |
| `vibetags-bom` install | pass |
| `example` clean compile against the freshly installed BOM | pass |
| Processor actually ran during that compile | confirmed — `example/vibetags.log` written this run, every output `no changes` |
| Installed jar manifest | `Implementation-Version: 1.0.0-RC9` |
| `mvn compile -Pself-annotate` | no drift in the repo's own committed guardrails |
| pre-commit: gitleaks, end-of-file-fixer, trailing-whitespace | pass |
| pre-commit: **checkstyle** | **skipped, not passed** — the hook builds a Docker image and the local Docker daemon was not running. CI runs it. |

Maven exit codes were read via `PIPESTATUS`, so no pipe swallowed a failure.

## After merge

Create the GitHub release `v1.0.0-RC9` against `main` with `--prerelease`, which triggers `publish.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvM9EixA4SrrZRsGvWC3En
