### PR TITLE
chore: prepare release v1.0.4

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.0.3
+version: 1.0.4
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.3'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.3'
+compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.4'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.4'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)
@@ -1066,7 +1066,7 @@ Use on: **class, method, field**
 @AIKeepInSync(mirrors = {"pom.xml:<version>", "README.md badge", "docs/CHANGELOG.md"},
               reason = "The release version is asserted in three places and drifts silently",
               enforcedBy = "ProjectFactsConsistencyTest")
-public static final String VERSION = "1.0.3";
+public static final String VERSION = "1.0.4";
 ```
 
 The element is free to change — the failure mode is a *partial* change that desyncs a mirror no compiler checks. `@AIContract` freezes one signature so it cannot change at all; neither it nor `@AISchemaSafe` expresses "edit A ⇒ you must also edit B". Mirrors routinely point outside the compilation unit, so VibeTags can only *name* them, not verify them.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.3</version>
+            <version>1.0.4</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.3</version>
+                        <version>1.0.4</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -117,8 +117,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.3')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.3')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.4')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.4')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -434,7 +434,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.3</version>
+            <version>1.0.4</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -459,7 +459,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.3</version>
+                        <version>1.0.4</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -475,8 +475,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.3')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.3')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.4')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.4')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -490,15 +490,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.3'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.3'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.4'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.4'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-08-08
+
 ### Fixed
 - **`.vibetags-locks` recorded absolute source paths, so a committed report differed on every
   machine.** The `file` field carried whatever directory the repository happened to sit in
@@ -2094,7 +2096,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.3...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.4...HEAD
+[1.0.4]: https://github.com/PIsberg/vibetags/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/PIsberg/vibetags/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/PIsberg/vibetags/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/PIsberg/vibetags/compare/v1.0.0...v1.0.1

--- a/example-all-tiers/pom.xml
+++ b/example-all-tiers/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.0.3</vibetags.bom.version>
+    <vibetags.bom.version>1.0.4</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/example-multimodule-indexed/pom.xml
+++ b/example-multimodule-indexed/pom.xml
@@ -37,7 +37,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.0.3</vibetags.bom.version>
+    <vibetags.bom.version>1.0.4</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/example-multimodule/pom.xml
+++ b/example-multimodule/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.0.3</vibetags.bom.version>
+    <vibetags.bom.version>1.0.4</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.3')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.3')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.4')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.4')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.0.3</vibetags.bom.version>
+        <vibetags.bom.version>1.0.4</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.0.3</vibetags.bom.version>
+        <vibetags.bom.version>1.0.4</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.3'
+version = '1.0.4'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.0.3'
+            version = '1.0.4'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -39,12 +39,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.0.3&lt;/version&gt;
+                &lt;version&gt;1.0.4&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.3'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.3'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.4'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.4'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -36,7 +36,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.0.3&lt;/version&gt;
+                        &lt;version&gt;1.0.4&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.3')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.3')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.4')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.4')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.0.3</revision>
+        <revision>1.0.4</revision>
 
         <!-- release, not source/target: on a JDK newer than 21 (CI builds 21, 25 and 26)
              source/target compiles against the *running* JDK's API and javac warns that the

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.3'
+version = '1.0.4'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.0.3'
+            version = '1.0.4'
             from components.java
 
             pom {
@@ -78,7 +78,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.0.3'
+    api 'se.deversity.vibetags:vibetags-annotations:1.0.4'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.1'


### PR DESCRIPTION
Prepares the 1.0.4 release. Patch: four fixes, no new or changed API.

## What ships

- **`.vibetags-locks` recorded absolute source paths**, so a committed report differed on every machine. Paths under the VibeTags root are now relative to it; anything the root cannot claim is still reported verbatim. Also unblocks the `git status --porcelain` CI gate on `example-multimodule/`.
- **A cold reactor build deleted every other module's scoped rule files.** On a fresh clone, `mvn -B -pl core clean compile` removed 256 tracked rule files and exited 0. A reactor module round now sweeps nothing at the shared root. Issue #383.
- **Three Error Prone `VoidUsed` warnings** in `MethodBodyGuardrailScanner`, which falsified the zero-warning claim in `vibetags/pom.xml`.
- **The `-source 21` system-modules warning** on every Maven module built with a newer JDK.

Both correctness fixes carry a regression test written red first.

## Not in the changelog, deliberately

#385 (docs), #387 (test-only javac file-manager reuse), #388 (test dependency bump) and #389 (consumer-regression skill) changed nothing a consumer can observe, so they are not written up. Say the word if you want them listed.

## Version bump

`scripts/set-version.sh 1.0.4` moved `<revision>` plus the files that cannot inherit it: both `build.gradle` files, the `<description>` snippets, and the standalone example and demo poms. `load-tests/pom.xml` stays pinned so benchmarks can compare across versions.

The release skill still says the script leaves consumers alone and lists eight files to hand-edit. It no longer does — it updated `example/`, `example-multimodule/`, `example-all-tiers/`, `tools/demo/`, `README.md` and the usage skill itself. Worth correcting in a follow-up so the next release does not hand-edit files that are already right.

## Verification

Built in release order, all four green:

```
vibetags-annotations install  -> BUILD SUCCESS
vibetags       clean install  -> BUILD SUCCESS   957 tests, 0 failures, 0 errors, 0 skipped
vibetags-bom          install -> BUILD SUCCESS
example        clean compile  -> BUILD SUCCESS   (consumes the freshly installed BOM)
```

`BuildVersionParityTest` passes — that is the test that fails when a Gradle file or example pom is left behind by the bump.

`pre-commit run --all-files` could not complete locally: the checkstyle hook builds a Docker image and the daemon is down. Checkstyle, PMD and SpotBugs all ran inside the Maven build instead. gitleaks, end-of-file-fixer and trailing-whitespace passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YvoZUP3utfST8rgRocsjS
