### PR TITLE
ci: run gradle wrapper validation on every push to main

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,16 +1,22 @@
 name: Validate Gradle Wrapper
 
 # Verifies the checked-in gradle-wrapper.jar matches a known-good Gradle
-# release checksum. Scorecard's Binary-Artifacts check treats the wrapper
-# jar as acceptable when this validation workflow is present.
+# release checksum.
+#
+# The push trigger deliberately carries no `paths:` filter. Scorecard's
+# Binary-Artifacts check does not merely look for this workflow: it lists the
+# workflow's successful runs and requires one whose head SHA equals the latest
+# commit on the default branch (ossf/scorecard, checks/raw/binary_artifact.go,
+# func gradleWrapperValidated). Under a path filter almost no commit on main has
+# a run at all, so all three gradle-wrapper.jar files stay reported as
+# unverified binary artifacts. Running on every push to main is what clears it.
+#
+# Pull requests keep the filter: Scorecard never inspects them, and the
+# pre-merge value is limited to commits that touch the wrapper.
 
 on:
   push:
     branches: [ main ]
-    paths:
-      - '**/gradle/wrapper/gradle-wrapper.jar'
-      - '**/gradle/wrapper/gradle-wrapper.properties'
-      - '.github/workflows/gradle-wrapper-validation.yml'
   pull_request:
     paths:
       - '**/gradle/wrapper/gradle-wrapper.jar'


### PR DESCRIPTION
## Why

Scorecard code-scanning alerts **21, 22, 23** (Binary-Artifacts, high) flag all three checked-in `gradle-wrapper.jar` files as unverified binary artifacts, even though `gradle-wrapper-validation.yml` has run this repo's wrappers through `gradle/actions/wrapper-validation` since 6daaf95.

Scorecard does not stop at finding the workflow. `gradleWrapperValidated()` in `checks/raw/binary_artifact.go` lists that workflow's successful runs and requires one whose head SHA equals **the latest commit on the default branch**; only then are the jars reclassified as `FileTypeBinaryVerified`.

The workflow's `push` trigger carried a `paths:` filter, so main's HEAD almost never has a run. Last run on main was `7981e9c` (2026-07-21); HEAD is `7415d20`. The check therefore fails on every scan and the three alerts stay open.

## What

Removes the `paths:` filter from the `push` trigger, so every commit to main gets a validation run. The `pull_request` trigger keeps its filter, since Scorecard only ever inspects the default branch. Cost is one ~30s job per push to main.

## Verification

- `gradleWrapperValidated()` read from `ossf/scorecard` main, not from a changelog.
- `gh run list --workflow=gradle-wrapper-validation.yml` confirms no run exists for HEAD.
- Not yet verified: that the alerts actually close. That needs one Scorecard run on main after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MokCW5bBivp1snfzhTjajo
