### PR TITLE
test: move async-test-lib from 1.7.1 to the 1.7.3 release

### DIFF
--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -88,7 +88,7 @@
         <junit.platform.version>6.1.2</junit.platform.version>
         <mockito.version>5.23.0</mockito.version>
         <archunit.version>1.5.0</archunit.version>
-        <async-test-lib.version>1.7.1</async-test-lib.version>
+        <async-test-lib.version>1.7.3</async-test-lib.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <jmh.version>1.37</jmh.version>
 

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.5.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:6.1.2'
     // Concurrency-test harness, matching pom.xml. Resolves from Maven Central like any other dep.
-    testImplementation 'se.deversity.async-test-lib:async-test-lib:1.7.1'
+    testImplementation 'se.deversity.async-test-lib:async-test-lib:1.7.3'
     testImplementation 'org.mockito:mockito-core:5.23.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.23.0'
     // Test-only, matching pom.xml. The processor writes six YAML documents but must not gain a


### PR DESCRIPTION
## What

`async-test-lib` 1.7.1 → **1.7.3**, in both places that declare it:

- `vibetags-parent/pom.xml` — the `async-test-lib.version` property
- `vibetags/build.gradle` — the literal, which the comment beside it already says must match

Two build systems declare this dependency separately, so bumping one alone would leave the tiers
testing against different detector engines.

## Branch hygiene

Built in a **separate git worktree off `origin/main`**, so the checkout in `C:\dev\private\vibetags`
was never touched — it stayed on `perf/reuse-javac-file-manager` throughout. Nothing here rides on
those three unrelated commits.

## The one upstream risk, checked

1.7.3 removed the `UNCOMMITTED_CHANGES` detector, which is source-breaking for anyone naming that
constant in an `excludes` attribute — it broke a sibling repo outright. vibetags names no
`DetectorType` constants anywhere, confirmed by searching the tree rather than assumed, so nothing
needed adjusting.

## Verified on both build systems

`~/.m2` held a locally built jar masquerading as 1.7.3, so it was moved aside and the genuine
artifact refetched, sha1 `56e7d477` confirmed against Central before any run.

```
mvn test -Pe2e          1537 tests, 0 failures
./gradlew test -Pe2e    1537 tests, 0 failures
```

**The `e2e` tier is the one that matters here.** Three of the four `@AsyncTest` classes carry
`@Tag("e2e")`, so a plain `mvn test` runs only `WriteCacheAsyncTest` — it reports 957 green tests
and would have signed off on this bump having exercised a quarter of the async surface. Under
`-Pe2e` all four ran on both build systems: `GuardrailFileWriterAsyncTest`, `ModuleSidecarAsyncTest`,
`VibeTagsLoggerAsyncTest`, `WriteCacheAsyncTest` — confirmed in the surefire output and the Gradle
JUnit XML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwuXPyu9Mj2JaLMm1vJnRv
