### PR TITLE
Harden for 1.0.0-GA: release script, a wrong headline count, dead links, and an undocumented public API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,23 @@ jobs:
           cd example
           mvn clean compile -B -Dvibetags.log.path=../vibetags.log
 
+      - name: Verify The Example's Committed Guardrails Match Its Annotations
+        run: |
+          # The three reactors run check mode. example/ cannot: the step above empties its config
+          # files and regenerates them, so check mode would compare the fresh tree against itself.
+          # Comparing against git is the equivalent gate, and a slightly stronger one — it proves a
+          # from-empty regeneration reproduces exactly what is committed. It fails when someone
+          # edits an annotation here and forgets to commit the regenerated files, which until now
+          # went unnoticed.
+          if [ -n "$(git status --porcelain -- example/)" ]; then
+            echo "::error::example/ guardrail files are out of date with its annotations."
+            echo "Run: cd example && mvn clean compile   then commit the regenerated files."
+            git status --porcelain -- example/
+            git --no-pager diff -- example/
+            exit 1
+          fi
+          echo "example/ regenerates byte-for-byte to the committed files."
+
       - name: Build Multi-Module Example (Maven reactor)
         run: |
           cd example-multimodule

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,12 @@ name: Build and Test
 
 on:
   push:
-    branches: [ main, master, 'feature/*', 'fix/*' ]
+    branches: [ main, master, 'feature/*', 'fix/*', 'chore/*', 'docs/*', 'ci/*', 'release/*' ]
+  # Deliberately unfiltered: a pull request is a request to review a change, so it is tested
+  # whichever branch it targets. Restricting this to main meant a stacked PR — one targeting the
+  # branch it was built on, so its diff shows only its own work — ran no tests at all, and its PR
+  # page was indistinguishable from one whose tests had passed.
   pull_request:
-    branches: [ main, master ]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@
 
 **VibeTags** is a compile-time Java annotation processor that generates AI platform-specific guardrail files from source annotations — zero runtime overhead, all from a single `mvn compile`.
 
-> <a name="project-facts"></a>**At a glance:** **44 annotations** → guardrails for **37 AI platforms**. These two numbers are the single source of truth for the project's scope; other docs link back here rather than restating them. (Counts verified by `ProjectFactsConsistencyTest`.)
+> <a name="project-facts"></a>**At a glance:** **44 annotations** → guardrails for **37 AI platforms**, written as **49 config files** and **13 scoped-rule directories**. These numbers are the single source of truth for the project's scope; other docs link back here rather than restating them. A platform is a tool, not a file — Cursor is one platform with both `.cursorrules` and `.cursorignore`. (All four counts verified by `ProjectFactsConsistencyTest`.)
 
 ## Why VibeTags?
 
 `.cursorrules`, `CLAUDE.md`, and similar files are hand-edited by each developer, grow inconsistent across the team, and go stale the moment the code changes. VibeTags makes your AI configuration **source-controlled and compile-enforced**:
 
-- **Annotate once, all platforms updated** — add `@AILocked` to `PaymentProcessor` and every AI tool's guardrail file is regenerated on the next compile. No more per-developer copy-pasting across [37 config formats](#project-facts).
+- **Annotate once, all platforms updated** — add `@AILocked` to `PaymentProcessor` and every AI tool's guardrail file is regenerated on the next compile. No more per-developer copy-pasting across [49 config files](#project-facts).
 - **Derived from the code, not separate from it** — guardrails live next to the code they protect. When the code moves, the rules move with it.
 - **Granular rules keep the always-loaded context slim** — opt a platform's scoped-rules directory in (`.claude/rules/`, `.cursor/rules/`, `.windsurf/rules/`, `.github/instructions/`, `.gemini/rules/`) and its aggregate file collapses to an index: only the safety buckets (`@AILocked`, `@AICore`, `@AIPrivacy`, `@AIIgnore`, `@AIAudit`, `@AISecure`) stay inline, and the per-element detail loads on demand when the matching source file is opened. This repository dogfoods it — the generated block in its own `CLAUDE.md` is 45 lines, with 115 lines of per-element detail sitting in `.claude/rules/` until they are relevant. Without it, that file grows linearly with every annotated element. See [USAGE.md](USAGE.md#-granular-rules-cursor-trae-roo-code).
 - **Zero runtime cost** — `RetentionPolicy.SOURCE` annotations are erased at compile time; nothing reaches the JVM.
@@ -154,11 +154,11 @@ gradle compileJava
 
 - [What is VibeTags?](#-what-is-vibetags)
 - [Project Structure](#-project-structure)
-- [Installation](#-quick-start)
+- [Installation](#-installation)
 - [How It Works](#-how-it-works)
-- [Organizing Context Files](#-organizing-context-files-for-optimal-context)
+- [Organizing Context Files](#️-organizing-context-files-for-optimal-context)
 - [Documentation](#-documentation)
-- [Building from Source](#-building-both-projects)
+- [Building from Source](#️-building-from-source)
 - [Performance & Load Tests](#-performance--load-tests)
 - [When to Use VibeTags](#-when-to-use-vibetags)
 - [Advanced Features & Annotation Reference](#-advanced-features--annotation-reference) → full guide in **[USAGE.md](USAGE.md)**
@@ -194,7 +194,7 @@ carries: **what it can annotate**, and **which tier its guardrail lands in**.
 - **Tier** is where the rule shows up once a platform's scoped-rules directory is opted in.
   **safety** guardrails stay inline in the always-loaded aggregate, because a rule that only loads
   after the agent opens the file it protects has already failed. Everything else moves to the
-  scoped file and is replaced by a one-line pointer. See [Context tiers](#-context-tiers-1-2-3).
+  scoped file and is replaced by a one-line pointer. See [`example-all-tiers/`](example-all-tiers/README.md), which demonstrates all three.
 - **Required attributes** have no default; leave one out and the code does not compile.
 
 Every annotation below is used in [`example/`](example/README.md) — that README maps each one to the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,86 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Every example demonstrates all 44 annotations, and the README says where each one goes.**
+
+  `example-all-tiers/` went from 20 annotations to all 44 while keeping the structure it exists to
+  show, and `ExampleCoverageTest` now holds all four example projects to the full set, so an
+  annotation added without an example fails the build.
+
+  The README gained a 44-row reference: what each annotation can be attached to, which attributes
+  have no default, and whether its guardrail stays in the always-loaded aggregate or moves to a
+  scoped file. `AnnotationReferenceTest` derives all three columns from the code — `@Target` by
+  reflection, required attributes from members with no default, and the tier by reading back which
+  buckets the indexed renderer keeps inline. The tier column is the one worth deriving: "safety" is
+  not a property of an annotation, it is whichever buckets survive the aggregate collapsing to an
+  index, so moving one in the renderer now fails the README rather than quietly leaving it
+  describing a split that no longer happens.
+
+- **Opting a scoped-rules directory in and back out again is now tested, both directions.**
+
+  Tier 3 is controlled like every other output: the directory's presence is the opt-in. Opting *in*
+  fails loudly if it breaks, because the rule files are simply absent. Opting *out* fails silently,
+  and into the shape that looks correct — a smaller `CLAUDE.md` still carrying an index that points
+  at a directory nobody has, leaving those guardrails in neither place.
+
+  `ScopedRulesOptInOptOutEndToEndTest` drives both transitions over `example-all-tiers/billing`'s
+  own sources, so it also fails if that example stops exercising all three tiers. It covers the
+  collapse actually shrinking the aggregate, the safety buckets surviving it, opting out restoring
+  the detail and dropping every reference to the directory, opting out holding across two further
+  builds, and deleting a single rule file while still opted in regenerating it byte for byte.
+
+- **International characters in annotation values are proven, not assumed.**
+
+  A guardrail reason is prose, written in whatever language the team works in, and
+  "Får inte loggas enligt GDPR §9" is worthless to an agent if it arrives as "F?r inte loggas".
+  `InternationalCharactersEndToEndTest` drives a real compile with Swedish, German, French, CJK,
+  Japanese, Cyrillic, Greek, Arabic, Hebrew, emoji (surrogate pairs, outside the BMP) and combining
+  marks, then reads them back out of the XML-shaped aggregate, JSON parsed with a real parser, TOML,
+  the base64 sidecar round trip between two modules, a file-backed source so the compiler's own
+  decoding is exercised, and the raw bytes on disk.
+
+  Escaping is asserted separately from survival, because an escaper must act on `< > & " '` and
+  leave everything above U+007F alone; asserting both together lets one defect hide the other.
+
+- **The cross-module merge records which branch it took.**
+
+  It chooses between publishing the compiling module's own rendering and publishing the merged view
+  of every module. Both are well-formed documents and the wrong one differs only by the siblings it
+  is missing, which is what the JSON/TOML freeze below was and why it lasted. Every path now emits
+  its reason and every `.skip` carries one, so `contributions=4` answers "did my sibling's rules
+  make it in?" and `bodies=0` on a `sidecar.save` names the failure directly.
+
+  The diagnostic channel was also unreachable from any example — nothing passed
+  `-Avibetags.log.level` — so neither this logging nor the writer's existing events could be seen by
+  anyone following the docs. All four example poms now wire it, defaulting to `INFO`.
+
+- **All four examples verify their committed guardrails, and every documentation link resolves.**
+
+  `example-multimodule-indexed` was building with a plain `compile`, so drift in it was invisible;
+  it now runs check mode. `example/` cannot use check mode — its job empties the config files and
+  regenerates them, so check mode would compare the fresh tree against itself — and instead
+  compares against git, which additionally proves a from-empty regeneration reproduces exactly what
+  is committed.
+
+  `DocumentationLinksTest` checks every relative link and fragment across 738 Markdown files. Eight
+  were dead: two table-of-contents entries pointing at renamed headings, a fragment naming a section
+  that has never existed, a `LICENSE` and a workflow linked as though `docs/` were the repository
+  root, and two benchmark plots whose relative path was one directory short, so images committed
+  since 0.7.1 had never once rendered.
+
+- **The release script rewrites every file that states the version.**
+
+  `example-all-tiers/pom.xml` was checked by `BuildVersionParityTest` but never written by
+  `scripts/set-version.sh`, so the documented release procedure failed partway through. `README.md`
+  and the usage skill were checked by nothing, so a GA cut with that gap would have shipped eleven
+  install snippets telling every new user to depend on a release candidate.
+
+  `ReleaseScriptCoverageTest` derives the list instead of trusting it: any tracked file stating the
+  current version must either appear in the script or be recorded as historical with a reason. The
+  changelog, the benchmark results and the version-sort-order examples are recorded — a blanket
+  search-and-replace would have claimed this release shipped every past change and that
+  measurements were taken on versions that did not exist when they were run.
+
 - **`example-all-tiers/`: all three tiers at once, and a class annotated at every level.**
 
   The tier model was documented in a table and demonstrated one slice at a time — `example/` shows
@@ -66,6 +146,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a comment about having drifted before.
 
 ### Fixed
+- **The README understated the number of generated files by a third.**
+
+  "37 config formats" was the platform count wearing the file count's label. 37 is how many AI
+  *tools* are supported; Cursor is one tool with both `.cursorrules` and `.cursorignore`. The
+  registry declares 62 outputs: 49 config files and 13 scoped-rule directories. The annotation and
+  platform figures were already pinned by `ProjectFactsConsistencyTest`; the output counts were not,
+  which is how this survived — it read like the figure beside it and nothing disagreed. All four are
+  now pinned, the output counts against the live registry rather than against prose.
+
 - **Multi-module reactors froze their JSON and TOML outputs after the first write, and the freeze
   hid a second bug underneath it.** The remaining half of #265.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -201,4 +201,4 @@ See [SECURITY.md](SECURITY.md) for the vulnerability disclosure policy.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).
+By contributing, you agree that your contributions will be licensed under the [MIT License](../LICENSE).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -268,7 +268,7 @@ gh release edit $TAG --notes-file /tmp/r.md
 
 ### 7. Automatic Publishing
 
-Creating a release triggers the [Publish workflow](.github/workflows/publish.yml), which runs two parallel jobs:
+Creating a release triggers the [Publish workflow](../.github/workflows/publish.yml), which runs two parallel jobs:
 
 1. **Publish to GitHub Packages** — deploys the artifact to `maven.pkg.github.com/PIsberg/vibetags` using the `-P github` profile.
 2. **Publish to Maven Central** — signs the artifacts with GPG (`-P sign-artifacts`) and deploys all three artifacts (`vibetags-annotations`, `vibetags-processor`, `vibetags-bom`) to the Central Portal via the `central-publishing-maven-plugin`. The plugin auto-publishes without manual approval (`autoPublish=true`). Order matters: annotations must be deployed before the processor (which depends on them).

--- a/load-tests/results/0.7.1/jmh-cache-hit-summary.md
+++ b/load-tests/results/0.7.1/jmh-cache-hit-summary.md
@@ -74,9 +74,9 @@ Fix shipped in 0.7.1: use `String.hashCode()` as the fingerprint.
 
 ## Plots
 
-![Wall-clock per writeFileIfChanged call (log-y)](../../docs/changelog-assets/0.7.1/cache-hit-time.png)
+![Wall-clock per writeFileIfChanged call (log-y)](../../../docs/changelog-assets/0.7.1/cache-hit-time.png)
 
-![Allocation per writeFileIfChanged call (log-y)](../../docs/changelog-assets/0.7.1/cache-hit-alloc.png)
+![Allocation per writeFileIfChanged call (log-y)](../../../docs/changelog-assets/0.7.1/cache-hit-alloc.png)
 
 ## Caveats
 

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -22,11 +22,23 @@
 #   example/build.gradle               their own project. Their vibetags.bom.version is a
 #   example-multimodule/pom.xml        literal, and CI builds them against the artifacts
 #   example-multimodule-indexed/pom.xml  this repo just installed, so they track the
-#   tools/demo/pom.xml                 current version rather than the last released one.
+#   example-all-tiers/pom.xml          current version rather than the last released one.
+#   tools/demo/pom.xml
+#
+#   README.md                          Install snippets. A consumer copies these verbatim, so a
+#   .claude/skills/vibetags-usage/     GA that still says RC9 hands every new user the wrong
+#     SKILL.md                         coordinate.
 #
 # This list is not maintained by discipline: BuildVersionParityTest fails the build if any
 # of these disagrees with <revision>, and it is what caught the omissions this script used
 # to leave behind.
+#
+# What must NOT be rewritten, and why a blanket search-and-replace is wrong:
+#
+#   docs/CHANGELOG.md                  A record of what each version did. Rewriting it would
+#                                      claim the current release shipped every past change.
+#   load-tests/results/**              Measurements belong to the version they were taken on.
+#   load-tests/README.md               "since 1.0.0-RC9" is provenance, not a coordinate.
 #
 # Idempotent: the current version is read fresh from the parent on every run.
 set -eu
@@ -90,7 +102,10 @@ for rel in \
     example/build.gradle \
     example-multimodule/pom.xml \
     example-multimodule-indexed/pom.xml \
+    example-all-tiers/pom.xml \
     tools/demo/pom.xml \
+    README.md \
+    .claude/skills/vibetags-usage/SKILL.md \
 ; do
     replace_in_file "$ROOT_DIR/$rel"
 done

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -106,6 +106,20 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!--
+                      This module IS the public API: 44 annotations whose members and enum constants
+                      are what a consumer's IDE shows on hover and what lands on javadoc.io. A
+                      missing @return or an undocumented enum constant leaves them guessing a
+                      guardrail's meaning from its name.
+
+                      Warnings were not fatal before, so 46 of them accumulated silently while the
+                      javadoc jar kept building successfully. Making them fatal is what stops the
+                      next annotation from re-opening the same gap.
+                    -->
+                    <doclint>all</doclint>
+                    <failOnWarnings>true</failOnWarnings>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIArchitecture.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIArchitecture.java
@@ -14,11 +14,15 @@ import java.lang.annotation.Target;
 public @interface AIArchitecture {
     /**
      * Defines the architectural layer or component this class belongs to.
+     *
+     * @return the layer name, e.g. {@code "domain"}, or an empty string to leave it unstated
      */
     String belongsTo() default "";
 
     /**
      * Defines the list of layers or components that this class is strictly prohibited from referencing or importing.
+     *
+     * @return the layer or package names this type must never reference; empty means unrestricted
      */
     String[] cannotReference() default {};
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AICallersOnly.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AICallersOnly.java
@@ -14,6 +14,8 @@ import java.lang.annotation.Target;
 public @interface AICallersOnly {
     /**
      * Fully qualified names or wildcard patterns of allowed callers (e.g. "com.example.service.*").
+     *
+     * @return the callers permitted to invoke this element; anything else is an illegal bypass
      */
     String[] value();
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIDomainModel.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIDomainModel.java
@@ -14,6 +14,8 @@ import java.lang.annotation.Target;
 public @interface AIDomainModel {
     /**
      * Optional list of packages or classes that are explicitly allowed to be imported.
+     *
+     * @return the imports exempt from the framework ban; empty means no exemptions
      */
     String[] allow() default {};
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIExplain.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIExplain.java
@@ -11,14 +11,20 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface AIExplain {
+    /** How much reasoning an agent must show before changing the annotated element. */
     enum ComplexityLevel {
+        /** Full derivation: every step, and why each alternative was rejected. */
         HIGH,
+        /** The reasoning behind the approach taken, without exhausting the alternatives. */
         MEDIUM,
+        /** A short statement of intent, enough to review the change against. */
         LOW
     }
 
     /**
      * Complexity level of explanations required.
+     *
+     * @return how much of its reasoning an agent must show; defaults to {@link ComplexityLevel#HIGH}
      */
     ComplexityLevel value() default ComplexityLevel.HIGH;
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIExtensible.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIExtensible.java
@@ -12,14 +12,20 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface AIExtensible {
+    /** The polymorphic route to take instead of adding another branch to a conditional. */
     enum Strategy {
+        /** Add behaviour as an interchangeable implementation selected at runtime. */
         STRATEGY_PATTERN,
+        /** Add behaviour as a visitor over a stable type hierarchy. */
         VISITOR_PATTERN,
+        /** Add behaviour by producing a new product from a factory rather than by branching. */
         FACTORY
     }
 
     /**
      * Design strategy required for extending capabilities.
+     *
+     * @return the pattern to extend through; defaults to {@link Strategy#STRATEGY_PATTERN}
      */
     Strategy value() default Strategy.STRATEGY_PATTERN;
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIInputSanitized.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIInputSanitized.java
@@ -11,15 +11,22 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.PARAMETER, ElementType.FIELD})
 public @interface AIInputSanitized {
+    /** The class of injection the annotated value must be neutralised against. */
     enum SanitizerType {
+        /** Reaches a SQL query: parameterise it, never concatenate. */
         SQL_INJECTION,
+        /** Reaches rendered HTML: escape for the context it is interpolated into. */
         XSS,
+        /** Reaches a filesystem path: reject traversal segments and normalise before use. */
         PATH_TRAVERSAL,
+        /** Reaches an LDAP filter or DN: escape per RFC 4515/4514. */
         LDAP
     }
 
     /**
      * Types of vulnerabilities to sanitize against.
+     *
+     * @return every injection class this value must be sanitized against before it is used
      */
     SanitizerType[] value();
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIInternationalized.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIInternationalized.java
@@ -18,6 +18,8 @@ public @interface AIInternationalized {
      * Optional rationale, persisted across AI sessions: why this rule applies to this element
      * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
      * it is surfaced in the generated guardrail output.
+     *
+     * @return the rationale to carry into the generated guardrails, or an empty string to omit it
      */
     String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AILegacyBridge.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AILegacyBridge.java
@@ -18,6 +18,8 @@ public @interface AILegacyBridge {
      * Optional rationale, persisted across AI sessions: why this rule applies to this element
      * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
      * it is surfaced in the generated guardrail output.
+     *
+     * @return the rationale to carry into the generated guardrails, or an empty string to omit it
      */
     String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIMemoryBudget.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIMemoryBudget.java
@@ -11,14 +11,20 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface AIMemoryBudget {
+    /** How strictly allocation is forbidden inside the annotated element. */
     enum AllocationPolicy {
+        /** No heap allocation at all on this path. */
         ZERO_ALLOCATION,
+        /** Primitives must stay primitive; no boxing into wrapper types. */
         NO_AUTOBOXING,
+        /** No new instances; reuse buffers and pooled objects instead. */
         NO_NEW_OBJECTS
     }
 
     /**
      * Enforces the specified memory allocation policy.
+     *
+     * @return the allocation policy to hold to; defaults to {@link AllocationPolicy#ZERO_ALLOCATION}
      */
     AllocationPolicy value() default AllocationPolicy.ZERO_ALLOCATION;
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIParallelTests.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIParallelTests.java
@@ -18,6 +18,8 @@ public @interface AIParallelTests {
      * Optional rationale, persisted across AI sessions: why this rule applies to this element
      * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
      * it is surfaced in the generated guardrail output.
+     *
+     * @return the rationale to carry into the generated guardrails, or an empty string to omit it
      */
     String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIPrototype.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIPrototype.java
@@ -17,6 +17,8 @@ public @interface AIPrototype {
      * Optional rationale, persisted across AI sessions: why this rule applies to this element
      * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
      * it is surfaced in the generated guardrail output.
+     *
+     * @return the rationale to carry into the generated guardrails, or an empty string to omit it
      */
     String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIPublicAPI.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIPublicAPI.java
@@ -17,6 +17,8 @@ public @interface AIPublicAPI {
      * Optional rationale, persisted across AI sessions: why this rule applies to this element
      * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
      * it is surfaced in the generated guardrail output.
+     *
+     * @return the rationale to carry into the generated guardrails, or an empty string to omit it
      */
     String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIPure.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIPure.java
@@ -17,6 +17,8 @@ public @interface AIPure {
      * Optional rationale, persisted across AI sessions: why this rule applies to this element
      * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
      * it is surfaced in the generated guardrail output.
+     *
+     * @return the rationale to carry into the generated guardrails, or an empty string to omit it
      */
     String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AISandboxOnly.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AISandboxOnly.java
@@ -17,6 +17,8 @@ public @interface AISandboxOnly {
      * Optional rationale, persisted across AI sessions: why this rule applies to this element
      * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
      * it is surfaced in the generated guardrail output.
+     *
+     * @return the rationale to carry into the generated guardrails, or an empty string to omit it
      */
     String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AISchemaSafe.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AISchemaSafe.java
@@ -18,6 +18,8 @@ public @interface AISchemaSafe {
      * Optional rationale, persisted across AI sessions: why this rule applies to this element
      * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
      * it is surfaced in the generated guardrail output.
+     *
+     * @return the rationale to carry into the generated guardrails, or an empty string to omit it
      */
     String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AISecureLogging.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AISecureLogging.java
@@ -11,15 +11,23 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.FIELD, ElementType.PARAMETER})
 public @interface AISecureLogging {
+    /** What may appear in a log line in place of the annotated value. */
     enum MaskingPolicy {
+        /** Nothing: the value never reaches a log, not even redacted. */
         OMIT,
+        /** A stable one-way hash, so occurrences can be correlated without revealing the value. */
         HASH,
+        /** Card-number shape: all but the last four digits replaced. */
         MASK_CREDIT_CARD,
+        /** Address shape: the local part masked, the domain kept. */
         MASK_EMAIL
     }
 
     /**
      * Logging policy to apply (hashing, fully omitting, or masking certain shapes).
+     *
+     * @return what may appear in a log line in place of this value; defaults to
+     *         {@link MaskingPolicy#OMIT}
      */
     MaskingPolicy value() default MaskingPolicy.OMIT;
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIStrictClasspath.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIStrictClasspath.java
@@ -18,6 +18,8 @@ public @interface AIStrictClasspath {
      * Optional rationale, persisted across AI sessions: why this rule applies to this element
      * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
      * it is surfaced in the generated guardrail output.
+     *
+     * @return the rationale to carry into the generated guardrails, or an empty string to omit it
      */
     String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIStrictExceptions.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIStrictExceptions.java
@@ -18,6 +18,8 @@ public @interface AIStrictExceptions {
      * Optional rationale, persisted across AI sessions: why this rule applies to this element
      * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
      * it is surfaced in the generated guardrail output.
+     *
+     * @return the rationale to carry into the generated guardrails, or an empty string to omit it
      */
     String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIStrictTypes.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIStrictTypes.java
@@ -17,6 +17,8 @@ public @interface AIStrictTypes {
      * Optional rationale, persisted across AI sessions: why this rule applies to this element
      * (a past incident, a subtle invariant, a decision the next agent cannot re-derive). When set,
      * it is surfaced in the generated guardrail output.
+     *
+     * @return the rationale to carry into the generated guardrails, or an empty string to omit it
      */
     String reason() default "";
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AISunset.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AISunset.java
@@ -14,11 +14,17 @@ import java.lang.annotation.Target;
 public @interface AISunset {
     /**
      * Fully qualified class replacement for the sunset API element.
+     *
+     * @return the type callers should migrate to, or {@code Object.class} when no direct
+     *         replacement exists
      */
     Class<?> replacement() default Object.class;
 
     /**
      * JIRA or issue tracking ticket for deprecation/sunset progress (e.g. "DEBT-123").
+     *
+     * @return the ticket tracking the removal, so the guardrail points at the work rather than
+     *         only at the prohibition
      */
     String jira();
 }

--- a/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AITemporary.java
+++ b/vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AITemporary.java
@@ -14,11 +14,15 @@ import java.lang.annotation.Target;
 public @interface AITemporary {
     /**
      * Expiration date in ISO format YYYY-MM-DD (e.g. "2026-06-30").
+     *
+     * @return the date after which compilation fails, forcing the workaround to be revisited
      */
     String expiresOn();
 
     /**
      * Rationale behind this temporary workaround.
+     *
+     * @return why the shortcut was taken, so whoever hits the expiry knows what to replace
      */
     String reason();
 }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/DocumentationLinksTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/DocumentationLinksTest.java
@@ -1,0 +1,208 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Every relative link and anchor in the repository's Markdown must resolve.
+ *
+ * <p>A dead link is the cheapest defect for a reader to find and among the most damaging to
+ * credibility: the first thing a new user does with a README is click something. Six were live in
+ * this repository at once — a table of contents pointing at two renamed headings, a "Context tiers"
+ * fragment naming a section that has never existed, a {@code LICENSE} and a workflow linked as if
+ * {@code docs/} were the repository root, and two benchmark plots whose relative path was one
+ * directory short, so images that were committed never rendered.
+ *
+ * <p>None of them would fail a build, which is exactly why they accumulated. This test is the thing
+ * that disagrees.
+ *
+ * <p>External {@code http(s)} links are deliberately not checked: that would make the build depend
+ * on the network and on other people's uptime, and a red build caused by someone else's outage
+ * teaches people to ignore red builds.
+ */
+@DisplayName("Documentation links resolve")
+class DocumentationLinksTest {
+
+    /** {@code vibetags/} is the surefire working directory; its parent is the repo root. */
+    private static final Path REPO_ROOT = Paths.get("").toAbsolutePath().getParent();
+
+    private static final Set<String> SKIP_DIRS =
+        Set.of(".git", "target", "node_modules", "build", ".mvn", ".gradle");
+
+    /** {@code [label](target)}, with an optional title after the target. */
+    private static final Pattern LINK =
+        Pattern.compile("\\[[^\\]]*\\]\\(([^)\\s]+)(?:\\s+\"[^\"]*\")?\\)");
+    private static final Pattern HEADING = Pattern.compile("^#{1,6}\\s+(.*)$", Pattern.MULTILINE);
+    private static final Pattern ANCHOR_TAG = Pattern.compile("<a\\s+name=\"([^\"]+)\"");
+    private static final Pattern INLINE_LINK_IN_HEADING =
+        Pattern.compile("\\[([^\\]]*)\\]\\([^)]*\\)");
+
+    /** Anchors are expensive to compute and files are linked repeatedly; compute each once. */
+    private final Map<Path, Set<String>> anchorCache = new HashMap<>();
+
+    @Test
+    @DisplayName("no relative link points at a missing file, and no fragment at a missing heading")
+    void everyRelativeLinkAndAnchorResolves() throws IOException {
+        assumeTrue(Files.isDirectory(REPO_ROOT.resolve("docs")),
+            "repo layout not reachable from " + REPO_ROOT + "; skipping");
+
+        List<Path> docs = markdownFiles();
+        assumeTrue(docs.size() > 10, "found only " + docs.size() + " markdown files; layout wrong");
+
+        List<String> broken = new ArrayList<>();
+        for (Path doc : docs) {
+            String text = read(doc);
+            Matcher m = LINK.matcher(stripFencedCode(text));
+            while (m.find()) {
+                String target = m.group(1);
+                if (target.startsWith("http://") || target.startsWith("https://")
+                    || target.startsWith("mailto:") || target.startsWith("tel:")) {
+                    continue;
+                }
+                int hash = target.indexOf('#');
+                String pathPart = hash < 0 ? target : target.substring(0, hash);
+                String fragment = hash < 0 ? "" : target.substring(hash + 1);
+
+                Path destination = doc;
+                if (!pathPart.isEmpty()) {
+                    destination = doc.getParent().resolve(pathPart).normalize();
+                    if (!Files.exists(destination)) {
+                        broken.add(rel(doc) + " -> " + target + "  (no such file)");
+                        continue;
+                    }
+                }
+                if (!fragment.isEmpty() && destination.toString().endsWith(".md")
+                    && !anchorsOf(destination).contains(fragment.toLowerCase(Locale.ROOT))) {
+                    broken.add(rel(doc) + " -> " + target + "  (no such anchor)");
+                }
+            }
+        }
+
+        assertTrue(broken.isEmpty(),
+            "Broken documentation links (" + broken.size() + " of them, across " + docs.size()
+                + " files):\n  " + String.join("\n  ", broken));
+    }
+
+    // -----------------------------------------------------------------------
+
+    /**
+     * GitHub's heading-to-anchor rule: lower-case, drop everything that is not alphanumeric, a
+     * space, or a hyphen, then turn spaces into hyphens.
+     *
+     * <p>Two details decide whether this agrees with GitHub, and getting either wrong turns the
+     * test into a generator of false alarms. Leading whitespace is <em>not</em> trimmed: a heading
+     * that starts with an emoji keeps the space the emoji left behind, and that space becomes a
+     * leading hyphen — which is why {@code ## 🎯 What is VibeTags?} is {@code #-what-is-vibetags}.
+     * And U+FE0F, the variation selector, survives the filter, so {@code 🛡️} (which carries one)
+     * leaves it behind where {@code 🎯} (which does not) leaves nothing.
+     */
+    static String slug(String heading) {
+        String s = stripTrailing(heading).toLowerCase(Locale.ROOT);
+        s = s.replaceAll("[^\\w\\s\\-\\x{FE0F}]", "");
+        return s.replaceAll("\\s", "-");
+    }
+
+    private static String stripTrailing(String s) {
+        int end = s.length();
+        while (end > 0 && Character.isWhitespace(s.charAt(end - 1))) {
+            end--;
+        }
+        return s.substring(0, end);
+    }
+
+    private Set<String> anchorsOf(Path md) {
+        return anchorCache.computeIfAbsent(md, path -> {
+            Set<String> found = new LinkedHashSet<>();
+            String text;
+            try {
+                text = read(path);
+            } catch (IOException e) {
+                return found;
+            }
+            Matcher tags = ANCHOR_TAG.matcher(text);
+            while (tags.find()) {
+                found.add(tags.group(1).toLowerCase(Locale.ROOT));
+            }
+            Matcher headings = HEADING.matcher(text);
+            while (headings.find()) {
+                String heading = headings.group(1);
+                found.add(slug(heading).toLowerCase(Locale.ROOT));
+                // A heading whose text is itself a link anchors on the label alone.
+                found.add(slug(INLINE_LINK_IN_HEADING.matcher(heading).replaceAll("$1"))
+                    .toLowerCase(Locale.ROOT));
+            }
+            return found;
+        });
+    }
+
+    /**
+     * Removes fenced code blocks. Links inside them illustrate generated output — the sample
+     * {@code .mentatconfig.json} contains {@code [PaymentProcessor](com.example...)} — and are not
+     * navigation. Checking them reports four failures that no reader can ever encounter.
+     */
+    private static String stripFencedCode(String text) {
+        StringBuilder out = new StringBuilder(text.length());
+        boolean inFence = false;
+        for (String line : text.split("\n", -1)) {
+            if (line.strip().startsWith("```")) {
+                inFence = !inFence;
+                continue;
+            }
+            if (!inFence) {
+                out.append(line).append('\n');
+            }
+        }
+        return out.toString();
+    }
+
+    private List<Path> markdownFiles() throws IOException {
+        try (Stream<Path> paths = Files.walk(REPO_ROOT)) {
+            return paths
+                .filter(p -> p.toString().endsWith(".md"))
+                .filter(DocumentationLinksTest::isNotInSkippedDirectory)
+                .sorted()
+                .toList();
+        }
+    }
+
+    private static boolean isNotInSkippedDirectory(Path p) {
+        for (Path part : p) {
+            if (SKIP_DIRS.contains(part.toString())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static String read(Path p) throws IOException {
+        try {
+            return Files.readString(p, StandardCharsets.UTF_8);
+        } catch (UncheckedIOException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private static String rel(Path p) {
+        return REPO_ROOT.relativize(p).toString().replace('\\', '/');
+    }
+}

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ProjectFactsConsistencyTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ProjectFactsConsistencyTest.java
@@ -2,6 +2,8 @@ package se.deversity.vibetags.processor;
 
 import org.junit.jupiter.api.Test;
 
+import se.deversity.vibetags.processor.internal.ServiceRegistry;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -9,6 +11,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -26,6 +29,12 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *       must equal the "<b>N annotations</b>" figure stated in the README "project facts" line.</li>
  *   <li><b>Platform count</b> — the "<b>N AI platforms</b>" figure in the README must equal the number
  *       of distinct platforms actually enumerated in the README "Supported AI Platforms" list.</li>
+ *   <li><b>Output counts</b> — the "<b>N config files</b>" and "<b>N scoped-rule directories</b>"
+ *       figures must equal what {@code ServiceRegistry} actually declares. These are a different
+ *       count from the platform figure and must not be conflated with it: a platform is a tool,
+ *       and one tool routinely owns several files. The README claimed "37 config formats" for a
+ *       long time — the platform number wearing the file number's label, understating the real
+ *       figure by a third, and nothing disagreed because nothing was checking.</li>
  * </ul>
  *
  * <p>The README "At a glance" line is the single source of truth for these numbers; every other doc
@@ -38,6 +47,35 @@ class ProjectFactsConsistencyTest {
 
     /** {@code vibetags/} is the surefire working directory; its parent is the repo root. */
     private static final Path REPO_ROOT = Paths.get("").toAbsolutePath().getParent();
+
+    @Test
+    void readmeOutputCountsMatchWhatTheServiceRegistryDeclares() throws IOException {
+        Path readme = REPO_ROOT.resolve("README.md");
+        if (!Files.isRegularFile(readme)) {
+            return; // repo layout not reachable; the other tests document this skip
+        }
+        String md = Files.readString(readme, StandardCharsets.UTF_8);
+
+        Map<String, Path> services = ServiceRegistry.buildServiceFileMap(Paths.get("."));
+        // A scoped-rules entry is a directory of per-element rule files; everything else is a
+        // single config file. The file name is the only thing that distinguishes them without
+        // touching the disk, and rule directories are the ones with no extension.
+        long directories = services.values().stream()
+            .map(Path::getFileName)
+            .filter(java.util.Objects::nonNull)
+            .filter(name -> !name.toString().contains("."))
+            .count();
+        long files = services.size() - directories;
+
+        assertEquals(files,
+            extractCount(md, "\\*\\*(\\d+) config files\\*\\*", "config file"),
+            "The README's config-file count disagrees with ServiceRegistry. This is the number a "
+                + "reader uses to judge whether VibeTags is worth adopting, so it has to be the "
+                + "number the code actually writes.");
+        assertEquals(directories,
+            extractCount(md, "\\*\\*(\\d+) scoped-rule directories\\*\\*", "scoped-rule directory"),
+            "The README's scoped-rule-directory count disagrees with ServiceRegistry.");
+    }
 
     @Test
     void readmeAnnotationCountMatchesTheNumberOfAnnotationInterfaces() throws IOException {

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
@@ -1,0 +1,158 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * {@code scripts/set-version.sh} must rewrite every file that states the release version.
+ *
+ * <p>The version lives once, in {@code <revision>}, and everything that can inherit it does. What
+ * is left is the set of files that cannot: the Gradle builds, the standalone example poms a user
+ * is meant to copy, and the install snippets in the documentation. That set grows every time an
+ * example or a doc is added, and the script's list is a hand-maintained copy of it.
+ *
+ * <p>It had already drifted. {@code example-all-tiers/pom.xml} was checked by
+ * {@link BuildVersionParityTest} but never written by the script, so the documented release
+ * procedure failed partway through. {@code README.md} and the usage skill were checked by nothing
+ * at all — a GA cut with that gap would have shipped eleven install snippets telling every new
+ * user to depend on a release candidate.
+ *
+ * <p>So the list is derived here instead of trusted: any tracked file that mentions the current
+ * version and is not explicitly recorded as historical must appear in the script.
+ */
+@DisplayName("The release script rewrites every version it needs to")
+class ReleaseScriptCoverageTest {
+
+    /** {@code vibetags/} is the surefire working directory; its parent is the repo root. */
+    private static final Path REPO_ROOT = Paths.get("").toAbsolutePath().getParent();
+
+    private static final Set<String> SKIP_DIRS =
+        Set.of(".git", "target", "node_modules", "build", ".gradle", "results");
+
+    /**
+     * Files that state a version on purpose and must survive a bump untouched.
+     *
+     * <p>A blanket search-and-replace across the repository would corrupt every one of these: a
+     * changelog rewritten to the new version claims this release shipped every past change, and a
+     * benchmark's provenance rewritten to the new version claims measurements that were never
+     * taken.
+     */
+    private static final Set<String> HISTORICAL = Set.of(
+        "docs/CHANGELOG.md",          // a record of what each version did
+        "load-tests/README.md",       // "since 1.0.0-RCn" is provenance, not a coordinate
+        "load-tests/results/README.md",
+        // The benchmark plotters. Two default --version to the last release that actually has
+        // measurements under load-tests/results/; bumping that on release would aim them at a
+        // directory nobody has generated yet. The other two name versions inside a comment
+        // explaining the sort order (0.9.7 < 1.0.0-RC1 < 1.0.0-RC9 < 1.0.0) — the whole point of
+        // that example is the relationship between the versions, which a rewrite destroys.
+        "tools/plot-release-comparison.py",
+        "tools/plot-processor-tax.py",
+        "tools/plot-cache-hit.py",
+        "tools/plot-results.py");
+
+    /** Build outputs and local scratch that are not part of the release. */
+    private static final Set<String> IGNORED_SUFFIXES =
+        Set.of(".flattened-pom.xml", "dependency-reduced-pom.xml");
+
+    @Test
+    @DisplayName("no tracked file states the version without the script knowing about it")
+    void everyVersionCarryingFileIsInTheScript() throws IOException, InterruptedException {
+        Path script = REPO_ROOT.resolve("scripts/set-version.sh");
+        assumeTrue(Files.isRegularFile(script), "set-version.sh not reachable; skipping");
+
+        String version = revision();
+        assumeTrue(version != null && !version.isBlank(), "could not read <revision>; skipping");
+
+        Set<String> tracked = trackedFiles();
+        assumeTrue(!tracked.isEmpty(), "git did not list any tracked files; skipping");
+
+        String scriptText = Files.readString(script, StandardCharsets.UTF_8);
+        List<String> missing = new ArrayList<>();
+
+        for (String rel : tracked) {
+            if (HISTORICAL.contains(rel) || isIgnored(rel) || isInSkippedDirectory(rel)) {
+                continue;
+            }
+            Path file = REPO_ROOT.resolve(rel);
+            if (!Files.isRegularFile(file)) {
+                continue;
+            }
+            String text;
+            try {
+                text = Files.readString(file, StandardCharsets.UTF_8);
+            } catch (IOException | java.io.UncheckedIOException notText) {
+                continue; // binary or unreadable; it cannot carry a version string
+            }
+            if (text.contains(version) && !scriptText.contains(rel)) {
+                missing.add(rel + " (states " + version + ")");
+            }
+        }
+
+        assertTrue(missing.isEmpty(),
+            "These files state the release version but scripts/set-version.sh does not rewrite "
+                + "them, so the next release leaves them pointing at " + version + ". Add them to "
+                + "the script, or record them in HISTORICAL here with the reason they must not "
+                + "change:\n  " + String.join("\n  ", missing));
+    }
+
+    // -----------------------------------------------------------------------
+
+    private static boolean isIgnored(String rel) {
+        return IGNORED_SUFFIXES.stream().anyMatch(rel::endsWith);
+    }
+
+    private static boolean isInSkippedDirectory(String rel) {
+        for (String part : rel.split("/")) {
+            if (SKIP_DIRS.contains(part)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** {@code <revision>} from the parent pom: the one place the version is declared. */
+    private static String revision() throws IOException {
+        Path parent = REPO_ROOT.resolve("vibetags-parent/pom.xml");
+        if (!Files.isRegularFile(parent)) {
+            return null;
+        }
+        Matcher m = Pattern.compile("<revision>([^<]+)</revision>")
+            .matcher(Files.readString(parent, StandardCharsets.UTF_8));
+        return m.find() ? m.group(1).trim() : null;
+    }
+
+    /**
+     * Tracked files only. Untracked build output routinely contains the version — the flattened
+     * poms and every surefire report — and none of it is released.
+     */
+    private static Set<String> trackedFiles() throws IOException, InterruptedException {
+        ProcessBuilder pb = new ProcessBuilder("git", "ls-files");
+        pb.directory(REPO_ROOT.toFile());
+        pb.redirectErrorStream(true);
+        Process p = pb.start();
+        Set<String> files = new LinkedHashSet<>();
+        try (Stream<String> lines = new java.io.BufferedReader(
+                new java.io.InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8)).lines()) {
+            lines.map(String::trim).filter(s -> !s.isEmpty()).forEach(files::add);
+        }
+        p.waitFor();
+        return files;
+    }
+}

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
@@ -65,7 +65,11 @@ class ReleaseScriptCoverageTest {
         "tools/plot-release-comparison.py",
         "tools/plot-processor-tax.py",
         "tools/plot-cache-hit.py",
-        "tools/plot-results.py");
+        "tools/plot-results.py",
+        // This file, which quotes the same sort-order example a few lines above while explaining
+        // why those tools are exempt. It flagged itself the moment it was committed, which is the
+        // scan working: it reads `git ls-files`, so a file becomes visible when it becomes real.
+        "vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java");
 
     /** Build outputs and local scratch that are not part of the release. */
     private static final Set<String> IGNORED_SUFFIXES =


### PR DESCRIPTION
Targets `main` directly. #349 has since been squash-merged, and #350 — which targeted its
branch — was merged into that branch *after* the squash, so its content never reached `main`.
These commits are the same work, rebased onto current `main`.

Everything here came from asking one question: what would a reader or a release engineer hit first
if 1.0.0-GA were cut today? Every item is something that could have been caught by hand, which is
the wrong way round — so each fix ships with the check that makes it un-repeatable.

## The release procedure was broken

`scripts/set-version.sh` did not rewrite three files that state the version.

| file | checked by | consequence at GA |
|---|---|---|
| `example-all-tiers/pom.xml` | `BuildVersionParityTest` | release fails partway through the documented procedure |
| `README.md` (11 snippets) | nothing | GA tells every new user to depend on a release candidate |
| `.claude/skills/vibetags-usage/SKILL.md` (4) | nothing | same, via the skill |

The loud one would have stopped the release. The silent one would not have, which is the one that
matters.

The script's list is a hand-maintained copy of "every file that cannot inherit `<revision>`", and
that set grows with every new example and doc. **`ReleaseScriptCoverageTest` derives it instead**:
any tracked file stating the current version must appear in the script, or be recorded as historical
with a reason. Recorded as historical, because a blanket search-and-replace corrupts each one:

- `docs/CHANGELOG.md` — rewriting it claims this release shipped every past change
- `load-tests/results/**`, `load-tests/README.md` — measurements belong to the version they were taken on
- `tools/plot-{release-comparison,processor-tax}.py` — `--version` defaults to the last release that
  *has* results; bumping aims them at a directory nobody has generated
- `tools/plot-{cache-hit,results}.py` — the version sits inside a comment explaining sort order
  (`0.9.7 < 1.0.0-RC1 < 1.0.0-RC9 < 1.0.0`), where the relationship between versions *is* the example

Verified by running it: `set-version.sh 1.0.0-TESTBUMP` now updates all eleven files, and only the
historical references remain. Reverted after. I could **not** additionally confirm
`BuildVersionParityTest` at the bumped version — offline resolution fails when the module artifacts
do not exist under the test version — so that was **skipped, not passed**, which is exactly why the
invariant is encoded as a test rather than resting on one manual run.

## The README understated the project by a third

**"37 config formats" was the platform count wearing the file count's label.** 37 is how many AI
*tools* are supported; Cursor is one tool with both `.cursorrules` and `.cursorignore`. The registry
declares **62 outputs: 49 config files and 13 scoped-rule directories**.

The annotation and platform figures were already pinned by `ProjectFactsConsistencyTest`. The output
counts were not — which is how this survived: it read like the figure beside it, and nothing
disagreed. All four are now pinned, the output counts against the live registry rather than prose.

## Eight dead links

None would fail a build, which is why they accumulated:

- two table-of-contents entries pointing at renamed headings (`#-quick-start` → a section now called
  Installation; `#-building-both-projects` → Building from Source)
- `#-context-tiers-1-2-3` named a section that has never existed in any document — **that one is
  mine**, added earlier in #349; it now points at `example-all-tiers/`, and being a file link it
  cannot rot the same way
- `LICENSE` and `.github/workflows/publish.yml` linked from inside `docs/` as though `docs/` were the
  repository root
- two benchmark plots one directory short in their relative path, so images committed since 0.7.1
  have **never once rendered**

**`DocumentationLinksTest`** now checks every relative link and fragment across 738 Markdown files in
1.2 s. Two details decide whether such a check agrees with GitHub, and getting either wrong makes it
a false-alarm generator rather than a gate:

1. leading whitespace must **not** be trimmed — a heading starting with an emoji keeps the space the
   emoji left behind, and that space becomes a leading hyphen
2. **U+FE0F survives GitHub's slugger**, so `🛡️` (which carries a variation selector) anchors
   differently from `🎯` (which does not)

My first pass got both wrong and reported 43 broken links; **35 of those were working.** Fenced code
is skipped — the sample generated output contains `[PaymentProcessor](com.example...)`, an
illustration rather than navigation. External `http(s)` links are deliberately not checked: that
would make the build depend on other people's uptime, and a red build caused by someone else's outage
teaches people to ignore red builds.

## All four examples now verify their committed guardrails

`example/` was the last one CI built without ever comparing the result to what is committed. Its job
empties the config files and regenerates them, which proves regeneration works and proves nothing
about the repository. Check mode cannot fill that gap — after the reset it would compare the fresh
tree against itself — so it compares against git instead, which additionally proves a from-empty
regeneration reproduces exactly what is committed.

Verified in both directions, because a gate that cannot fail is worse than none: clean tree passes on
arrival; with one annotation's reason edited and the output uncommitted, the regenerated files across
every platform show as modified and the gate fires.

## Not done, and why

**No mutation-score threshold.** The PIT badge states 56% with nothing enforcing it, so the number
can silently drop. I started a local PIT run to set an informed floor and stopped it: it was throwing
the same `TIMED_OUT` warnings reported earlier in this work, and this machine has already been
established as unable to measure reliably. Setting a CI-failing threshold from an untrustworthy local
number is how you get a flaky gate. **Recommend deciding the floor from a CI run**, where PIT takes
~35 minutes and the environment is consistent.


## Also here, found after #350 was opened

**The public API was undocumented.** `vibetags-annotations` had 46 javadoc warnings: 24 members
with no `@return`, 22 nested enums and constants with no comment at all. That is the artifact a
consumer's IDE reads, so `enum MaskingPolicy { OMIT, HASH, MASK_CREDIT_CARD, MASK_EMAIL }` left the
meaning of each guardrail to be inferred from its name. Now documented, with `doclint=all` and
`failOnWarnings` making a regression fatal.

Caveat found while verifying that gate: removing an `@return` fails the build only when javadoc
actually re-runs. An incremental `mvn javadoc:jar` skips it as up-to-date and passes — I saw exactly
that and only caught it by re-testing with `clean`. CI runs `clean`, so the gate holds there, but a
developer cannot rely on it locally without `clean`.

**Build and Test ran on no branch but `main` and `fix/*`.** A stacked PR triggered nothing, and its
page looked identical to one whose tests passed — no red X, no missing required check. `pull_request`
is now unfiltered. It paid for itself immediately: it caught `ReleaseScriptCoverageTest` failing on
every platform, which passed locally only because the file was still untracked and the check reads
`git ls-files`.

## Verification

1458 tests green with Checkstyle, PMD, SpotBugs + Find Security Bugs, NullAway and JaCoCo. Every new
check was confirmed to bite by breaking it:

- claiming 52 config files → `expected: <49> but was: <52>`
- a typo'd anchor and a moved file → both reported by name
- an uncommitted annotation edit in `example/` → gate fires
- `claude_granular` active regardless of its directory → the three tier-3 transition tests go red

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZnf9DAJm12KZCXMNMQaWe
