### PR TITLE
chore: prepare release v1.0.0-RC10

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.0.0-RC9
+version: 1.0.0-RC10
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.0-RC9</version>
+    <version>1.0.0-RC10</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.0-RC9'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC9'
+compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.0-RC10'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC10'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.0-RC9</version>
+            <version>1.0.0-RC10</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.0-RC9</version>
+                        <version>1.0.0-RC10</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -117,8 +117,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC9')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC9')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC10')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC10')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -434,7 +434,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.0-RC9</version>
+            <version>1.0.0-RC10</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -459,7 +459,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.0-RC9</version>
+                        <version>1.0.0-RC10</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -473,8 +473,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC9')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC9')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC10')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC10')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -488,15 +488,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.0-RC9</version>
+    <version>1.0.0-RC10</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC9'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC9'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC10'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC10'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-RC10] - 2026-08-03
+
 ### Added
 - **Every example demonstrates all 44 annotations, and the README says where each one goes.**
 
@@ -1723,7 +1725,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC9...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC10...HEAD
+[1.0.0-RC10]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC9...v1.0.0-RC10
 [1.0.0-RC9]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC8...v1.0.0-RC9
 [1.0.0-RC8]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC7...v1.0.0-RC8
 [1.0.0-RC7]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC6...v1.0.0-RC7

--- a/example-all-tiers/pom.xml
+++ b/example-all-tiers/pom.xml
@@ -26,7 +26,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.0.0-RC9</vibetags.bom.version>
+    <vibetags.bom.version>1.0.0-RC10</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/example-multimodule-indexed/pom.xml
+++ b/example-multimodule-indexed/pom.xml
@@ -30,7 +30,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.0.0-RC9</vibetags.bom.version>
+    <vibetags.bom.version>1.0.0-RC10</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/example-multimodule/pom.xml
+++ b/example-multimodule/pom.xml
@@ -29,7 +29,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.0.0-RC9</vibetags.bom.version>
+    <vibetags.bom.version>1.0.0-RC10</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC9')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC9')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC10')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC10')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.0.0-RC9</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0-RC10</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.0.0-RC9</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0-RC10</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.0-RC9'
+version = '1.0.0-RC10'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.0.0-RC9'
+            version = '1.0.0-RC10'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -39,12 +39,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.0.0-RC9&lt;/version&gt;
+                &lt;version&gt;1.0.0-RC10&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC9'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC9'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC10'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC10'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -36,7 +36,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.0.0-RC9&lt;/version&gt;
+                        &lt;version&gt;1.0.0-RC10&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC9')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC9')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC10')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC10')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -68,7 +68,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.0.0-RC9</revision>
+        <revision>1.0.0-RC10</revision>
 
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.0-RC9'
+version = '1.0.0-RC10'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.0.0-RC9'
+            version = '1.0.0-RC10'
             from components.java
 
             pom {
@@ -77,7 +77,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC9'
+    api 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC10'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.1'


### PR DESCRIPTION
Prepares the `1.0.0-RC10` release: version bump everywhere, and the `[Unreleased]` changelog section closed off as `[1.0.0-RC10] - 2026-08-03`.

## What is in the release

### Added
- **Every example demonstrates all 44 annotations, and the README says where each one goes.** `example-all-tiers/` went from 20 annotations to 44; `ExampleCoverageTest` now holds all four example projects to the full set. The README gained a 44-row reference whose three columns are derived from the code by `AnnotationReferenceTest`, including the tier column, which is a property of the renderer rather than of the annotation.
- **Opting a scoped-rules directory in and back out again is tested in both directions.** Opting out fails silently and into a shape that looks correct, so `ScopedRulesOptInOptOutEndToEndTest` drives both transitions over real sources.
- **International characters in annotation values are proven, not assumed.** `InternationalCharactersEndToEndTest` drives a real compile with 10 scripts plus emoji and combining marks, and reads them back through XML, a real JSON parser, TOML, the base64 sidecar round trip, and the raw bytes on disk.
- **The cross-module merge records which branch it took.** Every path emits its reason, every `.skip` carries one, and all four example poms now wire `-Avibetags.log.level` so the diagnostic channel is reachable by anyone following the docs.
- **All four examples verify their committed guardrails, and every documentation link resolves.** `DocumentationLinksTest` checks every relative link and fragment across 738 Markdown files; eight were dead.
- **The release script rewrites every file that states the version.** `ReleaseScriptCoverageTest` derives the list rather than trusting it, so a GA cut cannot ship install snippets pointing at a release candidate.
- **`example-all-tiers/`: all three tiers at once**, with `InvoiceController` carrying a guardrail at every level one can attach to, down to a method parameter.
- **Lifecycle coverage for the second compile, and check mode wired into an example.** `GuardrailLifecycleEndToEndTest` covers value edits, deletions, and platform opt-out, the last of which had nothing behind it despite being the load-bearing invariant.

### Fixed
- **The README understated the number of generated files by a third.** 37 is the tool count, not the file count; the registry declares 62 outputs. All four project figures are now pinned against the live registry.
- **Multi-module reactors froze their JSON and TOML outputs after the first write**, and the freeze hid a whole-file-overwrite bug underneath it. `PlatformRenderer.wholeFileMerge()` re-assembles those documents from every module, and `MultiModuleWholeFileMergeTest` derives which services need one. Measured on `example-multimodule`: `.mentatconfig.json` went from 1 entry from 1 of 4 modules to 51 entries across all modules.

Full detail in `docs/CHANGELOG.md`.

## Version bump

`scripts/set-version.sh 1.0.0-RC10` rewrote `<revision>` in `vibetags-parent/pom.xml` plus the 12 files that cannot inherit it. `load-tests/pom.xml` is deliberately untouched: its `<processor.version>` is pinned independently so benchmarks can compare across versions.

## Verification

Run locally on this branch:

| Gate | Result |
|---|---|
| `BuildVersionParityTest` | pass (5 tests) |
| `vibetags` full suite | pass, 1458 tests, 0 failures, 0 errors, 0 skipped |
| `example` clean compile | pass, processor reports `v1.0.0-RC10`, 44 active services |
| `example-multimodule`, `example-all-tiers`, `example-multimodule-indexed` | pass, plain compile and `-Dvibetags.check=true` |
| Leftover-version sweep | only the expected historical references remain (old changelog entries, `load-tests/` baselines and pom, `since 1.0.0-RC9` prose, the version-sort-order test comment) |
| `pre-commit run --all-files` | **not run**: `pre-commit` is not installed on this machine. Checkstyle ran as part of the Maven build and was clean; trailing whitespace and end-of-file were checked by hand across all 14 changed files and were clean. gitleaks did not run locally and will run in CI. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173dGYbrDQAyZvX7VN3uA5q
