### PR TITLE
ci: smoke-run the Jazzer fuzz harness on every push and PR

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -52,7 +52,10 @@ jobs:
 
       - name: Compile the fuzz harness
         run: |
-          javac -cp "vibetags/target/classes:jazzer-dist/jazzer-api.jar" \
+          # -proc:none: target/classes carries the processor's META-INF/services
+          # registration, so without it javac discovers AIGuardrailProcessor and
+          # fails instantiating it (slf4j is not on this compile classpath).
+          javac -proc:none -cp "vibetags/target/classes:jazzer-dist/jazzer-api.jar" \
             -d fuzz-classes oss-fuzz/VibeTagsFuzzer.java
 
       - name: Run the fuzz smoke (10,000 iterations)

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,75 @@
+name: Fuzz Smoke
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  jazzer-smoke:
+    name: Jazzer smoke run
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Install VibeTags annotations
+        run: cd vibetags-annotations && mvn install -B -q -DskipTests
+
+      - name: Compile VibeTags library
+        run: cd vibetags && mvn clean compile -B -q
+
+      - name: Fetch Jazzer (pinned by checksum)
+        run: |
+          curl -sSfL -o jazzer.tar.gz \
+            https://github.com/CodeIntelligenceTesting/jazzer/releases/download/v0.30.0/jazzer-linux-x86-64.tar.gz
+          echo "6eeaf0026d75599b07527d93b576593ce847cfca8b337a579971a5a9cdf792d0  jazzer.tar.gz" | sha256sum -c -
+          mkdir jazzer-dist && tar xzf jazzer.tar.gz -C jazzer-dist
+
+      - name: Fetch Jazzer API jar
+        run: |
+          mvn -B -q dependency:copy \
+            -Dartifact=com.code-intelligence:jazzer-api:0.24.0 \
+            -DoutputDirectory=jazzer-dist \
+            -Dmdep.stripVersion=true
+
+      - name: Compile the fuzz harness
+        run: |
+          javac -cp "vibetags/target/classes:jazzer-dist/jazzer-api.jar" \
+            -d fuzz-classes oss-fuzz/VibeTagsFuzzer.java
+
+      - name: Run the fuzz smoke (10,000 iterations)
+        run: |
+          mvn -B -q -f vibetags/pom.xml dependency:build-classpath \
+            -DincludeScope=runtime -Dmdep.outputFile=target/runtime-cp.txt
+          mkdir -p fuzz-findings
+          ./jazzer-dist/jazzer \
+            --cp="fuzz-classes:vibetags/target/classes:$(cat vibetags/target/runtime-cp.txt)" \
+            --target_class=VibeTagsFuzzer \
+            -artifact_prefix=fuzz-findings/ \
+            -runs=10000
+
+      - name: Upload crash inputs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-findings-${{ github.run_id }}
+          path: fuzz-findings/
+          if-no-files-found: ignore

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,6 +1,6 @@
 # GitHub Actions Workflows
 
-This document describes what happens during CI builds in `.github/workflows/`. Five workflows run on push, pull request, schedule, or release; a sixth, mutation testing, runs only when someone asks for it.
+This document describes what happens during CI builds in `.github/workflows/`. Six workflows run on push, pull request, schedule, or release; a seventh, mutation testing, runs only when someone asks for it.
 
 ## Overview
 
@@ -11,6 +11,7 @@ This document describes what happens during CI builds in `.github/workflows/`. F
 | Dependency Review | `dependency-review.yml` | Pull requests |
 | Scorecard | `scorecards.yml` | Push to `main`, branch-protection-rule, weekly cron (Tuesdays 07:20 UTC) |
 | Publish to Maven Central | `publish.yml` | GitHub Release `created` |
+| Fuzz Smoke (Jazzer) | `fuzz.yml` | Push/PR to `main` |
 | Mutation Testing (PIT) | `mutation.yml` | Manual only (`workflow_dispatch`) |
 
 All jobs run on `ubuntu-latest` and start with the StepSecurity `harden-runner` action in `audit` mode, which records every outbound network call. The default token permission for every workflow is `contents: read`; jobs that need more (e.g. CodeQL writes `security-events`) escalate explicitly.
@@ -87,7 +88,7 @@ Mirror of `build-maven` but with Gradle. Matrix over **JDK 21, 25, 26**. Differe
 
 The same `.github/actions/verify-generated-files` composite action runs after the Gradle build, so any divergence between Maven and Gradle output paths is caught.
 
-Mutation testing used to be a job here. It now lives in its own manually triggered workflow — see section 6.
+Mutation testing used to be a job here. It now lives in its own manually triggered workflow — see section 7.
 
 ---
 
@@ -134,7 +135,21 @@ Required repository secrets: `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`, `CENTRAL_TOKEN
 
 ---
 
-## 6. Mutation Testing (`mutation.yml`)
+## 6. Fuzz Smoke (`fuzz.yml`)
+
+A 10,000-iteration Jazzer run against the OSS-Fuzz harness in `oss-fuzz/`, on every push and pull request to `main`. Single JDK 21 leg, `contents: read`, 15-minute timeout.
+
+It exists to catch two failure classes:
+
+- **Harness rot.** The harness compiles against the live processor classes (`vibetags/target/classes`), so a processor API change that breaks `oss-fuzz/VibeTagsFuzzer.java` is a red build here instead of a surprise at OSS-Fuzz submission time. Not hypothetical: the harness sat unused from 2026-04 and had to be re-synced to the 0.7.1 API by hand.
+- **Real findings.** The run is a genuine coverage-guided fuzz of `AIGuardrailProcessor.writeFileIfChanged` (marker parsing, front-matter detection, content merge). 10,000 iterations is a smoke, not a campaign, but Jazzer's CMP instrumentation discovers the `VIBETAGS-START` marker strings on its own within a few thousand executions, so the interesting parse paths are reached. An uncaught exception or hang fails the job and uploads the triggering input as the `fuzz-findings-<run_id>` artifact.
+
+- Steps: harden runner → checkout → set up JDK 21 (Maven cache) → `cd vibetags-annotations && mvn install -B -q -DskipTests` → `cd vibetags && mvn clean compile -B -q` → download Jazzer v0.30.0 and verify it against a SHA-256 recorded in the workflow (a moved release tag cannot substitute a different binary) → fetch `com.code-intelligence:jazzer-api` from Maven Central for the compile classpath → `javac` the harness → build the runtime classpath with `dependency:build-classpath` (the processor jar is not shaded, so slf4j/logback must be on the fuzzer's `--cp`) → run with `-runs=10000` (measured: 120 s for 10,000 runs on a Windows laptop; Linux runners are faster).
+- There is no `continue-on-error`: a failure here is either a real finding or real rot, never noise.
+
+---
+
+## 7. Mutation Testing (`mutation.yml`)
 
 PIT mutation coverage over `se.deversity.vibetags.*`. **On demand only** — the sole trigger is `workflow_dispatch`, so nothing starts it on push or pull request. Run it from Actions → Mutation Testing (PIT) → Run workflow, picking the branch to analyse.
 

--- a/oss-fuzz/README.md
+++ b/oss-fuzz/README.md
@@ -2,8 +2,8 @@
 
 This directory contains the artefacts that **[OSS-Fuzz](https://github.com/google/oss-fuzz)** — Google's continuous fuzzing service for open-source projects — needs to build and run a [Jazzer](https://github.com/CodeIntelligenceTesting/jazzer) fuzzer against `AIGuardrailProcessor`.
 
-> **Status (2026-05): compile-ready, not yet submitted upstream.** Files were added in commit
-> [`b3a3edf`](https://github.com/PIsberg/vibetags/commit/b3a3edf) (2026-04-17) as a starter template, sat unused for a few weeks, and were brought back into sync with the v0.7.1 processor API in this PR. CI does not currently run them, and the project has not been submitted to upstream OSS-Fuzz — see [What's left](#whats-left) below.
+> **Status (2026-08): smoke-tested in CI on every push, not yet submitted upstream.** Files were added in commit
+> [`b3a3edf`](https://github.com/PIsberg/vibetags/commit/b3a3edf) (2026-04-17) as a starter template, sat unused for a few weeks, and were brought back into sync with the v0.7.1 processor API. Since 2026-08 the [`fuzz.yml`](../.github/workflows/fuzz.yml) workflow compiles this harness against the current processor and runs a 10,000-iteration Jazzer smoke on every push and PR to `main`, so the harness can no longer rot silently. The project has not been submitted to upstream OSS-Fuzz; see [What's left](#whats-left) below.
 
 ## What OSS-Fuzz is
 
@@ -41,18 +41,27 @@ You don't need OSS-Fuzz infrastructure to run a Jazzer fuzzer:
 cd vibetags-annotations && mvn install -DskipTests
 cd ../vibetags             && mvn install -DskipTests
 
-# 2. Grab a Jazzer release (https://github.com/CodeIntelligenceTesting/jazzer/releases)
-JAZZER=~/jazzer-linux-x86_64
+# 2. Grab a Jazzer release (https://github.com/CodeIntelligenceTesting/jazzer/releases).
+#    The tarball holds the `jazzer` binary and `jazzer_standalone.jar`; the API jar
+#    the harness compiles against comes from Maven Central.
+JAZZER=~/jazzer   # extracted jazzer-<os>.tar.gz
+mvn dependency:copy -Dartifact=com.code-intelligence:jazzer-api:0.24.0 \
+    -DoutputDirectory=$JAZZER -Dmdep.stripVersion=true
 
 # 3. Compile the fuzzer
-PROCESSOR_JAR=$(find ~/.m2/repository/se/deversity/vibetags/vibetags-processor -name "*.jar" | head -1)
-javac -cp $PROCESSOR_JAR:$JAZZER/jazzer_api_deploy.jar oss-fuzz/VibeTagsFuzzer.java -d /tmp/fuzz
+PROCESSOR_JAR=$(find ~/.m2/repository/se/deversity/vibetags/vibetags-processor \
+    -name "*.jar" ! -name "*sources*" ! -name "*javadoc*" | head -1)
+javac -cp $PROCESSOR_JAR:$JAZZER/jazzer-api.jar oss-fuzz/VibeTagsFuzzer.java -d /tmp/fuzz
 
-# 4. Run a few thousand iterations
-$JAZZER/jazzer --cp=/tmp/fuzz:$PROCESSOR_JAR --target_class=VibeTagsFuzzer -runs=10000
+# 4. Run a few thousand iterations. The processor jar is not shaded, so its
+#    runtime deps (slf4j, logback) must be on the fuzzer classpath too.
+cd vibetags && mvn dependency:build-classpath -DincludeScope=runtime \
+    -Dmdep.outputFile=target/runtime-cp.txt && cd ..
+$JAZZER/jazzer --cp=/tmp/fuzz:$PROCESSOR_JAR:$(cat vibetags/target/runtime-cp.txt) \
+    --target_class=VibeTagsFuzzer -runs=10000
 ```
 
-A short smoke run (`-runs=10000`) takes about 30 seconds on a quiescent laptop and is enough to verify the harness is wired up correctly. Submit-grade campaigns are open-ended — OSS-Fuzz runs them indefinitely.
+A short smoke run (`-runs=10000`) takes between 30 seconds and two minutes depending on the machine (measured 2026-08: 120 s at 83 exec/s on a Windows laptop) and is enough to verify the harness is wired up correctly. Submit-grade campaigns are open-ended — OSS-Fuzz runs them indefinitely. CI runs exactly this smoke on every push via [`fuzz.yml`](../.github/workflows/fuzz.yml).
 
 ## Submitting to OSS-Fuzz upstream
 
@@ -63,9 +72,8 @@ When ready, the path is:
 
 ## What's left
 
-Two follow-ups still open, both genuinely optional:
+One follow-up still open, genuinely optional:
 
-1. **Broaden the harness.** `VibeTagsFuzzer` only exercises `writeFileIfChanged`. Equally interesting attack surfaces — `stripLegacyVibeTagsBlock` against malformed XML, `cleanupGranularDirectory` against directory-traversal-like paths, the marker-position parsing in `writeWithMarkers` — are not covered. Adding `*Fuzzer.java` siblings is enough; `build.sh` already loops over every `*Fuzzer.java` it finds and emits a launcher.
-2. **CI smoke-compile.** Nothing currently verifies the harness still compiles against the live processor jar — a future API change can rot it again. A 30-second job in `build.yml` that runs the local recipe with `-runs=1` would catch this.
+1. **Broaden the harness.** `VibeTagsFuzzer` only exercises `writeFileIfChanged`. Equally interesting attack surfaces (`stripLegacyVibeTagsBlock` against malformed XML, `cleanupGranularDirectory` against directory-traversal-like paths, the marker-position parsing in `writeWithMarkers`) are not covered. Adding `*Fuzzer.java` siblings is enough for OSS-Fuzz; `build.sh` already loops over every `*Fuzzer.java` it finds and emits a launcher. The CI smoke ([`fuzz.yml`](../.github/workflows/fuzz.yml)) compiles and runs `VibeTagsFuzzer` by name, so add new siblings there as well.
 
-Neither blocks an upstream submission; both reduce the chance of the harness silently rotting again.
+The second follow-up this section used to list, a CI job that smoke-runs the harness so it cannot rot unnoticed, was implemented in 2026-08 as [`fuzz.yml`](../.github/workflows/fuzz.yml): 10,000 Jazzer iterations on every push and PR to `main`. It does not block an upstream submission; it removes the main reason the harness went stale before.


### PR DESCRIPTION
## Why

Part of completing the OpenSSF Best Practices badge (https://www.bestpractices.dev/en/projects/13275): the `dynamic_analysis` criterion asks that a dynamic analysis tool be applied before releases. The repo already had an OSS-Fuzz/Jazzer harness in `oss-fuzz/`, but nothing ran it, and its own README listed a CI smoke job as an open follow-up. A harness nothing compiles rots silently; that already happened once between 2026-04 and the 0.7.1 re-sync.

## What

- New `fuzz.yml` workflow: compiles `oss-fuzz/VibeTagsFuzzer.java` against the live processor classes and runs a 10,000-iteration coverage-guided Jazzer smoke on every push and PR to `main`. Jazzer v0.30.0 is pinned by SHA-256, not just release tag; all actions pinned by commit SHA per repo convention. Crash inputs upload as an artifact on failure. No `continue-on-error`.
- `oss-fuzz/README.md`: status updated, the completed follow-up moved out of "What's left", and the local recipe corrected (current Jazzer tarballs ship no `jazzer_api_deploy.jar`; the API jar comes from Maven Central, and the unshaded processor jar needs slf4j/logback on the fuzzer classpath).
- `docs/WORKFLOW.md`: new section 6 for the workflow; mutation testing renumbered to 7.

## Verification

- Ran the exact harness locally on Windows against processor 1.0.1: compiles, 10,000 runs, zero findings, exit 0 (120 s, 83 exec/s). Jazzer's CMP instrumentation rediscovered the `<!-- VIBETAGS-START -->` marker unaided, so the interesting parse paths are reached.
- `fuzz.yml` parses (yaml.safe_load); gitleaks, end-of-file and trailing-whitespace hooks pass. Checkstyle hook skipped locally (needs Docker, no Java files changed); CI runs it.
- The Linux leg of the workflow itself is verified by this PR's checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMyTGryfeWfX7c9EEVdHmG
