### PR TITLE
chore(deps): document every third-party artifact, bump eight, drop the async-test-lib clone

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,12 +35,6 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Install async-test-lib (required for concurrency tests, not on Maven Central)
-        run: |
-          git clone --depth 1 --branch v1.7.0-RC5 https://github.com/PIsberg/async-test-lib.git /tmp/async-test-lib
-          cd /tmp/async-test-lib
-          JAVA_HOME=$JAVA_HOME_21_X64 mvn install -DskipTests -B -q
-
       - name: Install VibeTags Annotations (Maven)
         run: |
           cd vibetags-annotations
@@ -429,12 +423,6 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Install async-test-lib (required for concurrency tests, not on Maven Central)
-        run: |
-          git clone --depth 1 --branch v1.7.0-RC5 https://github.com/PIsberg/async-test-lib.git "${RUNNER_TEMP}/async-test-lib"
-          cd "${RUNNER_TEMP}/async-test-lib"
-          mvn install -DskipTests -B -q
-
       - name: Install VibeTags Annotations (Maven)
         run: |
           cd vibetags-annotations
@@ -562,12 +550,6 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: gradle
-
-      - name: Install async-test-lib (required for concurrency tests, not on Maven Central)
-        run: |
-          git clone --depth 1 --branch v1.7.0-RC5 https://github.com/PIsberg/async-test-lib.git /tmp/async-test-lib
-          cd /tmp/async-test-lib
-          JAVA_HOME=$JAVA_HOME_21_X64 mvn install -DskipTests -B -q
 
       - name: Publish VibeTags Annotations (Gradle)
         run: |

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -30,12 +30,6 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Install async-test-lib (required for concurrency tests, not on Maven Central)
-        run: |
-          git clone --depth 1 --branch v1.7.0-RC5 https://github.com/PIsberg/async-test-lib.git /tmp/async-test-lib
-          cd /tmp/async-test-lib
-          mvn install -DskipTests -B -q
-
       - name: Install VibeTags Annotations (Maven)
         run: |
           cd vibetags-annotations

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Ground rules for any agent working here:
   → `example`. Always build from the subproject's own directory.
 - Reference docs load on demand: `docs/ANNOTATIONS.md` (annotation reference),
   `docs/PLATFORMS.md` (output-file table), `docs/TESTS.md` (test coverage map),
-  `docs/ARCHITECTURE.md` (deep dive).
+  `docs/ARCHITECTURE.md` (deep dive), `docs/DEPENDENCIES.md` (third-party artifacts).
 
 Note: this file is intentionally not VibeTags-managed — other AI config files
 exist at the root, so the processor's AGENTS.md sole-file fallback leaves it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ per-element detail lives in `.claude/rules/`, loaded on demand by glob.
 - `docs/ANNOTATIONS.md` — adding or changing an annotation: full table, semantics, validation warnings.
 - `docs/PLATFORMS.md` — adding a platform, or a question about a specific output file.
 - `docs/TESTS.md` — which test class covers what.
+- `docs/DEPENDENCIES.md` — every third-party artifact, why it is here, what ships to consumers and what only runs the build; where versions are declared and which newer versions were rejected.
 - `docs/LOAD-BEARING.md` — processing flow, file-existence opt-in, marker rules, the scoped-rules
   index, and the internal class map. The reasoning behind the invariants above.
 - `docs/ARCHITECTURE.md` — deep dive: system diagram, data flow, design decisions, limitations.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`docs/DEPENDENCIES.md`: every third-party artifact, and why.** Split by what it costs a
+  consumer. Three artifacts reach the consumer's annotation-processor path (jspecify, slf4j-api,
+  logback-classic) and `vibetags-annotations` has none at all; everything else is test or build
+  scope and never leaves the repository. The document names the parent property that holds each
+  version rather than restating the number, and records the versions deliberately not taken, so the
+  next sweep does not re-derive that slf4j 2.1.0-alpha1, maven-compiler-plugin 4.0.0-beta-4 and
+  surefire 3.6.0-M1 are prereleases.
+- **`BuildVersionParityTest` now checks Gradle's PMD `toolVersion`.** It is not a dependency
+  coordinate, so the existing parity check never saw it, and it had already drifted:
+  `vibetags-annotations/build.gradle` sat on PMD 7.24.0 while the parent and `vibetags/build.gradle`
+  were on 7.26.0, which is two modules analysed by two rule sets.
+
+### Changed
+- **Dependencies:** ArchUnit 1.4.2 → 1.5.0, SnakeYAML 2.5 → 2.6, maven-shade-plugin 3.5.2 → 3.6.2,
+  exec-maven-plugin 3.2.0 → 3.6.3, spotbugs-maven-plugin 4.10.2.0 → 4.10.3.0, pitest-maven 1.25.8 →
+  1.25.9, pitest-junit5-plugin 1.2.2 → 1.2.3, cyclonedx-maven-plugin 2.9.2 → 2.9.3, and PMD 7.26.0
+  in `vibetags-annotations/build.gradle`, which the parent had declared since 1.0.0-RC8. Verified by
+  the full Maven build (1465 tests) and both Gradle builds. async-test-lib stays at 1.7.0-RC8: the
+  1.7.0 that `versions:display-dependency-updates` reports is still a local install and 404s on
+  Central.
+- **CI no longer builds async-test-lib from a git tag.** Four jobs cloned
+  `github.com/PIsberg/async-test-lib` at `v1.7.0-RC5` and ran `mvn install` on it before every
+  build. The artifact has been on Maven Central all along, so those four jobs were paying for an
+  artifact Maven then resolved from Central anyway; the tag had also been left at RC5 when the
+  dependency moved to RC8, and one of the clones failed transiently and reddened an unrelated PR.
+  Verified by resolving 1.7.0-RC8 from Central into an empty local repository.
+
 ## [1.0.0] - 2026-08-04
 
 ### Added

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,0 +1,136 @@
+# Dependencies
+
+Every third-party artifact VibeTags uses, why it is here, and what happens if it changes.
+
+Versions are not listed here as the source of truth. `vibetags-parent/pom.xml` is, and this
+document names the property that holds each one so the two cannot quietly disagree. Where a number
+does appear below it is there to make the table readable; if it contradicts the parent, the parent
+is right and this file is stale.
+
+## What reaches a consumer
+
+VibeTags is an annotation processor, so "reaches a consumer" means "lands on the annotation
+processor path of somebody else's build". Three artifacts do. Nothing else in this repository ever
+leaves it.
+
+| Artifact | Property | Why it is here |
+|---|---|---|
+| `org.jspecify:jspecify` | `jspecify.version` | `@NullMarked`, `@Nullable`, `@NonNull` on the processor's own source, which is what NullAway checks against. The artifact is annotations only, all `SOURCE`/`CLASS` retention, so it adds no runtime behaviour. |
+| `org.slf4j:slf4j-api` | `slf4j.version` | The logging facade behind `VibeTagsLogger`. Every diagnostic event in the processor goes through it. |
+| `ch.qos.logback:logback-classic` | `logback.version` | The binding that actually writes `vibetags.log`. Without a binding, SLF4J is a no-op and the diagnostic channel described in `CLAUDE.md` produces nothing. |
+
+The two logging artifacts are compile-scope and deliberately **not** `<optional>`. Maven's
+`annotationProcessorPaths` resolver drops optional dependencies of a processor, so marking them
+optional produces a `NoClassDefFoundError` for `org.slf4j.Logger` at the consumer's compile time.
+The same comment sits in `vibetags/pom.xml`; do not undo it in either place alone.
+
+Because they sit on `annotationProcessorPaths` rather than in `<dependencies>`, they are invisible
+to the consumer's compile and runtime classpath. A consumer who wires VibeTags in as a plain
+compile dependency does get them, which is one more reason `USAGE.md` treats the processor-path
+form as the recommended setup and the class-path form as a fallback with caveats.
+
+`vibetags-annotations` has **no** third-party dependencies at all, by design. It is on the
+consumer's compile classpath, and anything added there is something a consumer's build has to
+resolve, shade or exclude.
+
+## What the tests use
+
+All test-scope, all in `vibetags/`.
+
+| Artifact | Property | Why it is here |
+|---|---|---|
+| `org.junit.jupiter:junit-jupiter` | `junit.version` | The test framework. |
+| `org.junit.platform:junit-platform-launcher` | `junit.platform.version` | Runtime-only. Surefire needs it on the JUnit 6 platform. |
+| `org.mockito:mockito-core`, `mockito-junit-jupiter` | `mockito.version` | Faking the javac side (`ProcessingEnvironment`, `Messager`, `Filer`) so processor logic can be tested without a running compiler. |
+| `com.tngtech.archunit:archunit-junit5` | `archunit.version` | Enforces the layering invariant: `processor/internal/content/` must not import `javax.lang.model`, `javax.annotation.processing` or `com.sun.source`. See `ArchitectureRulesTest`. This is a rule the compiler cannot express, so a library holds it instead. |
+| `se.deversity.async-test-lib` | `async-test-lib.version` | Concurrency tests for the parallel write phase and `WriteCache`. Sibling project, published to Maven Central like any other dependency. |
+| `org.yaml:snakeyaml` | `snakeyaml.version` | Parses the six YAML documents the renderers emit. The processor itself must never gain a YAML dependency: it runs on the consumer's annotation processor path, where every extra jar is one more collision. The tests need a real parser because "the file looks right" is not the property that matters; "a strict parser sees every module's guardrails" is. `YamlMergeShapeContractTest` depends on this distinction. |
+
+`load-tests/` additionally uses `org.openjdk.jmh:jmh-core` and `jmh-generator-annprocess`
+(`jmh.version`) for the benchmark harness. That module pins `<processor.version>` directly rather
+than inheriting it, on purpose: comparing one VibeTags release against another is the whole point of
+the module, and a BOM that forces both sides to the same version defeats it.
+
+## What the build uses
+
+Nothing in this section ships. It runs.
+
+**Compile and package.** `maven-compiler-plugin`, `maven-surefire-plugin`, `maven-jar-plugin`,
+`maven-source-plugin`, `maven-javadoc-plugin`. Two more serve `load-tests/` alone:
+`maven-shade-plugin` builds the benchmark fat jar, and `exec-maven-plugin` gives it an `exec:java`
+entry point into `org.openjdk.jmh.Main`.
+
+**Static analysis.** Four tools, each catching something the others do not:
+
+- `maven-pmd-plugin` with `pmd-core` and `pmd-java` (`pmd.version`) for source-level rules and
+  copy-paste detection. A red PMD gate is worth checking against the JDK before believing it: PMD
+  run on a newer JDK than the build targets reports confident nonsense.
+- `maven-checkstyle-plugin` for style, also wired into `pre-commit` so it fails before the commit
+  rather than in CI.
+- `spotbugs-maven-plugin` with `findsecbugs-plugin` (`findsecbugs-plugin.version`) for bytecode
+  analysis, the security rules included.
+- Error Prone (`error-prone.version`) with NullAway (`nullaway.version`), on
+  `annotationProcessorPaths` of the compiler plugin, main sources only. NullAway is what makes the
+  JSpecify annotations load-bearing instead of decorative.
+
+**Coverage and mutation.** `jacoco-maven-plugin` measures line coverage; `pitest-maven` with
+`pitest-junit5-plugin` measures whether the tests would notice if the code were wrong. Mutation
+testing runs on demand only, via `.github/workflows/mutation.yml`, because it costs minutes rather
+than seconds.
+
+**Supply chain and publishing.** `cyclonedx-maven-plugin` emits the SBOM.
+`central-publishing-maven-plugin` and `maven-gpg-plugin` sign and publish to Maven Central.
+`flatten-maven-plugin` resolves `${revision}` and strips `vibetags-parent` out of the deployed POMs,
+so what consumers download is self-contained.
+
+## Outside Maven
+
+- **GitHub Actions** are pinned to commit SHAs, not tags, with the human-readable version in a
+  trailing comment. Dependabot proposes the bumps. Pinning is what the OSSF Scorecard
+  Pinned-Dependencies check wants, and it is also the only form that cannot be moved under you.
+- **Gradle wrapper**, `gradle-9.6.1-bin.zip` in three subprojects. The checked-in
+  `gradle-wrapper.jar` files are validated against Gradle's published checksums by
+  `.github/workflows/gradle-wrapper-validation.yml`, which must run on every push to main for
+  Scorecard's Binary-Artifacts check to accept them.
+- **pre-commit hooks**: `gherynos/pre-commit-java` (Checkstyle), `gitleaks/gitleaks` (secret
+  scanning), and `pre-commit/pre-commit-hooks` (end-of-file and trailing-whitespace fixers).
+
+## Bumping
+
+`vibetags-parent/pom.xml` holds every version and nothing else holds any, with two exceptions the
+build itself enforces:
+
+- The Gradle files cannot inherit from a Maven parent, so `vibetags/build.gradle`,
+  `vibetags-annotations/build.gradle` and `example/build.gradle` repeat the coordinates as literals.
+- The example poms are standalone on purpose, so a reader can lift one into their own project.
+
+`BuildVersionParityTest` fails the build when either copy drifts from the parent, when a managed pom
+grows a version literal, or when a Gradle module's PMD `toolVersion` disagrees. That last check
+exists because it had already happened: `vibetags-annotations` sat on PMD 7.24.0 while everything
+else was on 7.26.0, so the two modules were analysed by different rule sets.
+
+To bump the VibeTags release version itself, use `scripts/set-version.sh <version>` and then run
+that test.
+
+### Versions deliberately not taken
+
+Checked 2026-08-04 against `maven-metadata.xml` on repo1.maven.org, not against a changelog:
+
+| Artifact | Newest published | Why we are not on it |
+|---|---|---|
+| `org.slf4j:slf4j-api` | 2.1.0-alpha1 | Alpha. The 2.0.x line is the stable one. |
+| `maven-compiler-plugin` | 4.0.0-beta-4 | Beta. |
+| `maven-surefire-plugin` | 3.6.0-M1 | Milestone. |
+| `maven-jar-plugin`, `maven-source-plugin` | 4.0.0-beta-1 | Beta. |
+| `se.deversity.async-test-lib` | 1.7.0-RC8 | `versions:display-dependency-updates` offers 1.7.0. That version exists only as a local install on the maintainer's machine and is a 404 on Central, so taking the suggestion breaks every other environment. Check the metadata URL before believing the plugin here. |
+
+Re-run the check with, from `vibetags/`:
+
+```bash
+mvn versions:display-dependency-updates -DprocessDependencyManagement=true
+mvn versions:display-plugin-updates
+```
+
+`display-plugin-updates` only reports plugins the scanned project actually uses, so a plugin
+declared in the parent's `pluginManagement` but used from `load-tests/` or a profile will not appear.
+Those need the metadata URL directly.

--- a/llms.txt
+++ b/llms.txt
@@ -11,9 +11,10 @@ Orientation facts: build order is `vibetags-annotations` → `vibetags` → `vib
 - [USAGE.md](USAGE.md): consumer guide — every annotation with usage examples
 - [SPEC.md](SPEC.md): behavior and output-format specification
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md): technical deep dive — system diagram, data flow, design decisions
-- [docs/ANNOTATIONS.md](docs/ANNOTATIONS.md): all 39 annotations — attribute table, semantics, compile-time validation warnings
+- [docs/ANNOTATIONS.md](docs/ANNOTATIONS.md): every annotation — attribute table, semantics, compile-time validation warnings
 - [docs/PLATFORMS.md](docs/PLATFORMS.md): generated file ↔ platform ↔ format table, granular-rules notes
 - [docs/TESTS.md](docs/TESTS.md): which test class covers what
+- [docs/DEPENDENCIES.md](docs/DEPENDENCIES.md): every third-party artifact and why it is here; what ships to consumers vs what only runs the build
 - [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md): contribution workflow
 - [docs/RELEASING.md](docs/RELEASING.md): release process
 - [docs/CHANGELOG.md](docs/CHANGELOG.md): version history

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -90,7 +90,7 @@ jar {
 
 pmd {
     consoleOutput = true
-    toolVersion = "7.24.0"
+    toolVersion = "7.26.0"
     ignoreFailures = false
     ruleSetFiles = files("${projectDir}/../pmd-ruleset.xml")
 }

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -85,9 +85,9 @@
         <junit.version>6.1.2</junit.version>
         <junit.platform.version>6.1.2</junit.platform.version>
         <mockito.version>5.23.0</mockito.version>
-        <archunit.version>1.4.2</archunit.version>
+        <archunit.version>1.5.0</archunit.version>
         <async-test-lib.version>1.7.0-RC8</async-test-lib.version>
-        <snakeyaml.version>2.5</snakeyaml.version>
+        <snakeyaml.version>2.6</snakeyaml.version>
         <jmh.version>1.37</jmh.version>
 
         <!-- Build plugins -->
@@ -96,22 +96,22 @@
         <maven-jar-plugin.version>3.5.1</maven-jar-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
-        <maven-shade-plugin.version>3.5.2</maven-shade-plugin.version>
-        <exec-maven-plugin.version>3.2.0</exec-maven-plugin.version>
+        <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
+        <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
         <flatten-maven-plugin.version>1.8.0</flatten-maven-plugin.version>
 
         <!-- Static analysis and coverage -->
         <maven-pmd-plugin.version>3.28.0</maven-pmd-plugin.version>
         <pmd.version>7.26.0</pmd.version>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
-        <spotbugs-maven-plugin.version>4.10.2.0</spotbugs-maven-plugin.version>
+        <spotbugs-maven-plugin.version>4.10.3.0</spotbugs-maven-plugin.version>
         <findsecbugs-plugin.version>1.14.0</findsecbugs-plugin.version>
         <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
-        <pitest-maven.version>1.25.8</pitest-maven.version>
-        <pitest-junit5-plugin.version>1.2.2</pitest-junit5-plugin.version>
+        <pitest-maven.version>1.25.9</pitest-maven.version>
+        <pitest-junit5-plugin.version>1.2.3</pitest-junit5-plugin.version>
         <error-prone.version>2.50.0</error-prone.version>
         <nullaway.version>0.13.8</nullaway.version>
-        <cyclonedx-maven-plugin.version>2.9.2</cyclonedx-maven-plugin.version>
+        <cyclonedx-maven-plugin.version>2.9.3</cyclonedx-maven-plugin.version>
 
         <!-- Publishing -->
         <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -87,9 +87,9 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:2.0.18'
     implementation 'ch.qos.logback:logback-classic:1.6.1'
 
-    testImplementation 'com.tngtech.archunit:archunit-junit5:1.4.2'
+    testImplementation 'com.tngtech.archunit:archunit-junit5:1.5.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:6.1.2'
-    // 1.7.0-RC5, matching pom.xml: not on Maven Central, built from the upstream git tag in CI.
+    // Concurrency-test harness, matching pom.xml. Resolves from Maven Central like any other dep.
     testImplementation 'se.deversity.async-test-lib:async-test-lib:1.7.0-RC8'
     testImplementation 'org.mockito:mockito-core:5.23.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.23.0'
@@ -98,7 +98,7 @@ dependencies {
     // is one more thing to collide with. The tests need a real parser because "the file looks
     // right" is not the property that matters - "the tool reading it sees every module's
     // guardrails" is, and only a parser shows that.
-    testImplementation 'org.yaml:snakeyaml:2.5'
+    testImplementation 'org.yaml:snakeyaml:2.6'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.2'
 }
 

--- a/vibetags/pom.xml
+++ b/vibetags/pom.xml
@@ -76,13 +76,13 @@
         <dependency>
             <groupId>se.deversity.async-test-lib</groupId>
             <artifactId>async-test-lib</artifactId>
-            <!-- Version in the parent (async-test-lib.version). Pinned deliberately: this artifact
-                 is NOT on Maven Central, so CI builds it from the upstream git tag (see
-                 .github/workflows/build.yml). Only bump to a version that has a matching tag at
-                 github.com/PIsberg/async-test-lib — `versions:display-dependency-updates` also
-                 reports versions that exist only as a local install, and taking that suggestion
-                 breaks every environment except the one that installed it. Change the four workflow
-                 clone tags in the same commit as the parent's property. -->
+            <!-- Version in the parent (async-test-lib.version). Resolves from Maven Central like any
+                 other dependency; CI no longer builds it from a git tag. Do not take
+                 `versions:display-dependency-updates` at its word here: it
+                 reports 1.7.0, which exists only as a local install on the maintainer's machine
+                 and is a 404 on Central. Check
+                 repo1.maven.org/maven2/se/deversity/async-test-lib/async-test-lib/maven-metadata.xml
+                 before bumping. -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/BuildVersionParityTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/BuildVersionParityTest.java
@@ -139,6 +139,34 @@ class BuildVersionParityTest {
             "A Gradle build publishing under the wrong version:\n  " + String.join("\n  ", problems));
     }
 
+    /**
+     * Gradle's PMD plugin takes its analyser version from {@code toolVersion}, not from a
+     * dependency coordinate, so {@link #gradleBuildsAgreeWithTheParentOnEveryManagedCoordinate}
+     * never saw it. It drifted: vibetags-annotations sat on PMD 7.24.0 while the parent and
+     * vibetags/build.gradle were on 7.26.0, which means the two modules were analysed by different
+     * rule sets and a rule added between those releases ran on one module only.
+     */
+    @Test
+    void gradlePmdToolVersionsMatchTheParent() {
+        String expected = properties().get("pmd.version");
+        Pattern toolVersion = Pattern.compile("^\\s*toolVersion\\s*=\\s*['\"]([^'\"]+)['\"]",
+            Pattern.MULTILINE);
+        List<String> problems = new ArrayList<>();
+
+        for (String file : GRADLE_FILES) {
+            Matcher m = toolVersion.matcher(read(repoRoot().resolve(file)));
+            while (m.find()) {
+                if (!expected.equals(m.group(1))) {
+                    problems.add(file + ": PMD toolVersion is " + m.group(1)
+                        + " but vibetags-parent declares pmd.version " + expected);
+                }
+            }
+        }
+        assertTrue(problems.isEmpty(),
+            "A Gradle module analysed by a different PMD than the rest of the build:\n  "
+                + String.join("\n  ", problems));
+    }
+
     @Test
     void managedPomsDeclareNoVersionOfTheirOwn() {
         List<String> problems = new ArrayList<>();


### PR DESCRIPTION
## What

A full inventory of every third-party artifact in the repository, the bumps that made sense, and two defects the inventory exposed.

### New: `docs/DEPENDENCIES.md`

Organised by what each artifact costs a consumer, not alphabetically.

- **Three reach the consumer**, all on the annotation-processor path: jspecify, slf4j-api, logback-classic. The doc records why the logging pair is compile-scope and deliberately not `<optional>` (Maven's `annotationProcessorPaths` resolver drops optional dependencies, giving a `NoClassDefFoundError` at the consumer's compile time). `vibetags-annotations` has no third-party dependencies at all.
- **Seven are test-scope**, each with the specific thing it holds: ArchUnit holds the layering invariant the compiler cannot express, SnakeYAML exists because "the file looks right" is not the property the YAML merge tests are checking.
- **The rest only runs the build**, grouped by job: compile and package, static analysis, coverage and mutation, supply chain and publishing.
- Plus what lives outside Maven (SHA-pinned Actions, the Gradle wrapper, pre-commit hooks), how to bump, and **which newer versions were deliberately not taken** so the next sweep does not re-derive it.

Linked from `CLAUDE.md`, `AGENTS.md` and `llms.txt`.

### Bumps

All stable, all checked against `maven-metadata.xml` on repo1.maven.org rather than against a changelog:

ArchUnit 1.4.2 → 1.5.0 · SnakeYAML 2.5 → 2.6 · shade 3.5.2 → 3.6.2 · exec 3.2.0 → 3.6.3 · spotbugs 4.10.2.0 → 4.10.3.0 · pitest-maven 1.25.8 → 1.25.9 · pitest-junit5 1.2.2 → 1.2.3 · cyclonedx 2.9.2 → 2.9.3

Skipped as prereleases: slf4j 2.1.0-alpha1, maven-compiler-plugin 4.0.0-beta-4, surefire 3.6.0-M1, jar and source 4.0.0-beta-1.

## Two defects found while inventorying

**1. Two modules were analysed by two different PMDs.** `vibetags-annotations/build.gradle` sat on PMD 7.24.0 while the parent and `vibetags/build.gradle` were on 7.26.0, ever since the 1.0.0-RC8 bump. `BuildVersionParityTest` reads dependency coordinates, and Gradle's PMD version is a `toolVersion` assignment, so nothing saw it. The test now covers it. Confirmed failing on 7.24.0 first:

```
BuildVersionParityTest.gradlePmdToolVersionsMatchTheParent
  vibetags-annotations/build.gradle: PMD toolVersion is 7.24.0
  but vibetags-parent declares pmd.version 7.26.0
```

**2. Four CI jobs were building an artifact that is on Maven Central.** Every Maven, Gradle and mutation job cloned `github.com/PIsberg/async-test-lib` at `v1.7.0-RC5` and ran `mvn install` on it, on the strength of a pom comment saying the artifact is not on Central. It is, and has been. Verified rather than assumed:

```
mvn dependency:get -Dartifact=se.deversity.async-test-lib:async-test-lib:1.7.0-RC8 \
    -Dmaven.repo.local=./target/coldrepo
Downloaded from central: .../async-test-lib-1.7.0-RC8.jar (988 kB)
BUILD SUCCESS
```

The clone tag had also been left at RC5 when the dependency moved to RC8 in #361, so the step was installing a version nothing asked for, and Maven then resolved RC8 from Central regardless. One of those clones failed transiently earlier today and reddened PR #362. The steps are removed and the stale comments in `vibetags/pom.xml` and `vibetags/build.gradle` corrected.

async-test-lib stays at 1.7.0-RC8. The 1.7.0 that `versions:display-dependency-updates` offers exists only as a local install on the maintainer's machine and 404s on Central; the pom comment now says so and gives the URL to check.

## Also

`llms.txt` claimed "all 39 annotations" against the 44 that exist. Fixed by dropping the restated count rather than correcting it, which is the rule the other docs already follow, so there is nothing left to drift. `ProjectFactsConsistencyTest` guards the README's figures and does not reach `llms.txt`.

## Verification

- Full Maven build: 1465 tests, 0 failures, including `ArchitectureRulesTest` on ArchUnit 1.5.0 and the YAML tests on SnakeYAML 2.6.
- Both Gradle builds green, which is what exercises the changed literals and the PMD `toolVersion`.
- New parity test shown red before green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MokCW5bBivp1snfzhTjajo
