### PR TITLE
chore: declare the MIT license in every pom and both publishing Gradle builds

### DIFF
--- a/example-all-tiers/pom.xml
+++ b/example-all-tiers/pom.xml
@@ -17,6 +17,14 @@
     and which tier it lands in.
   </description>
 
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <modules>
     <module>billing</module>
     <module>shipping</module>

--- a/example-multimodule-indexed/pom.xml
+++ b/example-multimodule-indexed/pom.xml
@@ -18,6 +18,14 @@
     layout) — see https://github.com/PIsberg/vibetags/issues/295.
   </description>
 
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <modules>
     <module>core</module>
     <module>app</module>

--- a/example-multimodule/pom.xml
+++ b/example-multimodule/pom.xml
@@ -17,6 +17,14 @@
     (regression example for https://github.com/PIsberg/vibetags/issues/278).
   </description>
 
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <modules>
     <module>core</module>
     <module>engine</module>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -13,6 +13,14 @@
     <name>VibeTags Example Project</name>
     <description>Example project demonstrating VibeTags AI guardrails library</description>
 
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -12,6 +12,14 @@
 
     <name>VibeTags Demo</name>
 
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -30,6 +30,7 @@ publishing {
                     license {
                         name = 'MIT License'
                         url = 'https://opensource.org/licenses/MIT'
+                        distribution = 'repo'
                     }
                 }
                 developers {

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -30,6 +30,7 @@
         <license>
             <name>MIT License</name>
             <url>https://opensource.org/licenses/MIT</url>
+            <distribution>repo</distribution>
         </license>
     </licenses>
 

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -31,6 +31,7 @@ publishing {
                     license {
                         name = 'MIT License'
                         url = 'https://opensource.org/licenses/MIT'
+                        distribution = 'repo'
                     }
                 }
                 developers {


### PR DESCRIPTION
GA metadata pass requested after the RC10 sweep: every pom now carries (or inherits) the MIT license block with distribution=repo, and both publishing Gradle builds emit it.

- vibetags-parent already declared MIT name+url; it gains distribution=repo. The four managed poms (processor, annotations, bom, load-tests) inherit it — declared once, the same way this repo treats versions.
- The five standalone roots that cannot inherit (example, example-multimodule, example-multimodule-indexed, example-all-tiers, tools/demo) each get the full block; their reactor children inherit from them.
- vibetags/build.gradle and vibetags-annotations/build.gradle add distribution = 'repo' to their existing license metadata. example/build.gradle publishes nothing and has no pom to carry metadata, so it is unchanged.

Verified: effective-pom shows the full block for a managed pom (vibetags) and a reactor child (example-multimodule/cli); the flattened deploy pom — the one that actually ships to Maven Central — keeps it; the Gradle-generated publication pom emits it; BuildVersionParityTest passes. Checkstyle hook not run locally (needs Docker, which is down; no Java changed) — CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013j5WQ59Jk8wwFP6ZZeyu5K