### PR TITLE
fix: silence the build's real warnings, Error Prone and -source 21

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Three Error Prone `VoidUsed` warnings in `MethodBodyGuardrailScanner`.** The body scanner
+  passed its always-null `Void p` through to `super.visitMethod`, `super.visitClass` and
+  `super.visitAnnotation` instead of a `null` literal. They arrived with the scanner in 1.0.3 and
+  falsified the claim in `vibetags/pom.xml` that the build emits zero Error Prone warnings, which
+  is the property that makes the next one visible. No behaviour change: `p` is `Void` and is only
+  ever null.
+- **Every Maven module warned `location of system modules is not set in conjunction with
+  -source 21` when built on a JDK newer than 21.** `<source>/<target>` compiles against the
+  *running* JDK's API while stamping class-file version 21, so a JDK 26 build could link a method
+  that does not exist on 21 and fail there at runtime. CI builds 21, 25 and 26, so two thirds of
+  the matrix carried the risk. Replaced with `<release>21</release>` (`maven.compiler.release` in
+  `vibetags-parent`, plus the six poms that cannot inherit it). Error Prone still runs under
+  `--release`, verified by the `VoidUsed` warnings above firing before they were fixed. The Gradle
+  builds needed no change: Gradle already infers `--release` when `sourceCompatibility` equals
+  `targetCompatibility`.
+
 ## [1.0.3] - 2026-08-07
 
 ### Fixed

--- a/example-all-tiers/pom.xml
+++ b/example-all-tiers/pom.xml
@@ -31,8 +31,7 @@
   </modules>
 
   <properties>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vibetags.bom.version>1.0.3</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
@@ -72,8 +71,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.15.0</version>
           <configuration>
-            <source>21</source>
-            <target>21</target>
+            <release>21</release>
             <compilerArgs>
               <!-- Every module shares the reactor root as the VibeTags root, anchored by the
                    .mvn/ directory. .vibetags-root-index at that root makes Tier 1 an index. -->

--- a/example-multimodule-indexed/pom.xml
+++ b/example-multimodule-indexed/pom.xml
@@ -32,8 +32,7 @@
   </modules>
 
   <properties>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
@@ -76,8 +75,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.15.0</version>
           <configuration>
-            <source>21</source>
-            <target>21</target>
+            <release>21</release>
             <compilerArgs>
               <!-- Every module shares the reactor root as the VibeTags root (anchored by
                    the .mvn/ directory). With .vibetags-root-index present at that root, the

--- a/example-multimodule/pom.xml
+++ b/example-multimodule/pom.xml
@@ -34,8 +34,7 @@
   </modules>
 
   <properties>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vibetags.bom.version>1.0.3</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
@@ -75,8 +74,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.15.0</version>
           <configuration>
-            <source>21</source>
-            <target>21</target>
+            <release>21</release>
             <compilerArgs>
               <!--
                 All modules share the REACTOR root as the VibeTags root, so the generated

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -22,8 +22,7 @@
     </licenses>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
@@ -64,8 +63,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <release>21</release>
                     <compilerArgs>
                         <arg>-Avibetags.root=${project.basedir}</arg>
                         <arg>-Avibetags.log.path=${vibetags.log.path}</arg>

--- a/load-tests/pom.xml
+++ b/load-tests/pom.xml
@@ -86,8 +86,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <release>21</release>
                     <!-- JMH annotation processor generates benchmark boilerplate -->
                     <annotationProcessorPaths>
                         <path>

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -21,8 +21,7 @@
     </licenses>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <vibetags.bom.version>1.0.3</vibetags.bom.version>
     </properties>
@@ -53,8 +52,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <release>21</release>
                     <compilerArgs>
                         <arg>-Avibetags.root=${project.basedir}</arg>
                     </compilerArgs>

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -71,8 +71,10 @@
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
         <revision>1.0.3</revision>
 
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <!-- release, not source/target: on a JDK newer than 21 (CI builds 21, 25 and 26)
+             source/target compiles against the *running* JDK's API and javac warns that the
+             result may not run on 21. release pins the API to 21 and the warning goes away. -->
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Third-party runtime/compile dependencies -->

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/MethodBodyGuardrailScanner.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/MethodBodyGuardrailScanner.java
@@ -131,7 +131,7 @@ public final class MethodBodyGuardrailScanner {
         public Void visitMethod(MethodTree method, Void p) {
             methodDepth++;
             try {
-                return super.visitMethod(method, p);
+                return super.visitMethod(method, null);
             } finally {
                 methodDepth--;
             }
@@ -144,7 +144,7 @@ public final class MethodBodyGuardrailScanner {
                 reportEveryGuardrailIn(type);
                 return null; // the whole subtree was just reported; do not visit it twice
             }
-            return super.visitClass(type, p);
+            return super.visitClass(type, null);
         }
 
         /** Reports every guardrail annotation anywhere inside an unreachable declaration. */
@@ -166,7 +166,7 @@ public final class MethodBodyGuardrailScanner {
                                 + " member, or move the annotation to the enclosing declaration.",
                             annotation, unit);
                     }
-                    return super.visitAnnotation(annotation, p);
+                    return super.visitAnnotation(annotation, null);
                 }
             }.scan((Tree) unreachable, null);
         }


### PR DESCRIPTION
## What

Two warning classes were live on every build. Both are gone; the build now emits no `[WARNING]` from javac in any module.

### Error Prone: 3 x `VoidUsed`, now 0

`MethodBodyGuardrailScanner` passed its always-null `Void p` through to `super.visitMethod`, `super.visitClass` and `super.visitAnnotation` instead of a `null` literal (lines 134, 147, 169).

They arrived with the body scanner in 1.0.3 and falsified the note in `vibetags/pom.xml`:

> the build now emits zero Error Prone warnings and the next one is visible

That note is the whole point of muting exactly three checks and fixing the rest. Once it stops being true, the next warning has somewhere to hide. Passing `null` is semantically identical: `p` is `Void` and is only ever null.

### javac: `-source 21` on every module, now 0

```
[WARNING] location of system modules is not set in conjunction with -source 21
  not setting the location of system modules may lead to class files that cannot run on JDK 21
    --release 21 is recommended instead of -source 21 -target 21
```

Not cosmetic. `<source>/<target>` compiles against the **running** JDK's API while stamping class-file version 21, so a JDK 26 build can link a method that does not exist on 21 and fail there at runtime. The CI matrix builds 21, 25 and 26, so two thirds of it carried the risk.

Replaced with `<release>21</release>`: `maven.compiler.release` in `vibetags-parent`, plus the six poms that cannot inherit it (`example`, `example-all-tiers`, `example-multimodule`, `example-multimodule-indexed`, `tools/demo`, `load-tests`).

The Gradle builds needed no change. Gradle already infers `--release` when `sourceCompatibility` equals `targetCompatibility`, and `gradle compileJava` emits the warning nowhere.

## How it was verified

| Check | Result |
|---|---|
| `mvn test -Pe2e` in `vibetags/`, JDK 26 | 1535 tests, 0 failures, 0 errors |
| `mvn clean compile` in `vibetags/`, JDK 21 | BUILD SUCCESS, zero `[WARNING]` |
| Rebuild of annotations, processor, bom, 4 examples, tools/demo, load-tests | zero javac `[WARNING]` |
| `mvn checkstyle:check` | 0 violations |
| Error Prone still active under `--release` | confirmed: the `VoidUsed` warnings fired on a `--release 21` build before they were fixed |

That last row is the one worth reading twice. A flag change that quietly disabled Error Prone would also produce a warning-free build, so "no warnings" alone proves nothing. The plugin was watched still finding the defect under the new flag before the defect was removed.

`pre-commit` is not installed on this machine and was **not run**. `checkstyle:check` was run directly, and the trailing-whitespace and end-of-file hooks were verified by hand against the staged files.

## Deliberately left alone

- The `@AIDraft` + `@AILocked` warning from `example` and `example-multimodule`. That is the demo exercising the validator; the exact text is documented at `USAGE.md:520`.
- `Unable to locate Source XRef to link to -- DISABLED` from maven-pmd-plugin. Wants `maven-jxr-plugin`; adding a plugin to silence a report-only line is a poor trade.
- `Unknown keyword meta:enum` / `deprecated` from cyclonedx-maven-plugin's schema validator. Third-party, no project-side lever.

## Not addressed here

Nothing fails the build when a new Error Prone warning appears, which is exactly how `VoidUsed` slipped in. Failing on Error Prone warnings would be the durable fix, but it risks red CI on a future Error Prone or JDK pairing, so it is a separate decision rather than a rider on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JcFUN1eiqo2d8AxjYHjYa
