### PR TITLE
docs: check mode needs a normal build first in a reactor

### DIFF
--- a/docs/PROCESSOR.md
+++ b/docs/PROCESSOR.md
@@ -104,6 +104,26 @@ recorded path fails the build via `Messager.ERROR`. The fingerprint short-circui
 bypassed so the verdict never depends on cache state; internal failures in check mode fail closed
 (ERROR, not the usual downgrade-to-WARNING).
 
+**In a reactor, check mode needs a normal build first.** It reads the same `.vibetags-mod-*`
+sidecars the merge does, and those are gitignored, so on a fresh clone they do not exist yet. Run as
+the *first* command after cloning, check mode sees each module in isolation, judges the committed
+root files to be missing every other module's content, and fails at the first module:
+
+```
+$ git clone <repo> && cd <reactor> && mvn -B clean compile -Dvibetags.check=true
+[ERROR] VibeTags: check failed — 306 guardrail file(s) are out of date with the annotations
+[INFO] BUILD FAILURE          (module [2/6])
+```
+
+Nothing is wrong with the tree. Build once, then check:
+
+```
+mvn -B clean compile && mvn -B compile -Dvibetags.check=true
+```
+
+CI does exactly this — the check step runs after the ordinary build, not instead of it. Single-module
+projects are unaffected: one module is the whole project, so the first compile already sees everything.
+
 ## Machine-readable lock report (`.vibetags-locks`)
 
 An opt-in pseudo-platform (service key `locks_report`, touch `.vibetags-locks` to enable) that emits


### PR DESCRIPTION
Documents a consumer trap found while confirming #383. No behaviour change.

## The trap

`-Dvibetags.check=true` as the **first** command on a fresh clone of a reactor fails at the first module:

```
$ git clone <repo> && cd <reactor> && mvn -B clean compile -Dvibetags.check=true
[ERROR] VibeTags: check failed — 306 guardrail file(s) are out of date with the annotations
[INFO] BUILD FAILURE          (module [2/6])
```

Nothing is wrong with the tree. Check mode reads the same `.vibetags-mod-*` sidecars the merge does, and those are gitignored, so after a clone they do not exist yet. Each module is judged in isolation against root files that legitimately carry every module's content.

This repo's CI already does the right thing — the check step runs after the ordinary build — but the reason recorded at `build.yml:170-179` is "the tree is regenerated by then", not "check mode cannot run cold". A consumer reading `docs/PROCESSOR.md` and wiring the documented option into their own CI had nothing to warn them, and the failure they would hit names 306 files and looks like a real drift.

## Verified, not asserted

On a cold `git clone` of this repository at `ea53c25`:

| command | result |
|---|---|
| `mvn -B clean compile -Dvibetags.check=true` | **BUILD FAILURE** at module 2/6 |
| `mvn -B clean compile && mvn -B compile -Dvibetags.check=true` | **BUILD SUCCESS** |

The documented remedy is the second line, tested rather than reasoned about.

Single-module projects are unaffected, and the doc says so: one module is the whole project, so the first compile already sees everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JcFUN1eiqo2d8AxjYHjYa
