### PR TITLE
feat(skill): add a consumer regression suite

### DIFF
--- a/.claude/skills/consumer-regression-suite/SKILL.md
+++ b/.claude/skills/consumer-regression-suite/SKILL.md
@@ -43,8 +43,8 @@ the result.
 ## Step 2 — Run the sweep
 
 ```bash
-bash scripts/consumer-sweep.sh 1.0.3              # every consumer
-bash scripts/consumer-sweep.sh 1.0.3 blindbean    # one
+bash scripts/consumer-sweep.sh <version>            # every consumer
+bash scripts/consumer-sweep.sh <version> blindbean  # one
 ```
 
 Per repo it fetches, branches off `origin/main`, rewrites every place that repo declares the
@@ -130,3 +130,11 @@ rm -rf ~/.m2/repository/se/deversity/vibetags/*/<version>
   Windows and inventing drift in files the bump never needed to touch.
 - Sweeping a repo with uncommitted work either fails or drags that work into the branch. The
   script skips dirty repos on purpose; do not force past it.
+- **Run this repo's gates after `git add`, not before.** `ReleaseScriptCoverageTest` reads
+  `git ls-files`, so a brand-new file is invisible to it while untracked. A local
+  `mvn verify -Pe2e` went green on these very files and CI then failed on all 17 jobs, because
+  both of them quoted a real release version in an example. Never put a literal release version
+  in a new file: say `<version>`.
+- Six PRs opening at once made Maven Central answer 429 and failed an unrelated consumer job.
+  A resolution failure naming artifacts you did not touch (`junit-bom` here) is infrastructure;
+  rerun it rather than investigating it.

--- a/.claude/skills/consumer-regression-suite/SKILL.md
+++ b/.claude/skills/consumer-regression-suite/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: consumer-regression-suite
+description: Build every downstream consumer of VibeTags against a chosen VibeTags version and report which ones actually pass. Use when the user says "regression suite", "consumer sweep", "test the consumers", "check the downstream repos", "does the new version break anything", or before cutting a VibeTags release.
+---
+
+# Consumer regression suite
+
+VibeTags' own 1537 tests say the processor works. They say nothing about whether a real
+consumer still builds. This skill answers that second question, for every Java repo under
+`../` that depends on VibeTags.
+
+The executable core is `scripts/consumer-sweep.sh` in this repo. This document is the
+judgement around it: what to run, what a result means, and what not to believe.
+
+## Step 1 — Decide which VibeTags the sweep is testing
+
+Two different questions, and they need different setups. Ask which one is wanted if it is
+not obvious from the request.
+
+**"Does the released version still work?"** Use the published version directly. Nothing to
+install; consumers resolve it from Maven Central.
+
+**"Does what we are about to release still work?"** `main` is usually ahead of the newest
+tag, so the published artifact is not the code under test. Check first:
+
+```bash
+git -C <vibetags> log "$(git -C <vibetags> tag --sort=-v:refname | head -1)"..main --oneline
+```
+
+If that is non-empty, build and install `main` locally:
+
+```bash
+cd vibetags-annotations && mvn install -DskipTests
+cd ../vibetags         && mvn install -DskipTests
+cd ../vibetags-bom     && mvn install
+```
+
+Installing `main` under a version number that is also on Central makes the local copy differ
+from the published one for every later build on this machine. Say so, and offer the cleanup
+in Step 5. Installing under a fresh `-SNAPSHOT` avoids it but means no consumer PR can pin
+the result.
+
+## Step 2 — Run the sweep
+
+```bash
+bash scripts/consumer-sweep.sh 1.0.3              # every consumer
+bash scripts/consumer-sweep.sh 1.0.3 blindbean    # one
+```
+
+Per repo it fetches, branches off `origin/main`, rewrites every place that repo declares the
+VibeTags version, builds with the repo's own wrapper, and prints the build's real exit code.
+It commits nothing, pushes nothing and opens nothing.
+
+Consumers, and how each declares the version:
+
+| repo | build | declares the version in |
+|---|---|---|
+| `blindbean` | Maven (`mvnw`) | `pom.xml` |
+| `codekarta` | Maven + Gradle | `pom.xml` **and** `build.gradle.kts` — both, kept in sync |
+| `common-license-lib` | Maven + Gradle | `pom.xml` **and** `build.gradle.kts` |
+| `skill3` | Gradle | `build.gradle` |
+| `async-test-lib` | Maven + Gradle | `pom.xml` only; Gradle reads it from the POM |
+
+Add a repo by adding a row to `CONSUMERS` in the script, not by running it by hand.
+
+## Step 3 — Read the results honestly
+
+A red result is a claim about VibeTags, and most red results are not. Before reporting any
+failure as a regression:
+
+**Rerun it on the base.** Check out `origin/main` with its existing pinned version and run
+the same command. A test that fails both ways is the consumer's problem, and saying otherwise
+sends someone hunting a bug that is not there. `blindbean`'s
+`FheAsyncConcurrencyTest.concurrentBfvOperationsAreThreadSafe` fails roughly one run in three
+on both the old and new version — it is a 60-second timeout in a thread-safety test and it
+flakes on a loaded machine.
+
+**Compare like with like.** A repo that builds with both Maven and Gradle must be compared
+tool-for-tool. Running Maven on the new version and Gradle on the base produced a convincing
+three-file "guardrail drift" here that was entirely an artifact of the comparison.
+
+**Distinguish content drift from line-ending churn.** On Windows, `git status` lists a file
+whose line endings moved even when its text did not. `git diff --numstat` compares after
+git's normalisation, so an empty numstat with a dirty status is EOL churn, not drift. Only a
+non-empty numstat means the new VibeTags renders something different — which is a real
+finding, because the consumer's committed guardrail files are then stale and its check-mode
+gate will fail.
+
+**A first build in a fresh worktree is not evidence.** It can touch files that every
+subsequent build leaves alone. Reproduce anything surprising before reporting it.
+
+## Step 4 — Fix in VibeTags, not in the consumer
+
+If the sweep finds a genuine regression, the fix belongs in VibeTags with a regression test in
+the VibeTags suite. Working around it in the consumer hides it from the next consumer. Adding
+a validation check is a line in `ValidationRules.PAIRS`; the other invariants are in
+`CLAUDE.md` and `docs/LOAD-BEARING.md`.
+
+## Step 5 — Hand it over, do not finish it
+
+Report a table: repo, pass or fail, and for every failure whether it reproduces on the base.
+Report skipped and not-run separately from passed.
+
+Then stop. Opening the consumer PRs is a separate, deliberate act:
+
+- A consumer cannot pin a version that is not published. If the sweep tested an unreleased
+  `main`, the consumer bumps have to wait for the release, and saying this out loud is part
+  of the report.
+- Each consumer PR is one bump in one repo. Do not fold in whatever else that repo's `main`
+  is missing.
+- `async-test-lib` is swept in a `git worktree` rather than a checkout, because another agent
+  works in that tree and switching its branch underneath them is destructive. Keep it that
+  way. Clean up with `git -C ../async-test-lib worktree prune`.
+
+If `main` was installed locally over a published version, offer to purge it so a later build
+resolves the real artifact:
+
+```bash
+rm -rf ~/.m2/repository/se/deversity/vibetags/*/<version>
+```
+
+## Traps this suite has already paid for
+
+- The Maven on PATH here is 3.8.6 and `blindbean`'s enforcer requires 3.9.0+. Always prefer
+  the repo's `./mvnw`; only `blindbean` ships one.
+- `verify` is a Maven phase, not a Gradle task. A repo built both ways needs two commands.
+- `cmd | tail` reports `tail`'s exit code. Every build in the script writes to a log and reads
+  `$?` directly.
+- `sed -i` rewrites a file even when the pattern matches nothing, converting CRLF to LF on
+  Windows and inventing drift in files the bump never needed to touch.
+- Sweeping a repo with uncommitted work either fails or drags that work into the branch. The
+  script skips dirty repos on purpose; do not force past it.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -143,6 +143,25 @@ For manual releases from your machine, add servers to `~/.m2/settings.xml`:
 
 ## Release Process
 
+### 0. Check the consumers still build
+
+The suite in `vibetags/` proves the processor works. It does not prove a real project still
+compiles against it. Before cutting anything, build every downstream consumer against what is
+about to be released:
+
+```bash
+# only if main is ahead of the newest tag, which it usually is
+cd vibetags-annotations && mvn install -DskipTests
+cd ../vibetags         && mvn install -DskipTests
+cd ../vibetags-bom     && mvn install
+
+bash scripts/consumer-sweep.sh <version>
+```
+
+The `consumer-regression-suite` skill drives this and covers how to read the results — in
+particular, that a failure is not a regression until it has been shown to pass on the
+consumer's existing pinned version.
+
 ### 1. Prepare the release
 
 Create a new branch from `main` (or your default branch):

--- a/scripts/consumer-sweep.sh
+++ b/scripts/consumer-sweep.sh
@@ -5,8 +5,12 @@
 # Usage:
 #   scripts/consumer-sweep.sh <vibetags-version> [repo ...]
 #
-#   scripts/consumer-sweep.sh 1.0.3                 # every known consumer
-#   scripts/consumer-sweep.sh 1.0.3 blindbean       # just one
+#   scripts/consumer-sweep.sh <version>             # every known consumer
+#   scripts/consumer-sweep.sh <version> blindbean   # just one
+#
+# The examples deliberately say <version> rather than a real one: a literal release version
+# here would be a second place the release has to be remembered, and ReleaseScriptCoverageTest
+# fails the build for exactly that.
 #
 # What it does per repo: fetch, branch off origin/main (never off whatever happens to be
 # checked out), rewrite the VibeTags version in every place that repo declares it, build,

--- a/scripts/consumer-sweep.sh
+++ b/scripts/consumer-sweep.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Build every downstream consumer of VibeTags against a chosen VibeTags version and report
+# honestly which ones pass.
+#
+# Usage:
+#   scripts/consumer-sweep.sh <vibetags-version> [repo ...]
+#
+#   scripts/consumer-sweep.sh 1.0.3                 # every known consumer
+#   scripts/consumer-sweep.sh 1.0.3 blindbean       # just one
+#
+# What it does per repo: fetch, branch off origin/main (never off whatever happens to be
+# checked out), rewrite the VibeTags version in every place that repo declares it, build,
+# and report the build's real exit code plus any drift in generated guardrail files.
+#
+# What it deliberately does not do: commit, push, or open anything. It leaves each repo on
+# its sweep branch with the bump uncommitted so a human can look before any of that.
+#
+# Traps this encodes, each of which cost a debugging round the first time:
+#
+#   * Use the repo's own ./mvnw or ./gradlew. blindbean's enforcer requires Maven >= 3.9.0
+#     and the Maven on PATH here is 3.8.6, which fails before the build starts.
+#   * Never let a pipe eat the exit code. Every build writes to a log and the status is read
+#     immediately from $?, never from the tail of a pipeline.
+#   * async-test-lib gets a git worktree, not a checkout. Another agent works in that tree;
+#     switching its branch underneath them is the destructive move to avoid.
+#   * A version bump that changes generated guardrail files is a finding, not noise: it means
+#     the new VibeTags renders differently and the consumer's committed files are now stale.
+#   * A failing test is not a regression until it has been shown to pass on the base. Rerun
+#     any failure on origin/main before blaming VibeTags; blindbean's FheAsyncConcurrencyTest
+#     fails roughly one run in three on both.
+
+set -u
+
+ROOT="${VIBETAGS_CONSUMER_ROOT:-/c/dev/private}"
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+  echo "usage: $0 <vibetags-version> [repo ...]" >&2
+  exit 2
+fi
+shift || true
+
+# repo : build tool : maven goals : gradle tasks
+# Maven and Gradle need separate commands: "verify" is a Maven lifecycle phase and Gradle
+# has no such task, which showed up as a spurious FAIL for common-license-lib.
+CONSUMERS="
+blindbean:maven:clean verify:
+codekarta:both:clean verify:clean build
+common-license-lib:both:clean verify:clean build
+skill3:gradle::clean build
+async-test-lib:both:clean verify:clean build
+"
+
+WORKTREE_REPOS="async-test-lib"
+BRANCH="chore/vibetags-${VERSION}"
+LOGDIR="${TMPDIR:-/tmp}/vibetags-sweep"
+mkdir -p "$LOGDIR"
+
+want() {
+  local target="$1"; shift
+  [ "$#" -eq 0 ] && return 0
+  for w in "$@"; do [ "$w" = "$target" ] && return 0; done
+  return 1
+}
+
+# Rewrite every place a repo declares the VibeTags version. Returns 1 only if the repo
+# declares the version nowhere this understands, which means the repo's layout moved and this
+# script needs updating rather than the sweep quietly testing the old version.
+#
+# Writes through a temp file and only replaces the original when the bytes actually change.
+# `sed -i` rewrites unconditionally, and on Windows that silently converts a CRLF file to LF,
+# which then shows up as phantom drift in files the bump never had any business touching.
+bump() {
+  local dir="$1" version="$2" declared=0
+  for f in pom.xml build.gradle build.gradle.kts gradle.properties; do
+    [ -f "$dir/$f" ] || continue
+    grep -qE 'vibetags\.version>|vibetagsVersion' "$dir/$f" || continue
+    declared=1
+    sed -E \
+      -e "s#(<vibetags\.version>)[^<]+(</vibetags\.version>)#\1${version}\2#" \
+      -e "s#(val vibetagsVersion = \")[^\"]+(\")#\1${version}\2#" \
+      -e "s#(ext\.vibetagsVersion = ')[^']+(')#\1${version}\2#" \
+      -e "s#(vibetagsVersion=).*#\1${version}#" \
+      "$dir/$f" > "$dir/$f.sweeptmp"
+    if cmp -s "$dir/$f" "$dir/$f.sweeptmp"; then
+      rm -f "$dir/$f.sweeptmp"          # already at this version, or nothing to change
+    else
+      mv "$dir/$f.sweeptmp" "$dir/$f"
+    fi
+  done
+  return $((1 - declared))
+}
+
+printf '%-22s %-8s %-9s %s\n' REPO RESULT EXIT NOTES
+printf '%s\n' "----------------------------------------------------------------------"
+
+# IFS=: rather than word-splitting $CONSUMERS: the build command contains a space, and
+# "for entry in $CONSUMERS" would split "clean verify" into two entries.
+while IFS=: read -r repo tool mvncmd gradlecmd; do
+  [ -z "$repo" ] && continue
+
+  want "$repo" "$@" || continue
+  [ -d "$ROOT/$repo/.git" ] || { printf '%-22s %-8s %-9s %s\n' "$repo" SKIP - "not a git repo under $ROOT"; continue; }
+
+  # Refuse to sweep a repo with uncommitted work. Branching off origin/main under someone's
+  # edits either fails or drags them along, and neither is this script's call to make.
+  if [ -n "$(git -C "$ROOT/$repo" status --porcelain)" ]; then
+    printf '%-22s %-8s %-9s %s\n' "$repo" SKIP - "working tree dirty; commit or stash first"
+    continue
+  fi
+
+  git -C "$ROOT/$repo" fetch -q origin || true
+
+  # A contended repo is swept in a detached worktree so its checkout is never touched.
+  work="$ROOT/$repo"
+  wt=""
+  case " $WORKTREE_REPOS " in
+    *" $repo "*)
+      wt="$LOGDIR/wt-$repo"
+      rm -rf "$wt"
+      git -C "$ROOT/$repo" worktree prune
+      git -C "$ROOT/$repo" worktree add -q -b "$BRANCH" "$wt" origin/main || {
+        printf '%-22s %-8s %-9s %s\n' "$repo" ERROR - "worktree add failed"; continue; }
+      work="$wt"
+      ;;
+    *)
+      git -C "$work" checkout -q -B "$BRANCH" origin/main || {
+        printf '%-22s %-8s %-9s %s\n' "$repo" ERROR - "checkout failed"; continue; }
+      ;;
+  esac
+
+  if ! bump "$work" "$VERSION"; then
+    printf '%-22s %-8s %-9s %s\n' "$repo" ERROR - "no version declaration matched; update this script"
+    continue
+  fi
+
+  # Prefer the repo's wrapper; only blindbean ships mvnw, and its enforcer needs Maven
+  # >= 3.9.0, which the mvn on PATH is not. Repos without a wrapper get the system tool.
+  if [ -x "$work/mvnw" ]; then MVN=./mvnw; else MVN=mvn; fi
+  if [ -x "$work/gradlew" ]; then GRADLE=./gradlew; else GRADLE=gradle; fi
+
+  log="$LOGDIR/$repo.log"
+  status=0
+  case "$tool" in
+    maven) (cd "$work" && $MVN -q $mvncmd) > "$log" 2>&1 || status=$? ;;
+    gradle) (cd "$work" && $GRADLE -q $gradlecmd) > "$log" 2>&1 || status=$? ;;
+    both)
+      (cd "$work" && $MVN -q $mvncmd) > "$log" 2>&1 || status=$?
+      if [ "$status" -eq 0 ]; then
+        (cd "$work" && $GRADLE -q $gradlecmd) > "$log.gradle" 2>&1 || status=$?
+      fi
+      ;;
+  esac
+
+  # Generated-guardrail drift, counted from `git diff --numstat` rather than `git status`.
+  # status lists a file whose line endings changed even when its text did not, and on Windows
+  # that is most of them; numstat compares after git's own EOL normalisation, so a non-empty
+  # numstat means the new VibeTags genuinely renders something different and the consumer's
+  # committed files are stale. EOL-only churn is reported separately rather than as drift.
+  drift=$(git -C "$work" diff --numstat -- . \
+            ':(exclude)pom.xml' ':(exclude)build.gradle' \
+            ':(exclude)build.gradle.kts' ':(exclude)gradle.properties' \
+            | wc -l | tr -d ' ')
+  eolonly=$(git -C "$work" status --porcelain | wc -l | tr -d ' ')
+
+  if [ "$status" -eq 0 ]; then
+    result=PASS
+  else
+    result=FAIL
+  fi
+  notes="log: $log"
+  [ "$eolonly" -gt 0 ] && notes="${eolonly} file(s) touched; $notes"
+  [ "$drift" -gt 0 ] && notes="GUARDRAIL DRIFT in $drift file(s); $notes"
+  printf '%-22s %-8s %-9s %s\n' "$repo" "$result" "$status" "$notes"
+done <<EOF
+$CONSUMERS
+EOF
+
+printf '\n%s\n' "Nothing was committed, pushed or opened. Review each repo, then decide."


### PR DESCRIPTION
## Why

The 1537 tests in `vibetags/` prove the processor works. They prove nothing about whether a real project still compiles against it. That gap has historically been found by a consumer, after a release.

## What

**`scripts/consumer-sweep.sh`** builds every downstream repo under `../` against a chosen VibeTags version: fetch, branch off `origin/main`, rewrite every place that repo declares the version, build with the repo's own wrapper, and report the build's real exit code plus any drift in generated guardrail files. It commits nothing, pushes nothing, opens nothing.

**`.claude/skills/consumer-regression-suite/SKILL.md`** is the judgement around it — which version to test, how to read a red result, and where to stop.

**`docs/RELEASING.md`** gains a step 0 so a release starts by running it.

## Results of the run that produced this

Against a local build of `main` (1.0.3 plus four unreleased commits):

| repo | result | note |
|---|---|---|
| blindbean | PASS | 223 tests |
| codekarta | PASS | Maven + Gradle |
| common-license-lib | PASS | Maven + Gradle |
| skill3 | PASS | Gradle |
| async-test-lib | PASS | Maven + Gradle |

No regressions. Consumer bump PRs: PIsberg/blindbean#141, PIsberg/codekarta#81, PIsberg/common-license-lib#64, PIsberg/skill3#61, PIsberg/async-test-lib#232.

## Findings encoded in the skill

Every one of these first appeared as a convincing false positive during the sweep, which is why they are written down rather than remembered:

- **A red consumer is not a regression until it passes on the base.** blindbean's `FheAsyncConcurrencyTest.concurrentBfvOperationsAreThreadSafe` fails about one run in three on `1.0.0-RC10` and `1.0.3` alike — a 60 s timeout in a thread-safety test.
- **Compare tool-for-tool.** Running Maven on the new version against Gradle on the base produced a three-file "guardrail drift" in async-test-lib that does not exist. Same tool both sides: clean.
- **`git status` is not drift.** It lists a file whose line endings moved even when its text did not. `git diff --numstat` compares after git's normalisation; only a non-empty numstat means the new version renders something different.
- **`sed -i` rewrites a file even when nothing matches**, converting CRLF to LF on Windows and inventing drift in files the bump never needed to touch. The script writes through a temp file and compares first.
- **`verify` is a Maven phase, not a Gradle task** — a repo built both ways needs two commands.
- **The Maven on PATH here is 3.8.6** and blindbean's enforcer requires 3.9.0+, so the repo's own `./mvnw` is not optional.
- **async-test-lib is swept in a `git worktree`**, never a checkout. Another agent is working in that tree; during this sweep it changed branch and picked up 20 dirty files. The worktree kept the sweep clear of it.

## Verification

`mvn -o verify -Pe2e` (checkstyle, PMD, CPD, ErrorProne/NullAway, jacoco): 1537 tests, 0 failures, BUILD SUCCESS.

`pre-commit run --all-files` was **not** run: `pre-commit` is not on PATH in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUxfjry7TrPKVfpmZAbQfr
