### PR TITLE
ci: run PIT mutation testing on demand only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -618,47 +618,5 @@ jobs:
           flags: unittests-gradle
           fail_ci_if_error: false
 
-  mutation-testing:
-    name: Mutation Testing (PIT)
-    runs-on: ubuntu-latest
-    needs: build-maven
-    continue-on-error: true
-
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-          cache: maven
-
-      - name: Install async-test-lib (required for concurrency tests, not on Maven Central)
-        run: |
-          git clone --depth 1 --branch v1.7.0-RC5 https://github.com/PIsberg/async-test-lib.git /tmp/async-test-lib
-          cd /tmp/async-test-lib
-          mvn install -DskipTests -B -q
-
-      - name: Install VibeTags Annotations (Maven)
-        run: |
-          cd vibetags-annotations
-          mvn install -B
-
-      - name: Run Mutation Coverage (PIT)
-        run: |
-          cd vibetags
-          mvn -B -Pmutation test-compile org.pitest:pitest-maven:mutationCoverage
-
-      - name: Upload PIT mutation report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: pitest-report-${{ github.run_id }}
-          path: vibetags/target/pit-reports/**
-          if-no-files-found: warn
+  # Mutation testing moved to .github/workflows/mutation.yml and runs on demand only
+  # (workflow_dispatch). It was the longest job here and nothing gated on its result.

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,55 @@
+name: Mutation Testing (PIT)
+
+# On demand only. A full PIT run over se.deversity.vibetags.* costs far more wall-clock than the
+# rest of CI combined and its score moves slowly, so running it on every push bought a number
+# nobody read. Trigger it from Actions -> Mutation Testing (PIT) -> Run workflow, choosing the
+# branch to analyse, when test strength is the actual question.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mutation-testing:
+    name: Mutation Testing (PIT)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Install async-test-lib (required for concurrency tests, not on Maven Central)
+        run: |
+          git clone --depth 1 --branch v1.7.0-RC5 https://github.com/PIsberg/async-test-lib.git /tmp/async-test-lib
+          cd /tmp/async-test-lib
+          mvn install -DskipTests -B -q
+
+      - name: Install VibeTags Annotations (Maven)
+        run: |
+          cd vibetags-annotations
+          mvn install -B
+
+      - name: Run Mutation Coverage (PIT)
+        run: |
+          cd vibetags
+          mvn -B -Pmutation test-compile org.pitest:pitest-maven:mutationCoverage
+
+      - name: Upload PIT mutation report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pitest-report-${{ github.run_id }}
+          path: vibetags/target/pit-reports/**
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Maven](https://img.shields.io/badge/build-Maven-blue?logo=apachemaven)](https://github.com/PIsberg/vibetags/actions/workflows/build.yml)
 [![Gradle](https://img.shields.io/badge/build-Gradle-blue?logo=gradle)](https://github.com/PIsberg/vibetags/actions/workflows/build.yml)
 [![codecov](https://codecov.io/gh/PIsberg/vibetags/branch/main/graph/badge.svg)](https://codecov.io/gh/PIsberg/vibetags)
-[![PIT Mutation Testing](https://img.shields.io/badge/PIT%20Mutation-56%25-yellow?logo=apachemaven&logoColor=white)](https://github.com/PIsberg/vibetags/actions/workflows/build.yml)
+[![PIT Mutation Testing](https://img.shields.io/badge/PIT%20Mutation-56%25-yellow?logo=apachemaven&logoColor=white)](https://github.com/PIsberg/vibetags/actions/workflows/mutation.yml)
 [![Lines of Code](https://www.aschey.tech/tokei/github/PIsberg/VibeTags?languages=Java&category=code)](https://github.com/PIsberg/VibeTags)
 [![PMD](https://img.shields.io/badge/PMD-passing-brightgreen)](https://pmd.github.io/)
 [![Analyzed with codekoll](https://img.shields.io/badge/analyzed%20with-codekoll-brightgreen?logo=java&logoColor=white)](https://github.com/PIsberg/codekoll)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **PIT mutation testing runs on demand only.** It moved out of `build.yml` into its own
+  `mutation.yml`, whose sole trigger is `workflow_dispatch`. The job was the longest leg in CI and
+  carried `continue-on-error: true`, so no score it produced could fail a build — every push paid
+  for a number nothing acted on. The standalone workflow drops `continue-on-error`: when someone
+  asks for the run, a failure should read as one. Nothing about the `mutation` Maven profile
+  changed, so `mvn -B -Pmutation test-compile org.pitest:pitest-maven:mutationCoverage` still works
+  locally and from a dispatched run.
+
 ## [1.0.0-RC10] - 2026-08-03
 
 ### Added

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,6 +1,6 @@
 # GitHub Actions Workflows
 
-This document describes what happens during CI builds in `.github/workflows/`. Five workflows run on push, pull request, schedule, or release.
+This document describes what happens during CI builds in `.github/workflows/`. Five workflows run on push, pull request, schedule, or release; a sixth, mutation testing, runs only when someone asks for it.
 
 ## Overview
 
@@ -11,6 +11,7 @@ This document describes what happens during CI builds in `.github/workflows/`. F
 | Dependency Review | `dependency-review.yml` | Pull requests |
 | Scorecard | `scorecards.yml` | Push to `main`, branch-protection-rule, weekly cron (Tuesdays 07:20 UTC) |
 | Publish to Maven Central | `publish.yml` | GitHub Release `created` |
+| Mutation Testing (PIT) | `mutation.yml` | Manual only (`workflow_dispatch`) |
 
 All jobs run on `ubuntu-latest` and start with the StepSecurity `harden-runner` action in `audit` mode, which records every outbound network call. The default token permission for every workflow is `contents: read`; jobs that need more (e.g. CodeQL writes `security-events`) escalate explicitly.
 
@@ -20,7 +21,7 @@ All third-party actions are pinned by full commit SHA with the version as a trai
 
 ## 1. Build and Test (`build.yml`)
 
-The main CI workflow. Jobs run in parallel except `load-tests` and `mutation-testing`, which both wait on `build-maven`.
+The main CI workflow. Jobs run in parallel except `load-tests`, which waits on `build-maven`.
 
 ### Job: `build-maven`
 
@@ -87,14 +88,7 @@ Mirror of `build-maven` but with Gradle. Matrix over **JDK 21, 25, 26**. Differe
 
 The same `.github/actions/verify-generated-files` composite action runs after the Gradle build, so any divergence between Maven and Gradle output paths is caught.
 
-### Job: `mutation-testing`
-
-Single JDK 21 leg, `needs: build-maven`, `continue-on-error: true` — a failing or low-scoring mutation run does not fail the overall workflow. Steps:
-
-1. **Harden runner**, **checkout**, **set up JDK 21** (Maven cache).
-2. **Install async-test-lib** and **Install VibeTags Annotations** — same as `build-maven`.
-3. **Run Mutation Coverage (PIT)** — `cd vibetags && mvn -B -Pmutation test-compile org.pitest:pitest-maven:mutationCoverage`. The `mutation` Maven profile (in `vibetags/pom.xml`) pulls in `pitest-maven` 1.19.1 and `pitest-junit5-plugin` 1.2.2 and is otherwise inactive — it only runs when `-Pmutation` is passed explicitly, so normal `mvn install`/`mvn test` runs are unaffected.
-4. **Upload PIT mutation report** — `if: always()`. Uploads `vibetags/target/pit-reports/**` as `pitest-report-${{ github.run_id }}`, `if-no-files-found: warn`.
+Mutation testing used to be a job here. It now lives in its own manually triggered workflow — see section 6.
 
 ---
 
@@ -138,6 +132,20 @@ Triggered when a GitHub Release is created.
 - **Sign and deploy BOM** — `cd vibetags-bom && mvn clean deploy -P central-publish,sign-artifacts -B -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"`. Same Sonatype Central + GPG profiles as the processor pom; publishes `se.deversity.vibetags:vibetags-bom:<version>` (pom-only) so consumers can import it. Runs after annotations and processor have been deployed.
 
 Required repository secrets: `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`, `CENTRAL_TOKEN_USERNAME`, `CENTRAL_TOKEN_PASSWORD`. CI also references `CODECOV_TOKEN` from `build.yml`.
+
+---
+
+## 6. Mutation Testing (`mutation.yml`)
+
+PIT mutation coverage over `se.deversity.vibetags.*`. **On demand only** — the sole trigger is `workflow_dispatch`, so nothing starts it on push or pull request. Run it from Actions → Mutation Testing (PIT) → Run workflow, picking the branch to analyse.
+
+It was a job in `build.yml` until it was split out. A full PIT run costs more wall-clock than the rest of CI put together, its score moves slowly, and `continue-on-error: true` meant no result it produced could ever fail a build — so every push paid for a number nobody read. The split also drops `continue-on-error`: when the run is deliberate, a red run should read as red.
+
+- Single JDK 21 leg, `ubuntu-latest`, `contents: read`.
+- Steps: harden runner → checkout → set up JDK 21 (Maven cache) → install `async-test-lib` → `cd vibetags-annotations && mvn install -B` → `cd vibetags && mvn -B -Pmutation test-compile org.pitest:pitest-maven:mutationCoverage`.
+- The `mutation` Maven profile (in `vibetags/pom.xml`) pulls in `pitest-maven` and `pitest-junit5-plugin` and is otherwise inactive — it only applies when `-Pmutation` is passed explicitly, so normal `mvn install` / `mvn test` runs are unaffected. It sets no `mutationThreshold`, so the job goes red only on a real failure, not on a low score.
+- **Upload PIT mutation report** — `if: always()`. Uploads `vibetags/target/pit-reports/**` as `pitest-report-${{ github.run_id }}`, `if-no-files-found: warn`.
+- The PIT badge in `README.md` is a hand-maintained static badge; update it from a dispatched run rather than expecting CI to move it.
 
 ---
 


### PR DESCRIPTION
PIT was a job in `build.yml` on every push and pull request. It was the longest leg in CI, and it carried `continue-on-error: true`, so no score it produced could ever fail a build. Every push paid for a number nothing acted on.

## What changed

- **`.github/workflows/mutation.yml` (new)** — the `mutation-testing` job, moved verbatim, with `on: workflow_dispatch` as its only trigger. Run it from Actions → Mutation Testing (PIT) → Run workflow, choosing the branch to analyse.
- **`.github/workflows/build.yml`** — job removed (−42 lines), replaced by a pointer comment. Remaining jobs: `build-maven`, `cross-platform`, `load-tests`, `build-gradle`.
- **`continue-on-error: true` dropped** in the move. It existed so a slow or low-scoring run would not fail CI. On a run someone deliberately asked for, a failure should read as one. The `mutation` profile sets no `mutationThreshold`, so the job goes red only on a real failure, not on a low score.
- **`docs/WORKFLOW.md`** — new section 6, a row in the overview table, and the now-false claim that `load-tests` and `mutation-testing` both wait on `build-maven` corrected.
- **`README.md`** — the PIT badge links to `mutation.yml` instead of `build.yml`. It stays a hand-maintained static badge.
- **`docs/CHANGELOG.md`** — entry under `[Unreleased]`.

The `mutation` Maven profile in `vibetags/pom.xml` is untouched, so `mvn -B -Pmutation test-compile org.pitest:pitest-maven:mutationCoverage` behaves the same locally and in a dispatched run.

## Verification

- Both workflow files parse as YAML; `build.yml` jobs are now `build-maven`, `cross-platform`, `load-tests`, `build-gradle`, and `mutation.yml` carries `workflow_dispatch` only.
- No Java test and no other workflow referenced the removed job (`grep` over `vibetags/src/test` and `.github/`).
- `pre-commit` was **not run** — it is not installed in the working shell (`python -m pre_commit` reports no module). Trailing whitespace and end-of-file newlines were checked by hand instead. Treat the hooks as unrun, not passed.
- The dispatched workflow itself cannot be exercised until it is on the default branch, since `workflow_dispatch` only lists workflows present there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fr9sysr7VcngChxfm2uTuw
