### PR TITLE
docs: document the two silent no-generation causes; complete the Unreleased changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 
 > **Note:** `maven-compiler-plugin`'s `<annotationProcessorPaths>` does not honour `<dependencyManagement>` (see [MCOMPILER-391](https://issues.apache.org/jira/browse/MCOMPILER-391)). Reuse the BOM version property there — see `example/pom.xml`.
 
+> **Note (JDK 23+):** `javac` only runs annotation processors that are explicitly configured; `<annotationProcessorPaths>` and Gradle's `annotationProcessor` qualify. A pom that instead lists `vibetags-processor` as an ordinary dependency silently generates nothing on JDK 23+ unless `<proc>full</proc>` is added to `maven-compiler-plugin`. More silent-failure cases: [Troubleshooting: Nothing Was Generated](USAGE.md#troubleshooting-nothing-was-generated).
+
 **Gradle:**
 ```groovy
 dependencies {

--- a/USAGE.md
+++ b/USAGE.md
@@ -6,6 +6,7 @@
 
 - [Logging Configuration](#logging-configuration)
 - [Choosing Which AI Services to Support (Opt-in Model)](#choosing-which-ai-services-to-support-opt-in-model)
+- [Troubleshooting: Nothing Was Generated](#troubleshooting-nothing-was-generated)
 - [Granular Rules (Cursor, Trae, Roo Code)](#-granular-rules-cursor-trae-roo-code)
 - [Qwen Configuration](#-qwen-configuration)
 - [llms.txt Standard](#-llmstxt-standard-windsurf-cascade--llm-agents)
@@ -264,6 +265,48 @@ Create one or more of the following files in your project root to opt in:
 ```
 
 **Teams:** Only commit the config files for the AI tools your team actually uses.
+
+### Troubleshooting: Nothing Was Generated
+
+The build says `BUILD SUCCESS`, an opted-in file exists, and it is still empty. Both known
+causes are silent, and both turned up in real consumer projects, so check these two first.
+
+**1. JDK 23+ only runs annotation processors that are explicitly configured.**
+
+Since JDK 23, `javac` no longer picks up annotation processors found on the class path. A pom
+that declares `vibetags-processor` as an ordinary (or `provided`) dependency compiles cleanly
+on JDK 23+ and generates nothing: no error, no warning, no files.
+
+The recommended setup is explicit and therefore unaffected: `<annotationProcessorPaths>` on
+Maven (as shown in the [README](README.md)), the `annotationProcessor` configuration on
+Gradle. If the processor must stay on the class path, restore processing with:
+
+```xml
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-compiler-plugin</artifactId>
+    <configuration>
+        <proc>full</proc>
+    </configuration>
+</plugin>
+```
+
+**2. A build with nothing to compile never starts `javac`.**
+
+VibeTags runs inside the compiler. An incremental `mvn compile` with no changed sources skips
+`javac` entirely, so a platform file you just opted in stays empty even though the build is
+green. The same applies to opting out and to verifying a regeneration: the change only shows
+once `javac` actually runs.
+
+Force one real compile after changing the opt-in set:
+
+```bash
+mvn clean compile      # or touch any source file, then compile
+```
+
+**Still empty?** Read `vibetags.log`. Every skipped write is a `write.skip` event carrying a
+`reason=`, and compiling with `-Avibetags.log.level=DEBUG` records the full decision path
+(see [Logging Configuration](#logging-configuration)).
 
 ### 🧩 Granular Rules (Cursor, Trae, Roo Code)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`USAGE.md` documents the two silent ways to get nothing generated.** A new Troubleshooting
+  section covers JDK 23+ no longer running class-path annotation processors, which turned a
+  `provided`-scope `vibetags-processor` into a no-op with no error and no warning in a real
+  consumer project (`<proc>full</proc>` or the recommended `<annotationProcessorPaths>` setup
+  restores it), and incremental builds with no stale sources never starting `javac`, which
+  leaves a freshly opted-in file empty until a clean or touched-source compile. The README's
+  installation section gained the JDK 23+ note beside its existing `annotationProcessorPaths`
+  caveat.
+- **The five aggregate-granular pairs claim is derived, not asserted (#356).**
+  `DocsGranularPairsClaimTest` reads the pair count and directory list from
+  `GranularIndexSection` and fails `PLATFORMS.md` or `LOAD-BEARING.md` when either disagrees.
+  It catches the exact drift #355 fixed: the docs said four platforms while the code gated
+  five.
+
 ### Changed
 - **PIT mutation testing runs on demand only.** It moved out of `build.yml` into its own
   `mutation.yml`, whose sole trigger is `workflow_dispatch`. The job was the longest leg in CI and
@@ -15,6 +30,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   asks for the run, a failure should read as one. Nothing about the `mutation` Maven profile
   changed, so `mvn -B -Pmutation test-compile org.pitest:pitest-maven:mutationCoverage` still works
   locally and from a dispatched run.
+- **Every published pom carries the complete MIT license block (#357).** The parent's existing
+  declaration gained `distribution=repo` and the four managed poms inherit it; the five
+  standalone example roots that cannot inherit each received the full block, and both
+  publishing Gradle builds now emit `distribution=repo` in their publication poms. Verified
+  through the effective pom of a managed pom and a reactor child, the flattened deploy pom,
+  and the Gradle-generated publication pom.
+
+### Fixed
+- **The Generating-files NOTE reports the resolved active-services set (#356).** With an
+  aggregate and its granular directory both opted in (`CLAUDE.md` plus `.claude/rules/`), the
+  NOTE counted only the aggregate content map and claimed one active service while
+  `vibetags.log` correctly said two. It now reports the same resolved set the log uses,
+  sorted. `ActiveServicesNoteTest` pins the message and failed red against the old one.
+- **A Trees-API failure is named instead of `null` (#356).** Under Gradle compiler workers a
+  classloader failure carries no message, so `@AIArchitecture`'s unchecked-layering note
+  rendered `Trees API not available: null`. The reason now falls back to the throwable's type
+  name and states that `cannotReference` was not checked this round.
+  `ArchitectureRuleReasonTest` covers message, null and blank.
 
 ## [1.0.0-RC10] - 2026-08-03
 


### PR DESCRIPTION
## Why

The RC10 consumer sweep proved two ways a green build generates nothing, and neither was
documented where a consumer would look:

- **JDK 23+ no longer runs annotation processors found on the class path.** A pom that
  declares `vibetags-processor` as an ordinary (or `provided`) dependency compiles cleanly
  and generates no files: no error, no warning. Seen in a real consumer during the sweep;
  `<proc>full</proc>` or the recommended `<annotationProcessorPaths>` setup restores
  processing.
- **A build with nothing to compile never starts `javac`**, so a freshly opted-in platform
  file stays empty until a clean or touched-source compile. For a tool whose opt-in signal
  is file presence, this reads exactly like a bug.

`USAGE.md` gains a `Troubleshooting: Nothing Was Generated` section covering both, ending
with the `write.skip` / `reason=` log pointer, linked from the README's installation notes
and listed in the USAGE.md contents.

The Unreleased changelog carried only the PIT entry. The #356 diagnostics fixes and the
#357 license completion were unrecorded, so a GA cut from this state would have shipped an
incomplete 1.0.0 section. Both are now recorded, plus the `DocsGranularPairsClaimTest`
addition under Added.

## Verified

- `DocumentationLinksTest` green: every new link and fragment resolves (the test covers
  fragments across all Markdown files).
- `ReleaseScriptCoverageTest` and `BuildVersionParityTest` green: no new version literals.
- Pre-commit gitleaks, end-of-file-fixer and trailing-whitespace hooks pass; checkstyle
  skipped (needs Docker, which is down; docs-only change, no Java touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBcFZEK33xgd1xr6JH2cet
