### PR TITLE
perf(test): reuse one javac file manager per test thread (CPU only, no wall-clock win)

### DIFF
--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ActiveServicesNoteTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ActiveServicesNoteTest.java
@@ -66,18 +66,17 @@ class ActiveServicesNoteTest {
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
-            fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
-            List<String> options = List.of(
-                "-classpath", System.getProperty("java.class.path"),
-                "-proc:only",
-                "-Avibetags.root=" + tmp.toAbsolutePath()
-            );
-            JavaCompiler.CompilationTask task = compiler.getTask(
-                null, fm, diagnostics, options, null, sources);
-            task.setProcessors(List.of(new AIGuardrailProcessor()));
-            task.call();
-        }
+        StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager();
+        fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
+        List<String> options = List.of(
+            "-classpath", System.getProperty("java.class.path"),
+            "-proc:only",
+            "-Avibetags.root=" + tmp.toAbsolutePath()
+        );
+        JavaCompiler.CompilationTask task = compiler.getTask(
+            null, fm, diagnostics, options, null, sources);
+        task.setProcessors(List.of(new AIGuardrailProcessor()));
+        task.call();
         for (var d : diagnostics.getDiagnostics()) {
             messages.add(d.getMessage(Locale.ROOT));
         }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ActiveServicesNoteTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ActiveServicesNoteTest.java
@@ -66,7 +66,7 @@ class ActiveServicesNoteTest {
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = compiler.getStandardFileManager(diagnostics, null, null)) {
+        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
             fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
             List<String> options = List.of(
                 "-classpath", System.getProperty("java.class.path"),

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/AnnotationValidatorArchitectureTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/AnnotationValidatorArchitectureTest.java
@@ -198,7 +198,7 @@ class AnnotationValidatorArchitectureTest {
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = compiler.getStandardFileManager(diagnostics, null, null)) {
+        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
             fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
             List<String> options = List.of(
                 "-classpath", System.getProperty("java.class.path"),

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/AnnotationValidatorArchitectureTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/AnnotationValidatorArchitectureTest.java
@@ -198,18 +198,17 @@ class AnnotationValidatorArchitectureTest {
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
-            fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
-            List<String> options = List.of(
-                "-classpath", System.getProperty("java.class.path"),
-                "-proc:only",
-                "-Avibetags.root=" + tmp.toAbsolutePath()
-            );
-            JavaCompiler.CompilationTask task = compiler.getTask(
-                null, fm, diagnostics, options, null, sources);
-            task.setProcessors(List.of(new AIGuardrailProcessor()));
-            task.call();
-        }
+        StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager();
+        fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
+        List<String> options = List.of(
+            "-classpath", System.getProperty("java.class.path"),
+            "-proc:only",
+            "-Avibetags.root=" + tmp.toAbsolutePath()
+        );
+        JavaCompiler.CompilationTask task = compiler.getTask(
+            null, fm, diagnostics, options, null, sources);
+        task.setProcessors(List.of(new AIGuardrailProcessor()));
+        task.call();
         for (var d : diagnostics.getDiagnostics()) {
             messages.add(d.getMessage(Locale.ROOT));
         }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/CoreRulesEdgeCaseTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/CoreRulesEdgeCaseTest.java
@@ -77,7 +77,7 @@ class CoreRulesEdgeCaseTest {
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = compiler.getStandardFileManager(diagnostics, null, null)) {
+        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
             fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
             JavaCompiler.CompilationTask task = compiler.getTask(
                 null, fm, diagnostics,

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/CoreRulesEdgeCaseTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/CoreRulesEdgeCaseTest.java
@@ -77,16 +77,15 @@ class CoreRulesEdgeCaseTest {
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
-            fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
-            JavaCompiler.CompilationTask task = compiler.getTask(
-                null, fm, diagnostics,
-                List.of("-classpath", System.getProperty("java.class.path"), "-proc:only",
-                        "-Avibetags.root=" + tempDir.toAbsolutePath()),
-                null, sources);
-            task.setProcessors(List.of(new AIGuardrailProcessor()));
-            task.call();
-        }
+        StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager();
+        fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
+        JavaCompiler.CompilationTask task = compiler.getTask(
+            null, fm, diagnostics,
+            List.of("-classpath", System.getProperty("java.class.path"), "-proc:only",
+                    "-Avibetags.root=" + tempDir.toAbsolutePath()),
+            null, sources);
+        task.setProcessors(List.of(new AIGuardrailProcessor()));
+        task.call();
         for (var d : diagnostics.getDiagnostics()) {
             messages.add(d.getMessage(Locale.ROOT));
         }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ErrorRaisedRoundGuardTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ErrorRaisedRoundGuardTest.java
@@ -104,7 +104,7 @@ class ErrorRaisedRoundGuardTest {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         assertTrue(compiler != null, "JavaCompiler unavailable — run tests with a JDK, not a JRE");
 
-        try (StandardJavaFileManager fm = compiler.getStandardFileManager(diagnostics, null, null)) {
+        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
             Path classOut = tempDir.resolve("classes");
             Files.createDirectories(classOut);
             fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ErrorRaisedRoundGuardTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ErrorRaisedRoundGuardTest.java
@@ -104,28 +104,27 @@ class ErrorRaisedRoundGuardTest {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         assertTrue(compiler != null, "JavaCompiler unavailable — run tests with a JDK, not a JRE");
 
-        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
-            Path classOut = tempDir.resolve("classes");
-            Files.createDirectories(classOut);
-            fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
+        StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager();
+        Path classOut = tempDir.resolve("classes");
+        Files.createDirectories(classOut);
+        fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
 
-            JavaFileObject source = new StringSource(
-                "com/example/Locked.java",
-                "package com.example;\n"
-                    + "import se.deversity.vibetags.annotations.AILocked;\n"
-                    + "@AILocked(reason = \"core logic\")\n"
-                    + "public class Locked {}\n");
+        JavaFileObject source = new StringSource(
+            "com/example/Locked.java",
+            "package com.example;\n"
+                + "import se.deversity.vibetags.annotations.AILocked;\n"
+                + "@AILocked(reason = \"core logic\")\n"
+                + "public class Locked {}\n");
 
-            List<String> options = List.of(
-                "-classpath", System.getProperty("java.class.path"),
-                "-proc:only",
-                "-Avibetags.root=" + tempDir.toAbsolutePath());
+        List<String> options = List.of(
+            "-classpath", System.getProperty("java.class.path"),
+            "-proc:only",
+            "-Avibetags.root=" + tempDir.toAbsolutePath());
 
-            JavaCompiler.CompilationTask task = compiler.getTask(
-                null, fm, diagnostics, options, null, List.of(source));
-            task.setProcessors(List.of(new AIGuardrailProcessor(), new ErrorRaisingPeerProcessor()));
-            return task.call();
-        }
+        JavaCompiler.CompilationTask task = compiler.getTask(
+            null, fm, diagnostics, options, null, List.of(source));
+        task.setProcessors(List.of(new AIGuardrailProcessor(), new ErrorRaisingPeerProcessor()));
+        return task.call();
     }
 
     private static final class StringSource extends SimpleJavaFileObject {

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ModernJavaDetectorTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ModernJavaDetectorTest.java
@@ -175,7 +175,7 @@ class ModernJavaDetectorTest {
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = compiler.getStandardFileManager(diagnostics, null, null)) {
+        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
             fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
             List<String> options = List.of(
                 "-classpath", System.getProperty("java.class.path"),

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ModernJavaDetectorTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ModernJavaDetectorTest.java
@@ -175,17 +175,16 @@ class ModernJavaDetectorTest {
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
-            fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
-            List<String> options = List.of(
-                "-classpath", System.getProperty("java.class.path"),
-                "-proc:only",
-                "-Avibetags.root=" + tempDir.toAbsolutePath()
-            );
-            JavaCompiler.CompilationTask task = compiler.getTask(null, fm, diagnostics, options, null, sources);
-            task.setProcessors(List.of(new AIGuardrailProcessor()));
-            task.call();
-        }
+        StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager();
+        fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
+        List<String> options = List.of(
+            "-classpath", System.getProperty("java.class.path"),
+            "-proc:only",
+            "-Avibetags.root=" + tempDir.toAbsolutePath()
+        );
+        JavaCompiler.CompilationTask task = compiler.getTask(null, fm, diagnostics, options, null, sources);
+        task.setProcessors(List.of(new AIGuardrailProcessor()));
+        task.call();
 
         for (var d : diagnostics.getDiagnostics()) {
             messages.add(d.getMessage(Locale.ROOT));

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV3ValidationTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV3ValidationTest.java
@@ -110,18 +110,17 @@ class NewAnnotationsV3ValidationTest {
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
-            fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
-            List<String> options = List.of(
-                "-classpath", System.getProperty("java.class.path"),
-                "-proc:only",
-                "-Avibetags.root=" + tempDir.toAbsolutePath()
-            );
-            JavaCompiler.CompilationTask task = compiler.getTask(
-                null, fm, diagnostics, options, null, sources);
-            task.setProcessors(List.of(new AIGuardrailProcessor()));
-            task.call();
-        }
+        StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager();
+        fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
+        List<String> options = List.of(
+            "-classpath", System.getProperty("java.class.path"),
+            "-proc:only",
+            "-Avibetags.root=" + tempDir.toAbsolutePath()
+        );
+        JavaCompiler.CompilationTask task = compiler.getTask(
+            null, fm, diagnostics, options, null, sources);
+        task.setProcessors(List.of(new AIGuardrailProcessor()));
+        task.call();
 
         for (var d : diagnostics.getDiagnostics()) {
             warnings.add(d.getMessage(Locale.ROOT));

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV3ValidationTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV3ValidationTest.java
@@ -110,7 +110,7 @@ class NewAnnotationsV3ValidationTest {
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = compiler.getStandardFileManager(diagnostics, null, null)) {
+        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
             fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
             List<String> options = List.of(
                 "-classpath", System.getProperty("java.class.path"),

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV5ValidationTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV5ValidationTest.java
@@ -85,7 +85,7 @@ class NewAnnotationsV5ValidationTest {
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = compiler.getStandardFileManager(diagnostics, null, null)) {
+        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
             fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
             List<String> options = List.of(
                 "-classpath", System.getProperty("java.class.path"),

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV5ValidationTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV5ValidationTest.java
@@ -85,18 +85,17 @@ class NewAnnotationsV5ValidationTest {
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
-            fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
-            List<String> options = List.of(
-                "-classpath", System.getProperty("java.class.path"),
-                "-proc:only",
-                "-Avibetags.root=" + tempDir.toAbsolutePath()
-            );
-            JavaCompiler.CompilationTask task = compiler.getTask(
-                null, fm, diagnostics, options, null, sources);
-            task.setProcessors(List.of(new AIGuardrailProcessor()));
-            task.call();
-        }
+        StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager();
+        fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
+        List<String> options = List.of(
+            "-classpath", System.getProperty("java.class.path"),
+            "-proc:only",
+            "-Avibetags.root=" + tempDir.toAbsolutePath()
+        );
+        JavaCompiler.CompilationTask task = compiler.getTask(
+            null, fm, diagnostics, options, null, sources);
+        task.setProcessors(List.of(new AIGuardrailProcessor()));
+        task.call();
 
         for (var d : diagnostics.getDiagnostics()) {
             warnings.add(d.getMessage(Locale.ROOT));

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV6ValidationTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV6ValidationTest.java
@@ -149,18 +149,17 @@ class NewAnnotationsV6ValidationTest {
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
-            fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
-            List<String> options = List.of(
-                "-classpath", System.getProperty("java.class.path"),
-                "-proc:only",
-                "-Avibetags.root=" + tempDir.toAbsolutePath()
-            );
-            JavaCompiler.CompilationTask task = compiler.getTask(
-                null, fm, diagnostics, options, null, sources);
-            task.setProcessors(List.of(new AIGuardrailProcessor()));
-            task.call();
-        }
+        StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager();
+        fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
+        List<String> options = List.of(
+            "-classpath", System.getProperty("java.class.path"),
+            "-proc:only",
+            "-Avibetags.root=" + tempDir.toAbsolutePath()
+        );
+        JavaCompiler.CompilationTask task = compiler.getTask(
+            null, fm, diagnostics, options, null, sources);
+        task.setProcessors(List.of(new AIGuardrailProcessor()));
+        task.call();
 
         for (var d : diagnostics.getDiagnostics()) {
             warnings.add(d.getMessage(Locale.ROOT));

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV6ValidationTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV6ValidationTest.java
@@ -149,7 +149,7 @@ class NewAnnotationsV6ValidationTest {
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = compiler.getStandardFileManager(diagnostics, null, null)) {
+        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
             fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
             List<String> options = List.of(
                 "-classpath", System.getProperty("java.class.path"),

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/OutputOrderDeterminismTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/OutputOrderDeterminismTest.java
@@ -92,17 +92,16 @@ class OutputOrderDeterminismTest {
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
-            fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
-            JavaCompiler.CompilationTask task = compiler.getTask(
-                null, fm, diagnostics,
-                List.of("-classpath", System.getProperty("java.class.path"),
-                        "-Avibetags.root=" + root.toAbsolutePath(),
-                        "-Avibetags.cache=false"),
-                null, sources);
-            task.setProcessors(List.of(new AIGuardrailProcessor()));
-            task.call();
-        }
+        StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager();
+        fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
+        JavaCompiler.CompilationTask task = compiler.getTask(
+            null, fm, diagnostics,
+            List.of("-classpath", System.getProperty("java.class.path"),
+                    "-Avibetags.root=" + root.toAbsolutePath(),
+                    "-Avibetags.cache=false"),
+            null, sources);
+        task.setProcessors(List.of(new AIGuardrailProcessor()));
+        task.call();
         return Files.readString(claudeMd, StandardCharsets.UTF_8);
     }
 

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/OutputOrderDeterminismTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/OutputOrderDeterminismTest.java
@@ -92,7 +92,7 @@ class OutputOrderDeterminismTest {
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = compiler.getStandardFileManager(diagnostics, null, null)) {
+        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
             fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
             JavaCompiler.CompilationTask task = compiler.getTask(
                 null, fm, diagnostics,

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ProcessorFailureGuardTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ProcessorFailureGuardTest.java
@@ -62,28 +62,27 @@ class ProcessorFailureGuardTest {
 
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
         boolean ok;
-        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
-            Path classOut = tempDir.resolve("classes");
-            Files.createDirectories(classOut);
-            fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
+        StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager();
+        Path classOut = tempDir.resolve("classes");
+        Files.createDirectories(classOut);
+        fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
 
-            JavaFileObject source = new StringSource(
-                "com/example/Locked.java",
-                "package com.example;\n"
-                    + "import se.deversity.vibetags.annotations.AILocked;\n"
-                    + "@AILocked(reason = \"core logic\")\n"
-                    + "public class Locked {}\n");
+        JavaFileObject source = new StringSource(
+            "com/example/Locked.java",
+            "package com.example;\n"
+                + "import se.deversity.vibetags.annotations.AILocked;\n"
+                + "@AILocked(reason = \"core logic\")\n"
+                + "public class Locked {}\n");
 
-            List<String> options = List.of(
-                "-classpath", System.getProperty("java.class.path"),
-                "-proc:only",
-                "-Avibetags.root=" + tempDir.toAbsolutePath());
+        List<String> options = List.of(
+            "-classpath", System.getProperty("java.class.path"),
+            "-proc:only",
+            "-Avibetags.root=" + tempDir.toAbsolutePath());
 
-            JavaCompiler.CompilationTask task = compiler.getTask(
-                null, fm, diagnostics, options, null, List.of(source));
-            task.setProcessors(List.of(new FaultyProcessor()));
-            ok = task.call();
-        }
+        JavaCompiler.CompilationTask task = compiler.getTask(
+            null, fm, diagnostics, options, null, List.of(source));
+        task.setProcessors(List.of(new FaultyProcessor()));
+        ok = task.call();
 
         // 1. The build must NOT fail because of the processor blowing up.
         assertTrue(ok, "Compilation should succeed: a guardrail failure must never break the build");

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ProcessorFailureGuardTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ProcessorFailureGuardTest.java
@@ -62,7 +62,7 @@ class ProcessorFailureGuardTest {
 
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
         boolean ok;
-        try (StandardJavaFileManager fm = compiler.getStandardFileManager(diagnostics, null, null)) {
+        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
             Path classOut = tempDir.resolve("classes");
             Files.createDirectories(classOut);
             fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ProcessorTestHarness.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ProcessorTestHarness.java
@@ -1,12 +1,14 @@
 package se.deversity.vibetags.processor;
 
 import javax.tools.DiagnosticCollector;
+import javax.tools.ForwardingJavaFileManager;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -32,6 +34,35 @@ import java.util.List;
  * }</pre>
  */
 class ProcessorTestHarness {
+
+    /**
+     * One file manager per test thread, reused across every compilation that thread runs.
+     *
+     * <p>A {@code StandardJavaFileManager} caches its view of the classpath and of the JDK image:
+     * building a fresh one per compile made javac re-open and re-index all 26 classpath entries
+     * and rebuild its {@code jrt:} index for each of the 278 compilations the suite performs.
+     * Measured on the {@code e2e} tier, reuse cut compile time from 931 s to 643 s of thread time.
+     * Pinned to 4 threads, which is the vCPU count CI gets, the tier went from 69 s to 47 s of
+     * wall clock once the twelve test classes that drive javac themselves were switched over too.
+     *
+     * <p>Per-thread rather than global because {@code JavacFileManager} is not thread-safe and the
+     * suite runs test classes and methods concurrently. Everything a compilation varies —
+     * {@code CLASS_OUTPUT}, the options, the compilation units — is set per call, so nothing
+     * leaks between tests on the same thread; the 1537 tests of the {@code e2e} tier are the
+     * regression check on that. Never closed: the instance lives for the lifetime of the fork.
+     */
+    private static final ThreadLocal<StandardJavaFileManager> SHARED_FILE_MANAGER =
+        ThreadLocal.withInitial(
+            () -> ToolProvider.getSystemJavaCompiler().getStandardFileManager(null, null, null));
+
+    /**
+     * This thread's shared file manager, wrapped so that closing it is a no-op. Test classes that
+     * drive javac themselves should use this instead of {@code getStandardFileManager}; see
+     * {@link #SHARED_FILE_MANAGER} for the measurement that motivates it.
+     */
+    static StandardJavaFileManager sharedFileManager() {
+        return new NonClosing(SHARED_FILE_MANAGER.get());
+    }
 
     private final Path root;
     private final List<JavaFileObject> sources = new ArrayList<>();
@@ -236,7 +267,7 @@ class ProcessorTestHarness {
             throw new IllegalStateException("JavaCompiler unavailable — run tests with a JDK, not a JRE");
         }
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = compiler.getStandardFileManager(diagnostics, null, null)) {
+        try (StandardJavaFileManager fm = sharedFileManager()) {
             Path classOut = root.resolve("classes");
             Files.createDirectories(classOut);
             fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
@@ -389,6 +420,64 @@ class ProcessorTestHarness {
             "    @AIContract(reason = \"External payment gateway API — breaking changes will violate SLA\")\n" +
             "    double charge(String customerId, double amount);\n" +
             "}\n");
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal: non-closing wrapper around the shared file manager
+    // -----------------------------------------------------------------------
+
+    /**
+     * Hands the shared {@link #SHARED_FILE_MANAGER} to a compilation task without letting the
+     * task's try-with-resources close it. Every other call forwards unchanged.
+     *
+     * <p>{@link ForwardingJavaFileManager} covers the {@code JavaFileManager} half; the four
+     * {@code getJavaFileObjects*} overloads and the {@code File}-based {@code setLocation} /
+     * {@code getLocation} come from {@code StandardJavaFileManager} and have to be forwarded by
+     * hand.
+     */
+    private static final class NonClosing
+            extends ForwardingJavaFileManager<StandardJavaFileManager>
+            implements StandardJavaFileManager {
+
+        NonClosing(StandardJavaFileManager delegate) {
+            super(delegate);
+        }
+
+        /** No-op: the delegate is shared with every other compilation on this thread. */
+        @Override
+        public void close() {
+            // deliberately not closed
+        }
+
+        @Override
+        public Iterable<? extends JavaFileObject> getJavaFileObjectsFromFiles(Iterable<? extends File> files) {
+            return fileManager.getJavaFileObjectsFromFiles(files);
+        }
+
+        @Override
+        public Iterable<? extends JavaFileObject> getJavaFileObjects(File... files) {
+            return fileManager.getJavaFileObjects(files);
+        }
+
+        @Override
+        public Iterable<? extends JavaFileObject> getJavaFileObjectsFromStrings(Iterable<String> names) {
+            return fileManager.getJavaFileObjectsFromStrings(names);
+        }
+
+        @Override
+        public Iterable<? extends JavaFileObject> getJavaFileObjects(String... names) {
+            return fileManager.getJavaFileObjects(names);
+        }
+
+        @Override
+        public void setLocation(Location location, Iterable<? extends File> files) throws IOException {
+            fileManager.setLocation(location, files);
+        }
+
+        @Override
+        public Iterable<? extends File> getLocation(Location location) {
+            return fileManager.getLocation(location);
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ProcessorTestHarness.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ProcessorTestHarness.java
@@ -40,8 +40,13 @@ class ProcessorTestHarness {
      * building a fresh one per compile made javac re-open and re-index all 26 classpath entries
      * and rebuild its {@code jrt:} index for each of the 278 compilations the suite performs.
      * Measured on the {@code e2e} tier, reuse cut compile time from 931 s to 643 s of thread time.
-     * Pinned to 4 threads, which is the vCPU count CI gets, the tier went from 69 s to 51 s of
-     * wall clock once the twelve test classes that drive javac themselves were switched over too.
+     *
+     * <p>That is CPU, not wall clock, and the distinction matters: at the default thread count the
+     * tier takes the same time either way (48.2 s against 48.4 s, three alternating runs each),
+     * and CI's e2e step is unchanged too (26 s and 28 s, against a 20 s to 31 s spread over eight
+     * runs of {@code main}). Neither a 16-core desktop nor a GitHub runner is CPU-bound here;
+     * instrumenting the harness put the wall clock on filesystem contention instead. Keep this for
+     * the CPU it saves, and do not cite a wall-clock figure for it without measuring again.
      *
      * <p>Per-thread rather than global because {@code JavacFileManager} is not thread-safe and the
      * suite runs test classes and methods concurrently. Everything a compilation varies —

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ProcessorTestHarness.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ProcessorTestHarness.java
@@ -1,14 +1,12 @@
 package se.deversity.vibetags.processor;
 
 import javax.tools.DiagnosticCollector;
-import javax.tools.ForwardingJavaFileManager;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -42,7 +40,7 @@ class ProcessorTestHarness {
      * building a fresh one per compile made javac re-open and re-index all 26 classpath entries
      * and rebuild its {@code jrt:} index for each of the 278 compilations the suite performs.
      * Measured on the {@code e2e} tier, reuse cut compile time from 931 s to 643 s of thread time.
-     * Pinned to 4 threads, which is the vCPU count CI gets, the tier went from 69 s to 47 s of
+     * Pinned to 4 threads, which is the vCPU count CI gets, the tier went from 69 s to 51 s of
      * wall clock once the twelve test classes that drive javac themselves were switched over too.
      *
      * <p>Per-thread rather than global because {@code JavacFileManager} is not thread-safe and the
@@ -56,12 +54,20 @@ class ProcessorTestHarness {
             () -> ToolProvider.getSystemJavaCompiler().getStandardFileManager(null, null, null));
 
     /**
-     * This thread's shared file manager, wrapped so that closing it is a no-op. Test classes that
-     * drive javac themselves should use this instead of {@code getStandardFileManager}; see
-     * {@link #SHARED_FILE_MANAGER} for the measurement that motivates it.
+     * This thread's shared file manager. Test classes that drive javac themselves should use this
+     * instead of {@code getStandardFileManager}; see {@link #SHARED_FILE_MANAGER} for the
+     * measurement that motivates it.
+     *
+     * <p>Never put the result in a try-with-resources, and never wrap it in a forwarding manager
+     * to absorb the {@code close()}. javac wraps any file manager that is not its own
+     * {@code JavacFileManager} in {@code ClientCodeWrapper$WrappedJavaFileManager}, and CodeQL's
+     * Java extractor reflects into that wrapper's {@code clientJavaFileManager} field — which
+     * {@code jdk.compiler} does not open, so the whole suite fails under CodeQL with
+     * {@code InaccessibleObjectException}. Handing javac its own class back keeps the compilation
+     * indistinguishable from one that built a fresh manager.
      */
     static StandardJavaFileManager sharedFileManager() {
-        return new NonClosing(SHARED_FILE_MANAGER.get());
+        return SHARED_FILE_MANAGER.get();
     }
 
     private final Path root;
@@ -267,7 +273,8 @@ class ProcessorTestHarness {
             throw new IllegalStateException("JavaCompiler unavailable — run tests with a JDK, not a JRE");
         }
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = sharedFileManager()) {
+        StandardJavaFileManager fm = sharedFileManager();
+        try {
             Path classOut = root.resolve("classes");
             Files.createDirectories(classOut);
             fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
@@ -420,64 +427,6 @@ class ProcessorTestHarness {
             "    @AIContract(reason = \"External payment gateway API — breaking changes will violate SLA\")\n" +
             "    double charge(String customerId, double amount);\n" +
             "}\n");
-    }
-
-    // -----------------------------------------------------------------------
-    // Internal: non-closing wrapper around the shared file manager
-    // -----------------------------------------------------------------------
-
-    /**
-     * Hands the shared {@link #SHARED_FILE_MANAGER} to a compilation task without letting the
-     * task's try-with-resources close it. Every other call forwards unchanged.
-     *
-     * <p>{@link ForwardingJavaFileManager} covers the {@code JavaFileManager} half; the four
-     * {@code getJavaFileObjects*} overloads and the {@code File}-based {@code setLocation} /
-     * {@code getLocation} come from {@code StandardJavaFileManager} and have to be forwarded by
-     * hand.
-     */
-    private static final class NonClosing
-            extends ForwardingJavaFileManager<StandardJavaFileManager>
-            implements StandardJavaFileManager {
-
-        NonClosing(StandardJavaFileManager delegate) {
-            super(delegate);
-        }
-
-        /** No-op: the delegate is shared with every other compilation on this thread. */
-        @Override
-        public void close() {
-            // deliberately not closed
-        }
-
-        @Override
-        public Iterable<? extends JavaFileObject> getJavaFileObjectsFromFiles(Iterable<? extends File> files) {
-            return fileManager.getJavaFileObjectsFromFiles(files);
-        }
-
-        @Override
-        public Iterable<? extends JavaFileObject> getJavaFileObjects(File... files) {
-            return fileManager.getJavaFileObjects(files);
-        }
-
-        @Override
-        public Iterable<? extends JavaFileObject> getJavaFileObjectsFromStrings(Iterable<String> names) {
-            return fileManager.getJavaFileObjectsFromStrings(names);
-        }
-
-        @Override
-        public Iterable<? extends JavaFileObject> getJavaFileObjects(String... names) {
-            return fileManager.getJavaFileObjects(names);
-        }
-
-        @Override
-        public void setLocation(Location location, Iterable<? extends File> files) throws IOException {
-            fileManager.setLocation(location, files);
-        }
-
-        @Override
-        public Iterable<? extends File> getLocation(Location location) {
-            return fileManager.getLocation(location);
-        }
     }
 
     // -----------------------------------------------------------------------

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/SignatureCaptureTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/SignatureCaptureTest.java
@@ -80,7 +80,7 @@ class SignatureCaptureTest {
         CapturingProcessor processor = new CapturingProcessor(capture);
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = compiler.getStandardFileManager(diagnostics, null, null)) {
+        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
             fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
             JavaCompiler.CompilationTask task = compiler.getTask(
                 null, fm, diagnostics,

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/SignatureCaptureTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/SignatureCaptureTest.java
@@ -80,16 +80,15 @@ class SignatureCaptureTest {
         CapturingProcessor processor = new CapturingProcessor(capture);
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        try (StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager()) {
-            fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
-            JavaCompiler.CompilationTask task = compiler.getTask(
-                null, fm, diagnostics,
-                List.of("-classpath", System.getProperty("java.class.path"), "-proc:only"),
-                null,
-                List.of(new StringSource("com/example/sig/Charger.java", SOURCE)));
-            task.setProcessors(List.of(processor));
-            task.call();
-        }
+        StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager();
+        fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classOut.toFile()));
+        JavaCompiler.CompilationTask task = compiler.getTask(
+            null, fm, diagnostics,
+            List.of("-classpath", System.getProperty("java.class.path"), "-proc:only"),
+            null,
+            List.of(new StringSource("com/example/sig/Charger.java", SOURCE)));
+        task.setProcessors(List.of(processor));
+        task.call();
         return processor.signature;
     }
 

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ValidationRuleUnitTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ValidationRuleUnitTest.java
@@ -382,16 +382,14 @@ class ValidationRuleUnitTest {
                 return code;
             }
         };
-        try (javax.tools.StandardJavaFileManager fm =
-                 ProcessorTestHarness.sharedFileManager()) {
+        javax.tools.StandardJavaFileManager fm = ProcessorTestHarness.sharedFileManager();
+        try {
             javax.tools.JavaCompiler.CompilationTask task = compiler.getTask(null, fm, diagnostics,
                 List.of("-classpath", System.getProperty("java.class.path"), "-proc:only",
                     "-Avibetags.root=" + tmp.toAbsolutePath()),
                 null, List.of(source));
             task.setProcessors(List.of(new AIGuardrailProcessor()));
             task.call();
-        } catch (java.io.IOException e) {
-            throw new IllegalStateException(e);
         } finally {
             VibeTagsLogger.shutdown();
         }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ValidationRuleUnitTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ValidationRuleUnitTest.java
@@ -383,7 +383,7 @@ class ValidationRuleUnitTest {
             }
         };
         try (javax.tools.StandardJavaFileManager fm =
-                 compiler.getStandardFileManager(diagnostics, null, null)) {
+                 ProcessorTestHarness.sharedFileManager()) {
             javax.tools.JavaCompiler.CompilationTask task = compiler.getTask(null, fm, diagnostics,
                 List.of("-classpath", System.getProperty("java.class.path"), "-proc:only",
                     "-Avibetags.root=" + tmp.toAbsolutePath()),


### PR DESCRIPTION
## Status: measured, and it does not deliver what the title originally promised

Read the numbers section before deciding. **I recommend closing this unless the CPU saving is wanted for its own sake.** It is green everywhere and harmless, but it does not make the suite faster in any configuration anyone runs.

## What it does

The suite drives javac in-process 278 times on the `e2e` tier, and every one of those compilations built a fresh `StandardJavaFileManager`. A file manager caches its view of the classpath and of the JDK image, so discarding it per compile made javac re-open and re-index all 26 classpath entries and rebuild the `jrt:` index, 278 times over.

This holds one per test thread (`JavacFileManager` is not thread-safe and the suite runs classes and methods concurrently) and hands javac the real instance rather than a forwarding wrapper. Everything a compilation varies — `CLASS_OUTPUT`, options, compilation units — was already set per call.

## Numbers

**CPU: a real 31% cut.** Instrumenting the harness over the `e2e` tier, compile time went from 931 s to 643 s of thread time.

**Wall clock: no change anywhere it matters.**

Default thread count, `e2e` surefire goal, alternating runs on a 16-core Windows desktop:

| | run 1 | run 2 | run 3 | mean |
|---|---|---|---|---|
| main | 33.4 s | 56.4 s | 54.8 s | 48.2 s |
| this branch | 44.3 s | 52.0 s | 48.8 s | 48.4 s |

CI, the `Run Full Test Suite (incl. e2e)` step of `Maven Build (JDK 26)`:

| | e2e step |
|---|---|
| main, 8 runs | 22, 29, 30, 29, 20, 30, 31, 29 s |
| this branch, 2 runs | 26 s, 28 s |

Both branch readings sit inside main's spread.

I originally claimed a 31% CI win off a local run with threads pinned to 4. That was wrong: it matched CI's core count but not its filesystem, and the filesystem is what the wall clock is bound by here. Re-indexing the classpath per compile is expensive on Windows and cheap on a Linux runner.

## Why no wall-clock win is available this way

Four experiments, all pointing the same direction. Running the fast tier with parallelism **off** takes 40.8 s against 30 s with 16 threads, so threads buy 1.35x. Thread count is flat from 8 to 24. `forkCount` 2 and 4 are both worse. And a spike that cut ~13,000 file writes (dropping the harness from 60 opt-in platforms to 1) bought 19% while this change, cutting 31% of the CPU, bought nothing — the bottleneck is filesystem operations, not compiler work.

## Incidental finding worth keeping

The first push broke the CodeQL `Analyze (java)` job with 36 `InaccessibleObjectException`s while every other job passed. javac wraps any file manager that is not its own `JavacFileManager` in `ClientCodeWrapper$WrappedJavaFileManager`, and CodeQL's Java extractor reflects into that wrapper's `clientJavaFileManager` field, which `jdk.compiler` does not open. The fix and the reason are recorded in the javadoc on `sharedFileManager()`, so the next person who reaches for a forwarding file manager in this harness finds out cheaply.

## Verification

All 14 checks green on `cf82769`, merge state CLEAN. `mvn -o verify -Pe2e` locally (checkstyle, PMD, CPD, ErrorProne/NullAway, jacoco): 1537 tests, 0 failures.

`pre-commit run --all-files` was **not** run: `pre-commit` is not on PATH in this environment. Checkstyle, PMD and CPD ran via `verify`; gitleaks and the whitespace fixers did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUxfjry7TrPKVfpmZAbQfr
