### PR TITLE
Harden for GA: scope the published javadoc to the API, and stop four docs claiming a stale count

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,19 +784,28 @@ VibeTags ships far more than the basics shown above:
 
 ## 🤝 Contributing
 
-VibeTags is designed to evolve based on community needs. Future extensions could include:
+VibeTags is designed to evolve based on community needs. The two annotations this section
+used to propose have both shipped — `@AIExtensible` takes a design pattern to extend through, and
+`@AITestDriven` enforces Red-Green-Refactor — so the open ground is elsewhere:
 
-- `@AIPattern` - Specify design patterns AI should follow
-- `@AITest` - Guide AI in generating tests
-- Custom annotation processors for organization-specific needs
+- **A new platform** — one renderer plus two registry entries; see the `add-platform` skill
+- **A new annotation** — see the `add-annotation` skill, which lists every place one has to be wired
+- **Organization-specific processors** that consume the same annotations for in-house tooling
+
+Every annotation must be demonstrated in all four example projects and appear in the
+[annotation reference](#annotation-reference); `ExampleCoverageTest` and `AnnotationReferenceTest`
+fail the build otherwise.
 
 ## 📊 Project Components
 
 ### vibetags/
-The core annotation processor library. Contains all 15 Java annotations and the annotation processor that generates AI configuration files at compile time.
+The core annotation processor library. Contains the annotation processor that generates AI
+configuration files at compile time; the annotations themselves live in `vibetags-annotations/`
+(see [project facts](#project-facts) for the count).
 
 ### [example/](example/README.md)
-A practical e-commerce application demonstrating real-world usage of all 8 VibeTags annotations. Shows how to protect legacy payment processors, guide AI on security configurations, request AI implementations for notification services, enforce continuous security auditing for database infrastructure, mark PII fields, identify core business logic, and enforce hot-path performance constraints.
+A practical e-commerce application demonstrating every VibeTags annotation
+(see [project facts](#project-facts) for the count), held to that by `ExampleCoverageTest`. Shows how to protect legacy payment processors, guide AI on security configurations, request AI implementations for notification services, enforce continuous security auditing for database infrastructure, mark PII fields, identify core business logic, and enforce hot-path performance constraints.
 
 ### [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 Technical reference for the annotation processor internals. Read this before contributing or if you need to understand why a particular file is (or is not) being generated.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -590,7 +590,7 @@ vibetags/
 │   ├── src/main/java/se/deversity/vibetags/annotations/
 │   │   ├── AILocked.java
 │   │   ├── AIContext.java
-│   │   ├── ...                          # 39 annotation @interface files in total — see ../README.md#project-facts
+│   │   ├── ...                          # every @interface — see ../README.md#project-facts
 │   │   └── AITemporary.java
 │   ├── pom.xml
 │   └── build.gradle

--- a/docs/vibetags-in-practice.md
+++ b/docs/vibetags-in-practice.md
@@ -20,7 +20,7 @@ Five codebases use VibeTags. All are authored by the same developer, so this is 
 
 Two areas inside the VibeTags repo are **not** real usage and are excluded from all counts below:
 
-- **`example/`** — 82 uses across all 39 annotation types, 26 of them exactly once. This is a coverage matrix, not a risk model: one annotation per formatter code path, wired into the `verify-generated-files` CI action that greps generated output for expected strings. Its heavy `@AIDraft` use (15 real sites) exists because demonstrating "AI, implement this" requires stub bodies.
+- **`example/`** — at least one use of every annotation type. This is a coverage matrix, not a risk model: one annotation per formatter code path, wired into the `verify-generated-files` CI action that greps generated output for expected strings. Its heavy `@AIDraft` use (15 real sites) exists because demonstrating "AI, implement this" requires stub bodies.
 - **`load-tests/`** — `SyntheticClassGenerator` emits annotations *as strings at runtime* on a modulo schedule (every class `@AIContext`, every 2nd `@AILocked`, every 5th `@AIPrivacy`…), sweeping N from 10 to 10,000 classes. Annotations as synthetic load, not guardrails.
 
 ### The headline finding

--- a/vibetags/pom.xml
+++ b/vibetags/pom.xml
@@ -273,6 +273,28 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!--
+                      The published javadoc documents what a consumer can actually use. Everything
+                      under processor.internal is the compiler-facing half — ArchitectureRulesTest
+                      polices its dependency direction precisely because it is free to change — so
+                      shipping it here would invite people to bind to classes with no stability
+                      promise.
+
+                      processor.model goes with it: it is the compiler-free data layer the
+                      renderers read, not something a consumer calls. Its 74 undocumented
+                      methods are a contributor-facing gap, not a published one.
+
+                      Between them they hold every javadoc warning in this module, so
+                      excluding them makes the artifact honest and lets doclint be fatal
+                      on the surface that really is API, rather than trading one for the
+                      other. Note javadoc caps output at -Xmaxwarns (100 by default), so
+                      a count of exactly 100 is a cap and not a total.
+                    -->
+                    <excludePackageNames>se.deversity.vibetags.processor.internal:se.deversity.vibetags.processor.internal.*:se.deversity.vibetags.processor.model</excludePackageNames>
+                    <doclint>all</doclint>
+                    <failOnWarnings>true</failOnWarnings>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
@@ -857,6 +857,18 @@ public class AIGuardrailProcessor extends AbstractProcessor {
         OrphanWarner.warnAboutOrphans(messager, log, active, hasLocked, hasIgnore, hasAudit);
     }
 
+    /**
+     * Writes {@code content} to {@code path} through the marker-aware writer, if it differs from
+     * what is already there.
+     *
+     * @param path        the file to write, absolute or relative to the VibeTags root
+     * @param content     the generated body; for a marker file this is the block between the
+     *                    markers, and hand-authored content outside them is preserved
+     * @param hasNewRules whether this round produced any rules. When false the writer leaves an
+     *                    existing file alone rather than emptying it, so a compile that saw no
+     *                    annotations cannot wipe guardrails another round wrote
+     * @return {@code true} if the file was created or changed, {@code false} if it was left as-is
+     */
     public boolean writeFileIfChanged(String path, String content, boolean hasNewRules) {
         return fileWriter.writeFileIfChanged(path, content, hasNewRules);
     }
@@ -885,13 +897,28 @@ public class AIGuardrailProcessor extends AbstractProcessor {
         fileWriter.cleanupGranularDirectory(dir, extension, excludeQNames);
     }
 
-    /** @deprecated call {@link ServiceRegistry#buildServiceFileMap(Path)} directly. */
+    /**
+     * Maps every known service key to the file or directory it would be written to.
+     *
+     * @param root the VibeTags root that output paths are resolved against
+     * @return service key to output path, for every service the processor knows about, whether or
+     *         not that path exists — presence is what decides activation, not this map
+     * @deprecated call {@link ServiceRegistry#buildServiceFileMap(Path)} directly.
+     */
     @Deprecated
     public static Map<String, Path> buildServiceFileMap(Path root) {
         return ServiceRegistry.buildServiceFileMap(root);
     }
 
-    /** @deprecated call {@link ServiceRegistry#resolveActiveServices(Messager, Map)} directly. */
+    /**
+     * Narrows the full service map to the services this project has opted into.
+     *
+     * @param messager        where to report activation notes to the compiler
+     * @param allServiceFiles every known service and its output path, as
+     *                        {@link #buildServiceFileMap(Path)} returns it
+     * @return the keys whose output file already exists, since file presence is the opt-in
+     * @deprecated call {@link ServiceRegistry#resolveActiveServices(Messager, Map)} directly.
+     */
     @Deprecated
     public static Set<String> resolveActiveServices(Messager messager, Map<String, Path> allServiceFiles) {
         return ServiceRegistry.resolveActiveServices(messager, allServiceFiles);

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/VibeTagsLogger.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/VibeTagsLogger.java
@@ -101,6 +101,9 @@ public final class VibeTagsLogger {
 
     /**
      * Detaches and stops appenders specifically for the given project root's logger.
+     *
+     * @param projectRoot the root whose logger should be torn down; {@code null} is a no-op, so a
+     *                    caller that never resolved a root does not have to guard the call
      */
     public static void shutdown(@Nullable Path projectRoot) {
         if (projectRoot == null) return;

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/model/SourceLocation.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/model/SourceLocation.java
@@ -6,6 +6,10 @@ package se.deversity.vibetags.processor.model;
  * <p>Best-effort metadata. Positions come from the javac Compiler Tree API, which is unavailable
  * under other compilers (e.g. ECJ) and in in-memory compilation — callers must treat a missing
  * location as normal, never as an error.
+ *
+ * @param file      path to the source file the declaration was read from
+ * @param startLine first line of the declaration, 1-based and inclusive
+ * @param endLine   last line of the declaration, 1-based and inclusive
  */
 public record SourceLocation(String file, long startLine, long endLine) {
 }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ProjectFactsConsistencyTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ProjectFactsConsistencyTest.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,80 @@ class ProjectFactsConsistencyTest {
 
     /** {@code vibetags/} is the surefire working directory; its parent is the repo root. */
     private static final Path REPO_ROOT = Paths.get("").toAbsolutePath().getParent();
+
+    /**
+     * Docs that state a version's own historical scope, which must keep their original numbers.
+     * A changelog entry saying a release "extends the set to 39 annotations" was true when written
+     * and stays true; rewriting it would claim that release shipped something it did not.
+     */
+    private static final Set<String> HISTORICAL_DOCS = Set.of(
+        "docs/CHANGELOG.md", "docs/proposed-annotations.md", "docs/PLAN.md",
+        "docs/ARCHITECTURE.md",       // its "Last updated" note quotes the counts it removed
+        "USAGE.md");                  // "v0.9.9 extends the set to 39" is a statement about v0.9.9
+
+    /**
+     * Prose that claims to state the <em>whole</em> set: "all N annotations", "the N annotations",
+     * or "N annotation ... in total".
+     *
+     * <p>Deliberately not every "N annotations". A sentence like "7 annotations have zero
+     * real-world traction" is a finding about a subset and is true; only a claim about the total
+     * can go stale. Matching both would force whole documents onto an exemption list, which would
+     * then hide the next real drift inside them.
+     *
+     * <p>Version strings are excluded by the leading guard: the 8 in "v0.9.8 annotations" is not a
+     * count.
+     */
+    private static final Pattern PROSE_COUNT = Pattern.compile(
+        "(?:all|the)\\s+(\\d+)\\s+(?:Java\\s+|VibeTags\\s+)?annotations?\\b"
+            + "|(?<![\\d.])(\\d+)\\s+(?:Java\\s+|VibeTags\\s+)?annotation\\b[^.\\n]*?\\bin total\\b");
+
+    @Test
+    void noDocRestatesADifferentAnnotationCount() throws IOException {
+        Path annotationsDir = REPO_ROOT.resolve(
+            "vibetags-annotations/src/main/java/se/deversity/vibetags/annotations");
+        assumeTrue(Files.isDirectory(annotationsDir), "annotations module not reachable; skipping");
+        long actual;
+        try (Stream<Path> files = Files.list(annotationsDir)) {
+            actual = files
+                .filter(p -> p.toString().endsWith(".java"))
+                .filter(ProjectFactsConsistencyTest::isAnnotationInterface)
+                .count();
+        }
+
+        List<String> drifted = new ArrayList<>();
+        try (Stream<Path> docs = Files.walk(REPO_ROOT)) {
+            for (Path doc : docs.filter(p -> p.toString().endsWith(".md")).toList()) {
+                String rel = REPO_ROOT.relativize(doc).toString().replace('\\', '/');
+                if (rel.contains("/target/") || rel.contains("/node_modules/")
+                    || rel.startsWith("target/") || HISTORICAL_DOCS.contains(rel)) {
+                    continue;
+                }
+                String text;
+                try {
+                    text = Files.readString(doc, StandardCharsets.UTF_8);
+                } catch (IOException notText) {
+                    continue;
+                }
+                Matcher m = PROSE_COUNT.matcher(text);
+                while (m.find()) {
+                    String captured = m.group(1) != null ? m.group(1) : m.group(2);
+                    int stated = Integer.parseInt(captured);
+                    if (stated != actual) {
+                        int line = (int) text.substring(0, m.start()).chars()
+                            .filter(c -> c == '\n').count() + 1;
+                        drifted.add(rel + ":" + line + " says \"" + m.group() + "\"");
+                    }
+                }
+            }
+        }
+
+        assertTrue(drifted.isEmpty(),
+            "There are " + actual + " annotations, but these docs state a different count. The "
+                + "README project-facts line is the single source of truth and other docs are "
+                + "meant to link to it rather than restate it — restating is how \"all 15 Java "
+                + "annotations\" survived six lines below the pinned figure:\n  "
+                + String.join("\n  ", drifted));
+    }
 
     @Test
     void readmeOutputCountsMatchWhatTheServiceRegistryDeclares() throws IOException {


### PR DESCRIPTION
The published javadoc jar documented every internal class in the module and warned on most of
them. Two problems in one artifact: it invites a consumer to bind to classes that are free to
change every release, and the noise is why nobody noticed the API itself was undocumented.

**Scoped to what a consumer can actually use.** processor.internal is the compiler-facing half —
ArchitectureRulesTest polices its dependency direction precisely because it has no stability
promise — and processor.model is the compiler-free data layer the renderers read. Neither is
called from outside. Both are now excluded from the published javadoc. Their 74 undocumented
methods remain a contributor-facing gap, and contributors read the source.

**The API surface that was left is now documented and enforced.** Ten gaps: the SourceLocation
record's three components, AIGuardrailProcessor.writeFileIfChanged (public, no comment at all),
two deprecated delegates missing @param/@return, and VibeTagsLogger.shutdown(Path). doclint=all
plus failOnWarnings now makes a regression fatal, matching what vibetags-annotations already does.
generateFiles() was not touched; it is @AILocked and none of these are it.

One measurement error worth recording, because it changed the conclusion twice: javadoc caps its
output at -Xmaxwarns, 100 by default. Two successive runs reported exactly 100 warnings and I read
the second as unchanged, when the first had actually been a truncated sample attributing
everything to processor.internal. The real distribution only appeared once the cap stopped binding
— at which point the remaining warnings turned out to be somewhere else entirely. A count equal to
the cap is a lower bound, not a total.

1458 tests green with Checkstyle, PMD, SpotBugs + Find Security Bugs, NullAway and JaCoCo; both
javadoc jars build clean with warnings fatal.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AZnf9DAJm12KZCXMNMQaWe

---

Follow-up to #351, which was squash-merged one commit before this landed on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZnf9DAJm12KZCXMNMQaWe