### PR TITLE
chore: prepare release v1.0.2

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.0.1
+version: 1.0.2
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.1'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.1'
+compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.2'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.2'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)
@@ -1066,7 +1066,7 @@ Use on: **class, method, field**
 @AIKeepInSync(mirrors = {"pom.xml:<version>", "README.md badge", "docs/CHANGELOG.md"},
               reason = "The release version is asserted in three places and drifts silently",
               enforcedBy = "ProjectFactsConsistencyTest")
-public static final String VERSION = "1.0.1";
+public static final String VERSION = "1.0.2";
 ```
 
 The element is free to change — the failure mode is a *partial* change that desyncs a mirror no compiler checks. `@AIContract` freezes one signature so it cannot change at all; neither it nor `@AISchemaSafe` expresses "edit A ⇒ you must also edit B". Mirrors routinely point outside the compilation unit, so VibeTags can only *name* them, not verify them.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.1</version>
+                        <version>1.0.2</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -117,8 +117,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.2')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -434,7 +434,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -459,7 +459,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.1</version>
+                        <version>1.0.2</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -475,8 +475,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.2')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -490,15 +490,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.1'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.1'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.2'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.2'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-08-07
+
 ### Fixed
+- **`scripts/set-version.sh` could silently bump an unrelated third-party dependency pin that
+  happened to equal the outgoing VibeTags version.** The parent POM edit was a blanket
+  `sed -i "s/$OLD/$NEW/g"` over the whole file, not scoped to `<revision>`. `jspecify.version`
+  had been pinned at `1.0.1` — the same string as the pre-1.0.2 VibeTags release — so bumping to
+  1.0.2 quietly rewrote it to `1.0.2` too, in both `vibetags-parent/pom.xml` and the mirrored
+  literal in `vibetags/build.gradle`. Caught during 1.0.2 release prep while investigating the
+  untracked-file trail left by the test-isolation bug below, not by any gate —
+  `BuildVersionParityTest` only checks that every VibeTags coordinate agrees with `<revision>`,
+  so a wrong-but-consistent jspecify version passes it. The script now edits `<revision>` in
+  isolation via a scoped tag match, and the two `build.gradle` files it must still hand-edit go
+  through a second scoped helper that only touches `version = '...'` and
+  `se.deversity.vibetags:<artifact>:<version>` coordinates, leaving any other pinned dependency
+  on that line alone.
+- **`ValidationRuleUnitTest`'s in-process compile ran the real `AIGuardrailProcessor` with no
+  `-Avibetags.root`, so it wrote into the actual working directory instead of an isolated temp
+  dir.** Every other test that compiles real sources through the processor
+  (`AnnotationValidatorArchitectureTest`, `AIGuardrailProcessorProcessTest`, ...) passes
+  `-Avibetags.root=<tempDir>`; this one did not. The processor's file-presence-is-the-opt-in
+  invariant means it never creates an opt-in file that does not already exist, but any opt-in
+  file that *does* exist in `vibetags/` at test time — `CONVENTIONS.md`,
+  `gemini_instructions.md`, `.github/copilot-instructions.md`, and the rest — got silently
+  overwritten with the test's `com.example.blank.BlankForbidden` fixture content on every
+  `mvn test`. Fixed by threading a `@TempDir` through both call sites of `compileAndCollect` and
+  passing it as `-Avibetags.root`, matching the existing pattern.
+
 - **A module's sidecar could be dropped from a parallel reactor build when a rename lost a race
   for more than 275 ms.** `ModuleSidecar.save()` writes a temp file and renames it over the live
   sidecar; on Windows that rename fails while anything else holds the target open, so it retries.
@@ -1944,7 +1971,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/PIsberg/vibetags/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/PIsberg/vibetags/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC10...v1.0.0
 [1.0.0-RC10]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC9...v1.0.0-RC10

--- a/example-all-tiers/pom.xml
+++ b/example-all-tiers/pom.xml
@@ -34,7 +34,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.0.1</vibetags.bom.version>
+    <vibetags.bom.version>1.0.2</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/example-multimodule-indexed/pom.xml
+++ b/example-multimodule-indexed/pom.xml
@@ -38,7 +38,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.0.1</vibetags.bom.version>
+    <vibetags.bom.version>1.0.2</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/example-multimodule/pom.xml
+++ b/example-multimodule/pom.xml
@@ -37,7 +37,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.0.1</vibetags.bom.version>
+    <vibetags.bom.version>1.0.2</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.2')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -27,7 +27,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.0.1</vibetags.bom.version>
+        <vibetags.bom.version>1.0.2</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -89,13 +89,50 @@ replace_in_file() {
     echo "  updated ${file#"$ROOT_DIR"/}"
 }
 
-# The one authoritative edit.
-replace_in_file "$PARENT_POM"
+# Scoped edit for files that also pin third-party dependency versions which can coincidentally
+# equal $OLD_VERSION (e.g. jspecify.version matched the VibeTags version once, and a blanket
+# replace_in_file bumped it right along with <revision>). Only two shapes are VibeTags's own:
+# the parent POM's <revision> property, and Gradle's `version = '...'` / `se.deversity.vibetags:
+# artifact:version` coordinate strings. Anything else on the line is left untouched.
+replace_xml_property() {
+    file="$1"
+    property="$2"
+    if [ ! -f "$file" ]; then
+        echo "warning: $file not found, skipping" >&2
+        return 0
+    fi
+    sed -i.bak -E "s#(<${property}>)$OLD_ESCAPED(</${property}>)#\1$NEW_VERSION\2#" "$file"
+    rm -f "$file.bak"
+    echo "  updated ${file#"$ROOT_DIR"/} (<$property> only)"
+}
+
+replace_gradle_vibetags_refs() {
+    file="$1"
+    if [ ! -f "$file" ]; then
+        echo "warning: $file not found, skipping" >&2
+        return 0
+    fi
+    sed -i.bak -E \
+        -e "s/^([[:space:]]*version = )'$OLD_ESCAPED'/\1'$NEW_VERSION'/" \
+        -e "s#(se\.deversity\.vibetags:[A-Za-z0-9_-]+:)$OLD_ESCAPED#\1$NEW_VERSION#g" \
+        "$file"
+    rm -f "$file.bak"
+    echo "  updated ${file#"$ROOT_DIR"/} (se.deversity.vibetags refs only)"
+}
+
+# The one authoritative edit — <revision> only, so a third-party version pin that happens to
+# equal $OLD_VERSION (jspecify.version has collided with it before) is never touched.
+replace_xml_property "$PARENT_POM" "revision"
 
 # Everything that cannot inherit it.
 for rel in \
     vibetags-annotations/build.gradle \
     vibetags/build.gradle \
+; do
+    replace_gradle_vibetags_refs "$ROOT_DIR/$rel"
+done
+
+for rel in \
     vibetags-annotations/pom.xml \
     vibetags-bom/pom.xml \
     example/pom.xml \

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -24,7 +24,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.0.1</vibetags.bom.version>
+        <vibetags.bom.version>1.0.2</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.1'
+version = '1.0.2'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.0.1'
+            version = '1.0.2'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -39,12 +39,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.0.1&lt;/version&gt;
+                &lt;version&gt;1.0.2&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.1'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.1'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.2'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.2'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -36,7 +36,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.0.1&lt;/version&gt;
+                        &lt;version&gt;1.0.2&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.1')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.1')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.2')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.2')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.0.1</revision>
+        <revision>1.0.2</revision>
 
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.1'
+version = '1.0.2'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.0.1'
+            version = '1.0.2'
             from components.java
 
             pom {
@@ -78,7 +78,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.0.1'
+    api 'se.deversity.vibetags:vibetags-annotations:1.0.2'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.1'

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ValidationRuleUnitTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ValidationRuleUnitTest.java
@@ -329,10 +329,10 @@ class ValidationRuleUnitTest {
     }
 
     @Test
-    void architectureRule_skipsTheScan_whenTheOnlyForbiddenEntryIsBlank() {
+    void architectureRule_skipsTheScan_whenTheOnlyForbiddenEntryIsBlank(@org.junit.jupiter.api.io.TempDir java.nio.file.Path tmp) {
         // A blank entry in cannotReference matches every import if it is not skipped, so this is
         // the difference between "you configured nothing" and "you forbade everything".
-        List<String> messages = compileAndCollect(
+        List<String> messages = compileAndCollect(tmp,
             "package com.example.blank;\n"
                 + "import se.deversity.vibetags.annotations.AIArchitecture;\n"
                 + "import java.util.List;\n"
@@ -345,11 +345,11 @@ class ValidationRuleUnitTest {
     }
 
     @Test
-    void architectureRule_matchesAnOnDemandImport_whenTheForbiddenEntryEndsWithADot() {
+    void architectureRule_matchesAnOnDemandImport_whenTheForbiddenEntryEndsWithADot(@org.junit.jupiter.api.io.TempDir java.nio.file.Path tmp) {
         // cannotReference = "com.example.forbidden." is how a package-with-trailing-dot reads to
         // somebody writing the annotation, and `import com.example.forbidden.*` is the import it is
         // most obviously meant to catch. The prefix-star arm is what makes that pair work.
-        List<String> messages = compileAndCollect(
+        List<String> messages = compileAndCollect(tmp,
             "package com.example.star;\n"
                 + "import se.deversity.vibetags.annotations.AIArchitecture;\n"
                 + "import java.util.*;\n"
@@ -361,8 +361,16 @@ class ValidationRuleUnitTest {
             "An on-demand import of a forbidden package must be reported: " + messages);
     }
 
-    /** Compiles one source with the real processor and returns {@code KIND|message} lines. */
-    private static List<String> compileAndCollect(String code, String name) {
+    /**
+     * Compiles one source with the real processor and returns {@code KIND|message} lines.
+     *
+     * <p>{@code -Avibetags.root} pins the processor's write root to the JUnit temp dir. Without it
+     * the processor falls back to the real working directory, so any opt-in file
+     * (CONVENTIONS.md, gemini_instructions.md, .github/copilot-instructions.md, ...) that happens to
+     * exist there gets silently overwritten with this test's fixture content on every {@code mvn
+     * test} — see issue found 2026-08-07.
+     */
+    private static List<String> compileAndCollect(java.nio.file.Path tmp, String code, String name) {
         List<String> messages = new ArrayList<>();
         javax.tools.JavaCompiler compiler = javax.tools.ToolProvider.getSystemJavaCompiler();
         javax.tools.DiagnosticCollector<javax.tools.JavaFileObject> diagnostics =
@@ -377,7 +385,8 @@ class ValidationRuleUnitTest {
         try (javax.tools.StandardJavaFileManager fm =
                  compiler.getStandardFileManager(diagnostics, null, null)) {
             javax.tools.JavaCompiler.CompilationTask task = compiler.getTask(null, fm, diagnostics,
-                List.of("-classpath", System.getProperty("java.class.path"), "-proc:only"),
+                List.of("-classpath", System.getProperty("java.class.path"), "-proc:only",
+                    "-Avibetags.root=" + tmp.toAbsolutePath()),
                 null, List.of(source));
             task.setProcessors(List.of(new AIGuardrailProcessor()));
             task.call();


### PR DESCRIPTION
## Summary

VibeTags 1.0.2. Fixed during release prep, not a planned feature release:

- **`scripts/set-version.sh` could silently bump an unrelated third-party dependency pin that happened to equal the outgoing VibeTags version.** The parent POM edit was a blanket `sed` over the whole file; `jspecify.version` (pinned at `1.0.1`, coincidentally the same string as the pre-1.0.2 VibeTags release) got bumped to `1.0.2` right along with `<revision>`. Now scoped to `<revision>` only, plus a helper for the two `build.gradle` files that only touches `version = '...'` and `se.deversity.vibetags:<artifact>:<version>` coordinates.
- **`ValidationRuleUnitTest`'s in-process compile ran the real `AIGuardrailProcessor` without `-Avibetags.root`**, so it wrote into the real working directory instead of an isolated temp dir — any opt-in file already sitting in `vibetags/` got silently overwritten with test fixture content on every `mvn test`. Fixed by threading a `@TempDir` through both call sites, matching every other real-compile test in the suite.

Both bugs were found while investigating an untracked-file trail in the working tree at the start of this release (three stray opt-in files with test-fixture content) rather than by any existing gate.

## Test plan

- [x] `BuildVersionParityTest` passes
- [x] `vibetags` fast-tier suite passes (`mvn test`), including the fixed `ValidationRuleUnitTest`
- [x] `example` module compiles end-to-end against the freshly installed 1.0.2 BOM
- [x] Targeted sed simulation against pre-bump files confirms `jspecify.version` stays at `1.0.1` while every VibeTags coordinate bumps to `1.0.2`
- [x] Full `1.0.1` literal sweep across the repo — only expected leftovers remain (CHANGELOG history, a pre-existing unrelated doc reference, a gitignored build artifact, an unrelated test fixture string)
- [ ] pre-commit (Checkstyle/gitleaks) — **not run locally**, Docker daemon unavailable in this environment; CI will run it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WAuufZgLit4ViE5mkp2dW
