### PR TITLE
chore: prepare release v1.0.0

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.0.0-RC10
+version: 1.0.0
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.0-RC10</version>
+    <version>1.0.0</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.0-RC10'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC10'
+compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.0'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,12 @@ repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:
-  # The code-karta SVGs under docs/diagrams/codekarta/ are generator output, byte for byte.
-  # Letting these hooks reformat them would leave the committed file permanently different
-  # from what tools/generate-architecture-diagrams.sh emits, so every regeneration would
-  # show up as a diff nobody made.
+  # The code-karta SVGs under docs/diagrams/codekarta/ are generator output, byte for byte,
+  # and the benchmark logs under load-tests/results/ are frozen measurement records.
+  # Letting these hooks reformat either would leave the committed file permanently different
+  # from what the generator or the benchmark harness actually emitted, so every regeneration
+  # would show up as a diff nobody made.
   - id: end-of-file-fixer
-    exclude: ^docs/diagrams/codekarta/
+    exclude: ^(docs/diagrams/codekarta/|load-tests/results/)
   - id: trailing-whitespace
-    exclude: ^docs/diagrams/codekarta/
+    exclude: ^(docs/diagrams/codekarta/|load-tests/results/)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.0-RC10</version>
+            <version>1.0.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.0-RC10</version>
+                        <version>1.0.0</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -117,8 +117,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC10')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC10')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -434,7 +434,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.0-RC10</version>
+            <version>1.0.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -459,7 +459,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.0-RC10</version>
+                        <version>1.0.0</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -475,8 +475,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC10')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC10')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -490,15 +490,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.0-RC10</version>
+    <version>1.0.0</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC10'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC10'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-08-04
+
 ### Added
 - **`USAGE.md` documents the two silent ways to get nothing generated.** A new Troubleshooting
   section covers JDK 23+ no longer running class-path annotation processors, which turned a
@@ -1811,7 +1813,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC10...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC10...v1.0.0
 [1.0.0-RC10]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC9...v1.0.0-RC10
 [1.0.0-RC9]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC8...v1.0.0-RC9
 [1.0.0-RC8]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC7...v1.0.0-RC8

--- a/example-all-tiers/pom.xml
+++ b/example-all-tiers/pom.xml
@@ -34,7 +34,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.0.0-RC10</vibetags.bom.version>
+    <vibetags.bom.version>1.0.0</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/example-multimodule-indexed/pom.xml
+++ b/example-multimodule-indexed/pom.xml
@@ -38,7 +38,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.0.0-RC10</vibetags.bom.version>
+    <vibetags.bom.version>1.0.0</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/example-multimodule/pom.xml
+++ b/example-multimodule/pom.xml
@@ -37,7 +37,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.0.0-RC10</vibetags.bom.version>
+    <vibetags.bom.version>1.0.0</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC10')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC10')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -27,7 +27,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.0.0-RC10</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -24,7 +24,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.0.0-RC10</vibetags.bom.version>
+        <vibetags.bom.version>1.0.0</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.0-RC10'
+version = '1.0.0'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.0.0-RC10'
+            version = '1.0.0'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -39,12 +39,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.0.0-RC10&lt;/version&gt;
+                &lt;version&gt;1.0.0&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC10'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0-RC10'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.0'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.0'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -36,7 +36,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.0.0-RC10&lt;/version&gt;
+                        &lt;version&gt;1.0.0&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC10')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0-RC10')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.0')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.0')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.0.0-RC10</revision>
+        <revision>1.0.0</revision>
 
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.0-RC10'
+version = '1.0.0'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.0.0-RC10'
+            version = '1.0.0'
             from components.java
 
             pom {
@@ -78,7 +78,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.0.0-RC10'
+    api 'se.deversity.vibetags:vibetags-annotations:1.0.0'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.1'

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
@@ -57,6 +57,47 @@ class ReleaseScriptCoverageTest {
         "docs/CHANGELOG.md",          // a record of what each version did
         "load-tests/README.md",       // "since 1.0.0-RCn" is provenance, not a coordinate
         "load-tests/results/README.md",
+        // Feature history and worked examples. "New in v1.0.0" in USAGE.md names the release
+        // an annotation shipped in, and proposed-annotations.md records the same fact;
+        // RELEASING.md walks its steps with 1.0.0 as the example version; CONCEPT_PLUGIN.md
+        // pitches hypothetical coordinates for a plugin that does not exist. None of them
+        // track the current release.
+        "USAGE.md",
+        "docs/proposed-annotations.md",
+        "docs/RELEASING.md",
+        "docs/CONCEPT_PLUGIN.md",
+        // The multi-module examples' own lineage. Each child pom names its example root
+        // (groupId se.deversity.vibetags.example) at version 1.0.0, which is the sample
+        // project's own version, not a VibeTags coordinate. The roots do carry one (the BOM
+        // property), and set-version.sh rewrites the roots.
+        "example-all-tiers/billing/pom.xml",
+        "example-all-tiers/shipping/pom.xml",
+        "example-multimodule-indexed/app/pom.xml",
+        "example-multimodule-indexed/core/pom.xml",
+        "example-multimodule/cli/pom.xml",
+        "example-multimodule/core/pom.xml",
+        "example-multimodule/engine/pom.xml",
+        "example-multimodule/showcase/pom.xml",
+        "example-multimodule/tests/pom.xml",
+        // Feature-wave references in code. The showcase demos say which release their five
+        // annotations shipped in and carry a CATALOG_VERSION fixture that happens to be
+        // 1.0.0; AIKeepInSync's javadoc quotes an illustrative VERSION constant; the
+        // NewAnnotations test javadocs name the wave they cover; GranularRenderer groups a
+        // formatter block by it; the fingerprint tests pass "1.0.0" as an arbitrary fixture
+        // version; BuildVersionParityTest documents example/build.gradle's own version.
+        // None of these are release coordinates.
+        "example/src/main/java/com/example/service/EvidenceBasedShowcase.java",
+        "example-multimodule/showcase/src/main/java/com/example/service/EvidenceBasedShowcase.java",
+        "vibetags-annotations/src/main/java/se/deversity/vibetags/annotations/AIKeepInSync.java",
+        "vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/platforms/GranularRenderer.java",
+        "vibetags/src/test/java/se/deversity/vibetags/processor/BuildFingerprintUnitTest.java",
+        "vibetags/src/test/java/se/deversity/vibetags/processor/BuildVersionParityTest.java",
+        "vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV5DefinitionTest.java",
+        "vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV5EndToEndTest.java",
+        "vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV5ValidationTest.java",
+        "vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV6DefinitionTest.java",
+        "vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV6EndToEndTest.java",
+        "vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV6ValidationTest.java",
         // The benchmark plotters. Two default --version to the last release that actually has
         // measurements under load-tests/results/; bumping that on release would aim them at a
         // directory nobody has generated yet. The other two name versions inside a comment
@@ -88,6 +129,7 @@ class ReleaseScriptCoverageTest {
         assumeTrue(!tracked.isEmpty(), "git did not list any tracked files; skipping");
 
         String scriptText = Files.readString(script, StandardCharsets.UTF_8);
+        Pattern statesVersion = wholeCoordinate(version);
         List<String> missing = new ArrayList<>();
 
         for (String rel : tracked) {
@@ -104,7 +146,7 @@ class ReleaseScriptCoverageTest {
             } catch (IOException | java.io.UncheckedIOException notText) {
                 continue; // binary or unreadable; it cannot carry a version string
             }
-            if (text.contains(version) && !scriptText.contains(rel)) {
+            if (statesVersion.matcher(text).find() && !scriptText.contains(rel)) {
                 missing.add(rel + " (states " + version + ")");
             }
         }
@@ -117,6 +159,16 @@ class ReleaseScriptCoverageTest {
     }
 
     // -----------------------------------------------------------------------
+
+    /**
+     * {@code version} stated as a whole coordinate. A bare {@code contains} would light up
+     * every {@code 1.0.0-RC3} and {@code 1.0.0-SNAPSHOT} mention the moment the release
+     * version becomes {@code 1.0.0}: those state a different version that merely starts with
+     * this one. The guards also keep {@code 21.0.0} from matching a search for {@code 1.0.0}.
+     */
+    private static Pattern wholeCoordinate(String version) {
+        return Pattern.compile("(?<![0-9.])" + Pattern.quote(version) + "(?![0-9A-Za-z.-])");
+    }
 
     private static boolean isIgnored(String rel) {
         return IGNORED_SUFFIXES.stream().anyMatch(rel::endsWith);


### PR DESCRIPTION
Promotes 1.0.0-RC10 to the 1.0.0 GA. RC10 is validated in five consumer repos (codekarta,
blindbean, common-license-lib, skill3, async-test-lib), all merged and CI-green on it; the
four commits since the RC10 tag are docs, changelog, license metadata and CI-shape changes.

## What 1.0.0 contains (since RC10)

From the new changelog section:

- **Added**: USAGE.md's Troubleshooting section for the two silent no-generation causes
  (JDK 23+ class-path processing, incremental builds with nothing to compile);
  `DocsGranularPairsClaimTest` deriving the five aggregate-granular pairs claim from code.
- **Changed**: PIT mutation testing moved to an on-demand workflow; every published pom
  carries the complete MIT license block with `distribution=repo`.
- **Fixed**: the Generating-files NOTE reports the resolved active-services set; a Trees-API
  failure is named instead of `null`.

## Release-prep changes in this PR

- `scripts/set-version.sh 1.0.0` across all 13 version-bearing files;
  `BuildVersionParityTest` green.
- Changelog: `[Unreleased]` became `[1.0.0] - 2026-08-04`, fresh empty `[Unreleased]` added,
  comparison links updated.
- `ReleaseScriptCoverageTest`: the version matcher now requires a whole coordinate. The bare
  `contains()` lit up every `1.0.0-RC3` / `1.0.0-SNAPSHOT` mention (31 files) the moment the
  release version became their prefix. Files genuinely stating `1.0.0` as frozen text are
  recorded in HISTORICAL with reasons. This flood is a one-time GA artifact: the milestone's
  number was pre-written into feature history for months.
- Pre-commit: `load-tests/results/` excluded from end-of-file-fixer and trailing-whitespace,
  same reasoning as the existing codekarta exclusion — frozen measurement records must not be
  reformatted. The five RC9 baselines the repo-wide run touched were restored from git.

## Verified

- Full vibetags suite green (`clean install`), BOM installed, `example/` compiled end-to-end
  against the freshly installed 1.0.0 artifacts.
- `pre-commit run --all-files`: gitleaks, end-of-file-fixer, trailing-whitespace pass;
  checkstyle skipped locally (needs Docker, which is down) — CI covers it.

After merge: the `v1.0.0` GitHub release (with `--latest`) triggers the Maven Central
publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBcFZEK33xgd1xr6JH2cet
