### PR TITLE
ci: bump every codeql-action entry point together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,20 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      # init, analyze and upload-sarif are three entry points into one action repo, and
+      # CodeQL refuses to run them at different versions: init stamps its config with its
+      # own version and analyze's post step rejects a config it did not write, with
+      # "Loaded a configuration file for version X, but running version Y".
+      #
+      # Dependabot bills each path as its own dependency, so ungrouped it opened one PR
+      # per entry point (#367 for init, #368 for analyze). Each PR moved half the pair,
+      # so each failed CI on its own and neither could merge — the bump deadlocked until
+      # someone hand-merged them. Grouping puts every codeql-action path in one PR that
+      # is consistent by construction.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: npm
     directory: /

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -77,6 +77,6 @@ jobs:
         run: cd example && mvn clean compile -B -q
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           category: "/language:${{matrix.language}}"

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/CodeQlActionVersionParityTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/CodeQlActionVersionParityTest.java
@@ -1,0 +1,82 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every {@code github/codeql-action/*} reference in the workflows must pin one commit.
+ *
+ * <p>{@code init}, {@code analyze} and {@code upload-sarif} are three entry points into a single
+ * action repository, and CodeQL will not run them at different versions: {@code init} stamps its
+ * config file with its own version, and {@code analyze}'s post step refuses a config it did not
+ * write — {@code "Loaded a configuration file for version '4.36.2', but running version '4.37.5'"}.
+ *
+ * <p>Dependabot bills each path as a separate dependency, so before the {@code codeql-action} group
+ * in {@code .github/dependabot.yml} it opened one PR per entry point: #367 moved {@code init} and
+ * #368 moved {@code analyze}, each leaving the other half of the pair behind. Both failed CI alone,
+ * so neither could merge and the bump deadlocked. The group is the fix; this test is what keeps it
+ * fixed, because a group is a convention on Dependabot's side and a hand-edit or a security update
+ * can still land half a bump. The failure it prevents is otherwise a post-action error message that
+ * names two versions and no file.
+ */
+@DisplayName("All codeql-action references pin the same commit")
+class CodeQlActionVersionParityTest {
+
+    /** {@code vibetags/} is the surefire working directory; its parent is the repo root. */
+    private static final Path REPO_ROOT = Paths.get("").toAbsolutePath().getParent();
+
+    /** Matches {@code uses: github/codeql-action/<entry>@<sha> # <version>}. */
+    private static final Pattern REFERENCE = Pattern.compile(
+        "github/codeql-action/(\\S+?)@([0-9a-f]{40})\\s*#\\s*(\\S+)");
+
+    @Test
+    void everyCodeQlActionReferencePinsTheSameCommitAndVersion() throws IOException {
+        Path workflows = REPO_ROOT.resolve(".github/workflows");
+        // Deliberately not assumeTrue: a skipped parity check reads exactly like a passed one,
+        // and this test exists because a silent half-bump already reached main once.
+        assertTrue(Files.isDirectory(workflows), "workflows not found at " + workflows);
+
+        Map<String, String> shaByRef = new TreeMap<>();
+        Map<String, String> versionByRef = new TreeMap<>();
+        try (Stream<Path> files = Files.list(workflows)) {
+            List<Path> yml = files.filter(p -> p.toString().endsWith(".yml")
+                                            || p.toString().endsWith(".yaml")).sorted().toList();
+            for (Path file : yml) {
+                Matcher matcher = REFERENCE.matcher(Files.readString(file, StandardCharsets.UTF_8));
+                while (matcher.find()) {
+                    String where = file.getFileName() + ":" + matcher.group(1);
+                    shaByRef.put(where, matcher.group(2));
+                    versionByRef.put(where, matcher.group(3));
+                }
+            }
+        }
+
+        assertTrue(shaByRef.size() >= 2,
+            "expected several codeql-action references to compare, found " + shaByRef.keySet()
+                + " — if the workflows stopped using CodeQL, delete this test rather than let it pass vacuously");
+
+        assertEquals(1, new TreeSet<>(shaByRef.values()).size(),
+            "codeql-action references pin different commits, which fails the analyze post step at "
+                + "runtime with a version-mismatch error: " + shaByRef);
+
+        assertEquals(1, new TreeSet<>(versionByRef.values()).size(),
+            "codeql-action version comments disagree, so one of them is lying about the commit "
+                + "beside it: " + versionByRef);
+    }
+}


### PR DESCRIPTION
## The problem

Dependabot cannot bump CodeQL in this repo. `init`, `analyze` and `upload-sarif` are three entry points into a single action repository, and CodeQL refuses to run them at different versions — `init` stamps its config file with its own version, and `analyze`'s post step rejects a config it did not write:

```
Error: analyze post-action step failed:
Loaded a configuration file for version '4.36.2', but running version '4.37.5'
```

Dependabot bills each path as a separate dependency, so it opened **one PR per entry point**: #367 for `init`, #368 for `analyze`. Each moved half the pair, so each failed CI on its own and neither could merge. The bump was deadlocked — the only way through was to hand-merge both.

## The fix

**1. Align the versions** — `codeql.yml` now pins `init` and `analyze` to the same commit `scorecards.yml` already uses for `upload-sarif` (`d1ba80a`, v4.37.5). That is the state #367 and #368 were trying to reach between them, so it clears the deadlock in one commit.

Both SHAs were verified against the GitHub API by dereferencing the annotated tags, rather than trusting the `# vX.Y.Z` comments:

| tag | commit |
|---|---|
| v4.36.2 | `8aad20d150bbac5944a9f9d289da16a4b0d87c1e` |
| v4.37.5 | `d1ba80a13dd99fba24a470575428917156a28b43` |

**2. Group future bumps** — `.github/dependabot.yml` gets a `codeql-action` group matching `github/codeql-action*`, so the next bump arrives as one PR that is consistent by construction instead of one PR per entry point.

**3. Enforce it in CI** — `CodeQlActionVersionParityTest` fails the build when the references disagree. The group is a convention on Dependabot's side: a hand-edit or a security update can still land half a bump. The runtime error names two versions and no file; the test names the file and the entry point:

```
codeql-action references pin different commits, which fails the analyze post step
at runtime with a version-mismatch error:
{codeql.yml:analyze=d1ba80a..., codeql.yml:init=8aad20d..., scorecards.yml:upload-sarif=d1ba80a...}
```

It deliberately does not `assumeTrue` on the workflows directory — a skipped parity check reads exactly like a passed one, and a silent half-bump has already reached `main` once.

## Verification

- Reproduced #368's exact state (analyze bumped, init left behind) and confirmed the new test **fails**, then passes once the two agree. Failing case shown above.
- Full gate green afterwards: `mvn clean install -B` — **1485 tests, 0 failures, PMD and SpotBugs clean, BUILD SUCCESS**.
- YAML of `dependabot.yml` parsed and the group asserted.

One thing I could not verify locally: that Dependabot's glob actually groups all three paths. `github/codeql-action*` is the documented idiom for this case, but the proof is the next Dependabot run. If it still opens separate PRs, the pattern needs splitting into `github/codeql-action` and `github/codeql-action/*` — the parity test will catch it either way rather than letting a half-bump merge.

## Follow-up

#367 and #368 are superseded by this and should close automatically once it merges, since the dependency will already be at v4.37.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoD63GKhRELx1vWjVerNMF
