### PR TITLE
chore: prepare release v1.0.3

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.0.2
+version: 1.0.3
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.2'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.2'
+compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.3'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.3'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)
@@ -1066,7 +1066,7 @@ Use on: **class, method, field**
 @AIKeepInSync(mirrors = {"pom.xml:<version>", "README.md badge", "docs/CHANGELOG.md"},
               reason = "The release version is asserted in three places and drifts silently",
               enforcedBy = "ProjectFactsConsistencyTest")
-public static final String VERSION = "1.0.2";
+public static final String VERSION = "1.0.3";
 ```
 
 The element is free to change — the failure mode is a *partial* change that desyncs a mirror no compiler checks. `@AIContract` freezes one signature so it cannot change at all; neither it nor `@AISchemaSafe` expresses "edit A ⇒ you must also edit B". Mirrors routinely point outside the compilation unit, so VibeTags can only *name* them, not verify them.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.3</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.2</version>
+                        <version>1.0.3</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -117,8 +117,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.3')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -434,7 +434,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.3</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -459,7 +459,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.2</version>
+                        <version>1.0.3</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -475,8 +475,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.3')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -490,15 +490,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.2'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.2'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.3'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.3'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.
@@ -829,4 +829,3 @@ VibeTags is built and maintained by a single developer in his spare time. If it 
 This project is licensed under the [MIT License](LICENSE).
 
 **Built with ❤️ for safer AI-assisted development**
-

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-08-07
+
 ### Fixed
 - **A failed compilation could rewrite guardrail files, sidecars, and the write cache.** The
   final-round handler never consulted `RoundEnvironment.errorRaised()`, so a build failed by a
@@ -2046,7 +2048,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.2...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.3...HEAD
+[1.0.3]: https://github.com/PIsberg/vibetags/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/PIsberg/vibetags/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/PIsberg/vibetags/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/PIsberg/vibetags/compare/v1.0.0-RC10...v1.0.0

--- a/example-all-tiers/pom.xml
+++ b/example-all-tiers/pom.xml
@@ -34,7 +34,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.0.2</vibetags.bom.version>
+    <vibetags.bom.version>1.0.3</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/example-multimodule-indexed/pom.xml
+++ b/example-multimodule-indexed/pom.xml
@@ -38,7 +38,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.0.2</vibetags.bom.version>
+    <vibetags.bom.version>1.0.3</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/example-multimodule/pom.xml
+++ b/example-multimodule/pom.xml
@@ -37,7 +37,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.0.2</vibetags.bom.version>
+    <vibetags.bom.version>1.0.3</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.3')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -27,7 +27,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.0.2</vibetags.bom.version>
+        <vibetags.bom.version>1.0.3</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -24,7 +24,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.0.2</vibetags.bom.version>
+        <vibetags.bom.version>1.0.3</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.2'
+version = '1.0.3'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.0.2'
+            version = '1.0.3'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -39,12 +39,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.0.2&lt;/version&gt;
+                &lt;version&gt;1.0.3&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.2'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.2'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.3'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.3'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -36,7 +36,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.0.2&lt;/version&gt;
+                        &lt;version&gt;1.0.3&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.2')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.2')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.3')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.3')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.0.2</revision>
+        <revision>1.0.3</revision>
 
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.2'
+version = '1.0.3'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.0.2'
+            version = '1.0.3'
             from components.java
 
             pom {
@@ -78,7 +78,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.0.2'
+    api 'se.deversity.vibetags:vibetags-annotations:1.0.3'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.1'

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/MissingFormatterCoverageTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/MissingFormatterCoverageTest.java
@@ -23,7 +23,7 @@ class MissingFormatterCoverageTest {
     @Test
     void testAllPlatformsForLowCoverageFormatters() {
         TaggedElement el = mockEl("com.example.TestClass");
-        
+
         AnnotationFormatter[] formatters = {
             new AILegacyBridgeFormatter(),
             new AISchemaSafeFormatter(),

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV4ValidationEdgeCaseTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV4ValidationEdgeCaseTest.java
@@ -245,14 +245,14 @@ class NewAnnotationsV4ValidationEdgeCaseTest {
             }
             return null;
         }).when(m).printMessage(any(Diagnostic.Kind.class), any(CharSequence.class), any());
-        
+
         doAnswer(inv -> {
             if (Diagnostic.Kind.WARNING.equals(inv.getArgument(0))) {
                 sink.add(inv.getArgument(1, CharSequence.class).toString());
             }
             return null;
         }).when(m).printMessage(any(Diagnostic.Kind.class), any(CharSequence.class));
-        
+
         return m;
     }
 }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/internal/content/platforms/PlatformRenderersTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/internal/content/platforms/PlatformRenderersTest.java
@@ -76,7 +76,7 @@ class PlatformRenderersTest {
         assertNotNull(output);
         assertTrue(output.contains("AUTO-GENERATED"));
     }
-    
+
     @Test
     void codyRenderer_rendersEmptyModel() {
         CodyRenderer renderer = new CodyRenderer();
@@ -84,7 +84,7 @@ class PlatformRenderersTest {
         assertNotNull(output);
         assertTrue(output.contains("vibetags-review"));
     }
-    
+
     @Test
     void rooModesRenderer_rendersEmptyModel() {
         RooModesRenderer renderer = new RooModesRenderer();
@@ -206,7 +206,7 @@ class PlatformRenderersTest {
         when(load.breaksIf()).thenReturn("Failure");
         when(load.suppressAudit()).thenReturn(false);
         when(mockElement.annotation(AILoadBearing.class)).thenReturn(load);
-        
+
         AIFeatureFlag flag = mock(AIFeatureFlag.class);
         when(flag.flag()).thenReturn("FLAG_A");
         when(flag.defaultValue()).thenReturn(true);


### PR DESCRIPTION
## Summary

Release v1.0.3 — promotes the audit fixes from PR #380 (fixed compile-failure write corruption, fingerprint short-circuit gaps, body-scoped guardrail visibility) plus locked-override warnings and lock-range recovery under Gradle.

### Fixed
- A failed compilation could rewrite guardrail files, sidecars, and the write cache — the final round now leaves every artifact untouched when errors were raised.
- Changing `-Avibetags.project` or `-Avibetags.module` was silently swallowed by the fingerprint short-circuit — both options are now bound into the run context.
- Hand-authored prose quoting the generated header line could be eaten on regeneration — header matching is now line-anchored.
- `.vibetags-locks` lost every line range under Gradle — the resolver now reflectively unwraps Gradle's incremental-processing wrapper.
- Two javadoc safety claims about hash collisions were wrong in direction — corrected to state the actual risk.

### Added
- Overriding an `@AILocked` concrete method now draws a compile-time WARNING (`LockedOverrideRule`).
- Guardrail annotations inside method bodies now warn instead of silently doing nothing (`MethodBodyGuardrailScanner`).

### Changed
- Pair-rule diagnostics now anchor at the conflicting annotation's mirror instead of the whole declaration.
- `docs/PROCESSOR.md` corrected: the processor claims `se.deversity.vibetags.annotations.*` (not `"*"`), and VibeTags annotations being `SOURCE`-retention means Gradle's incremental-processing contract cannot be assumed.

Full changelog: `docs/CHANGELOG.md#103---2026-08-07`

## Test plan
- [x] `BuildVersionParityTest` — 6/6 passing, confirms every managed pom/gradle file agrees with `<revision>` 1.0.3
- [x] Build order: `vibetags-annotations` → `vibetags` (clean install) → `vibetags-bom` — all `BUILD SUCCESS`
- [x] `example` clean compile against the freshly installed 1.0.3 BOM — `BUILD SUCCESS` (end-to-end annotation processing check)
- [x] Version sweep grep for leftover `1.0.2` references — only the frozen `docs/CHANGELOG.md` entry remains, as expected
- [x] `pre-commit` — gitleaks passed; end-of-file-fixer and trailing-whitespace auto-fixed 4 files (mechanical whitespace only, included in this commit)
- [~] `checkstyle` pre-commit hook unavailable (Docker Desktop not running locally) — ran the equivalent `mvn checkstyle:check` directly instead: 0 violations in both `vibetags-annotations` and `vibetags`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VLhiBK2dttAabGCVrYici
