### PR TITLE
fix: a reactor module round must not sweep the shared root (#383)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **A cold reactor build deleted every other module's scoped rule files.** On a fresh clone,
+  `mvn -B -pl core clean compile` in `example-multimodule` removed 256 tracked rule files and
+  exited 0. `.vibetags-mod-*` sidecars are gitignored, so after a clone the exclusion list a module
+  round builds from them is empty of every sibling, and `cleanupAll` treats each sibling's
+  committed file as an orphan. A full reactor hid it: the files were deleted mid-build and
+  rewritten by a later module before the end, leaving a clean diff and one warning
+  (`removed 32 scoped rule file(s) ... while writing only 1`) that had been in CI on `main` for
+  some time. `DestructiveRewriteWarner` worked exactly as designed; the message was read as noise.
+  A reactor module round now sweeps nothing at the shared root, keeping only its own directory
+  (`ModuleOutputWriter`) and its own mirrors (`cleanupMirrored`, already scoped that way).
+  Counting sidecars was tried first and is not sufficient — the sweep merely moves to reactor
+  module 3, which sees two siblings and still not the fourth. The cost is a genuinely orphaned root
+  rule file surviving until the root compiles, which is the trade already documented for an emptied
+  module's last contribution. `DestructiveRewriteWarningTest.coldReactorModule_withNoSiblingSidecars_leavesTheOtherModulesRulesAlone`
+  pins it, written red first. Issue #383.
 - **Three Error Prone `VoidUsed` warnings in `MethodBodyGuardrailScanner`.** The body scanner
   passed its always-null `Void p` through to `super.visitMethod`, `super.visitClass` and
   `super.visitAnnotation` instead of a `null` literal. They arrived with the scanner in 1.0.3 and

--- a/docs/MULTI-MODULE.md
+++ b/docs/MULTI-MODULE.md
@@ -103,6 +103,17 @@ function computed *before* the write so the `@AILocked` `generateFiles()` step o
 Every cleanup pass adds every *other* sidecar's stems to its exclusion list, which is what stops a
 round from deleting rule files belonging to another source set — or another module.
 
+That list is necessary but not sufficient, because it can only exclude what it can see. Sidecars are
+gitignored, so on a fresh clone they arrive one module at a time and a module round looking at the
+shared root sees a directory full of files nothing has claimed *yet*. Sweeping on that evidence
+deleted 256 committed rule files on a cold `mvn -B -pl core clean compile`, exit 0 (issue #383). So
+the rule is jurisdiction, not arithmetic: **a reactor module round never sweeps the shared root.**
+It cleans its own per-module directory and its own mirrors, both already scoped to it; only a round
+whose compilation root *is* the VibeTags root may retire a root rule file. Counting sidecars instead
+does not work — the sweep simply moves to reactor module 3, which sees two siblings and still not
+the fourth. The cost is the same one the next paragraph describes: an orphan can outlive the build
+that orphaned it.
+
 Two preservation guards keep compiles with **no annotations** from destroying content: the module's
 sidecar is only saved when annotations were found, and shared-file writes with no contributions
 preserve the existing file content. Consequence: removing *all* annotations from a module leaves its

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
@@ -572,7 +572,32 @@ public class AIGuardrailProcessor extends AbstractProcessor {
             granularWriter.writeAll(elementRules, serviceFiles, activeServices, rootRoles,
                 ModuleSidecar.mergeGranular(allSidecars)));
         writtenQNames.addAll(ModuleSidecar.granularStemsFrom(allSidecars, moduleId, null));
-        Set<String> removedQNames = granularWriter.cleanupAll(serviceFiles, activeServices, writtenQNames);
+        // Only a round compiling the root itself may sweep the root's granular directory. A module
+        // round cannot tell an orphan from a sibling it has not been shown: `.vibetags-mod-*` is
+        // gitignored, so on a fresh clone the sidecars appear one module at a time, and every module
+        // before the last sees a directory full of files nothing has claimed yet. Sweeping on that
+        // evidence deleted 256 tracked rule files on a cold `mvn -pl core clean compile`, exit 0
+        // (issue #383); a full reactor hid it because a later module rewrote them before the end.
+        //
+        // Counting sidecars is not a strong enough test — it was tried, and the sweep simply moved
+        // to reactor module 3, which sees two siblings and still not the fourth. Jurisdiction, not
+        // arithmetic, is the rule: a module owns its own directory (ModuleOutputWriter) and its own
+        // mirrors (cleanupMirrored, already scoped this way), never the shared root. The cost is a
+        // genuinely orphaned root rule file surviving until the root compiles, which matches the
+        // trade already documented for an emptied module's last contribution.
+        //
+        // The predicate is the one lines 366 and 372 already use for "this is a reactor module
+        // round". `compilationRoot.equals(root)` alone is NOT equivalent and was tried: a
+        // single-module project with no pom.xml to anchor the compilation root fails it, and five
+        // rename/delete cleanup tests went red because ordinary orphan cleanup stopped happening.
+        boolean maySweepRoot = moduleIdentity == null || compilationRoot.equals(root);
+        Set<String> removedQNames = maySweepRoot
+            ? granularWriter.cleanupAll(serviceFiles, activeServices, writtenQNames)
+            : Set.of();
+        if (!maySweepRoot && log != null && log.isDebugEnabled()) {
+            log.debug("granular.sweep.skip reason=module-round-not-root module={} written={}",
+                moduleId, writtenQNames.size());
+        }
         // myGranular's keys ARE the stems this round planned — the same map the sidecar recorded,
         // so the sweep can never be judged against a differently-computed set.
         destructiveWarner().orphanSweep("the reactor root", removedQNames, myGranular.keySet());

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/DestructiveRewriteWarningTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/DestructiveRewriteWarningTest.java
@@ -184,6 +184,74 @@ class DestructiveRewriteWarningTest {
             "removing one annotation of three is not a destructive rewrite: " + messages(sweep));
     }
 
+    /**
+     * The fresh-clone case: {@code .vibetags-mod-*} is gitignored, so the first module of a reactor
+     * to compile after a clone has no sibling sidecars on disk. Its exclusion list is therefore
+     * empty of every other module's stems, and a sweep judged on that evidence deletes rule files
+     * whose sources it was never shown.
+     *
+     * <p>This is not hypothetical arithmetic. On a cold clone of this repository,
+     * {@code cd example-multimodule && mvn -B -pl core clean compile} deleted 256 committed rule
+     * files and exited 0. The full reactor hid it, because a later module rewrote them all before
+     * the build ended.
+     *
+     * <p>A round that cannot see the project has no basis for the word "orphan", so it must not
+     * sweep at all. Deleting on no information is the failure; the warning was only ever the symptom.
+     */
+    @Test
+    void coldReactorModule_withNoSiblingSidecars_leavesTheOtherModulesRulesAlone() throws Exception {
+        Files.createFile(root.resolve("CLAUDE.md"));
+        Files.createDirectories(root.resolve(".claude/rules"));
+        compileModule("module-core", "com.example.core.IrNode", "Core IR node");
+        compileModule("module-cli", "com.example.cli.Cli", "CLI entry point");
+
+        Path siblingRule = root.resolve(".claude/rules/com-example-cli-Cli.md");
+        assertTrue(Files.exists(siblingRule), "precondition: both modules own a scoped rule file");
+
+        // The fresh clone: rule files are committed, sidecars are not.
+        deleteAllSidecars();
+        ProcessorTestHarness.awaitFilesystemTick(root);
+        VibeTagsLogger.shutdown();
+
+        List<Diagnostic<? extends JavaFileObject>> cold =
+            compileModuleReturningDiagnostics("module-core", "com.example.core.IrNode", "Core IR node");
+
+        assertTrue(Files.exists(siblingRule),
+            "a reactor module with no sibling sidecars cannot tell an orphan from a file it simply "
+                + "never saw, so it must delete nothing: " + messages(cold));
+        assertFalse(warns(cold, "while writing only"),
+            "and with nothing swept there is nothing to report: " + messages(cold));
+    }
+
+    private void deleteAllSidecars() throws IOException {
+        try (java.util.stream.Stream<Path> files = Files.list(root)) {
+            for (Path p : files.filter(f -> f.getFileName().toString().startsWith(".vibetags-mod-")).toList()) {
+                Files.delete(p);
+            }
+        }
+    }
+
+    private void compileModule(String module, String fqn, String reason) throws IOException {
+        compileModuleReturningDiagnostics(module, fqn, reason);
+    }
+
+    private List<Diagnostic<? extends JavaFileObject>> compileModuleReturningDiagnostics(
+            String module, String fqn, String reason) throws IOException {
+        ProcessorTestHarness harness = new ProcessorTestHarness(root, false);
+        Files.createDirectories(root.resolve(module));
+        Files.writeString(root.resolve(module).resolve("pom.xml"),
+            "<project><artifactId>" + module + "</artifactId></project>", StandardCharsets.UTF_8);
+        int lastDot = fqn.lastIndexOf('.');
+        harness.writeSourceFile(module + "/src/main/java/" + fqn.replace('.', '/') + ".java",
+            "package " + fqn.substring(0, lastDot) + ";\n"
+                + "import se.deversity.vibetags.annotations.AILocked;\n"
+                + "@AILocked(reason = \"" + reason + "\")\n"
+                + "public class " + fqn.substring(lastDot + 1) + " {}\n");
+        List<Diagnostic<? extends JavaFileObject>> diagnostics = harness.compileReturningDiagnostics();
+        VibeTagsLogger.shutdown();
+        return diagnostics;
+    }
+
     private int ruleFileCount() throws IOException {
         try (java.util.stream.Stream<Path> files = Files.list(root.resolve(".claude/rules"))) {
             return (int) files.filter(Files::isRegularFile).count();


### PR DESCRIPTION
Fixes #383.

## The bug

On a fresh clone, building one module of a reactor deletes every other module's committed scoped rule files and exits 0.

```
git clone <repo> && cd example-multimodule
mvn -B -pl core clean compile            # exit 0
git status --porcelain | grep -c '^ D'   # 256
```

`.vibetags-mod-*` sidecars are gitignored, so after a clone the exclusion list a module round builds from them is empty of every sibling, and `cleanupAll` treats each sibling's committed rule file as an orphan.

## Why it stayed invisible

A full reactor hid it. The files were deleted mid-build and rewritten by a later module before the end, so the net diff came out clean. The only trace was one line, which has been in CI on `main` for some time:

```
[WARNING] VibeTags: removed 32 scoped rule file(s) under the reactor root (...) while writing only 1.
```

`DestructiveRewriteWarner` did exactly what it was built for. The message was read as noise — which is the failure mode that guard exists to prevent. It surfaced here only because I was chasing build warnings for an unrelated PR and refused to file this one under "cosmetic".

`example-multimodule` also has no `git status --porcelain` gate in CI, unlike `example/` (`build.yml:91-99`).

## The fix

Jurisdiction, not arithmetic: **a reactor module round sweeps nothing at the shared root.** It still cleans its own per-module directory (`ModuleOutputWriter`) and its own mirrors (`cleanupMirrored`), both already scoped to it. Only a round whose compilation root *is* the VibeTags root may retire a root rule file.

Two weaker guards were tried and rejected, both by measurement:

| attempt | why it failed |
|---|---|
| `isMultiModule(allSidecars)` — "does it see siblings?" | the sweep just moves to reactor **module 3**, which sees two siblings and still not the fourth. Verified: the warning reappeared, one module later |
| `compilationRoot.equals(root)` alone | **5 tests went red.** A single-module project with no `pom.xml` to anchor the compilation root fails it, so ordinary rename/delete orphan cleanup stopped happening |

The predicate shipped is the one lines 366 and 372 already use for "this is a reactor module round". The second attempt is the useful one: the suite named the boundary I was guessing at, which is worth more than the guess.

**Cost:** a genuinely orphaned root rule file survives until the root compiles. That is the same trade already documented for an emptied module's last contribution (`GuardrailLifecycleEndToEndTest.emptyingAModuleEntirely_leavesItsLastContributionUntilTheSidecarIsDeleted`).

## About the lock

This edits `AIGuardrailProcessor.generateFiles()`, which this repository's own `<locked_files>` guardrail covers. I stopped at it, raised it, and only proceeded on the lock holder's explicit approval.

The locked property is step order, and it is untouched: no step is reordered, added or removed. One existing step becomes conditional.

## Verification

| check | result |
|---|---|
| `coldReactorModule_withNoSiblingSidecars_leavesTheOtherModulesRulesAlone`, **written red first** | failed on the sibling's file being deleted; passes now |
| `mvn test -Pe2e` | **1536 tests, 0 failures** (1535 before, +1 new) |
| cold clone, `mvn -B -pl core clean compile` | **256 deletions → 0** |
| cold clone, `mvn clean verify` | **1 destructive WARNING → 0**, 0 deletions |
| `example`, `example-multimodule-indexed`, `example-all-tiers` regenerate | **zero git diff** — committed output byte-identical |
| `checkstyle:check` | 0 violations |

`pre-commit` is not installed on this machine and was **not run**; trailing-whitespace and end-of-file were checked by hand.

The one residual diff after a full reactor build is `example-multimodule/.vibetags-locks`, which carries absolute `file:` paths and so differs by checkout directory. Pre-existing, unrelated, and the reason the missing CI gate would need that fixed first.

## Not in this PR

- **`-Dvibetags.check=true` is unusable as the first command on a fresh clone of a reactor.** It fails at module 2 of 6 with `check failed — 306 guardrail file(s) are out of date`, because check mode also depends on sidecars that do not exist yet. `docs/PROCESSOR.md` does not say so. Recorded in #383.
- **The missing `git status --porcelain` gate on `example-multimodule/`.** It would have caught this class of defect; it needs the `.vibetags-locks` path churn resolved first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JcFUN1eiqo2d8AxjYHjYa
