### PR TITLE
test: cover the file-recovery and element-transition halves of the lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,8 @@ cd ../vibetags         && mvn clean install     # or: gradle clean build publish
 cd ../vibetags-bom     && mvn install           # Maven only
 
 # Tests (from vibetags/)
-mvn test                                   # fast tier: 87 classes, 957 tests. Skips @Tag("e2e").
-mvn test -Pe2e                             # everything: 140 classes, 1535 tests. What CI runs.
+mvn test                                   # fast tier: 88 classes, 957 tests. Skips @Tag("e2e").
+mvn test -Pe2e                             # everything: 142 classes, 1546 tests. What CI runs.
 mvn test -Dtest=AnnotationProcessorEndToEndTest   # -Dtest overrides the tag filter
 mvn test -Dtest=AIGuardrailProcessorUnitTest#methodName
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -8,15 +8,16 @@ Index of every test class in `vibetags/src/test` and what it covers — use this
 everything, and that is what CI runs on all three legs that execute tests (`build-maven`,
 `cross-platform`, `build-gradle`). Gradle mirrors both: `gradlew test` and `gradlew test -Pe2e`.
 
-Measured on a 16-core Windows machine on 2026-08-06, warm compile, `-Dmaven.pmd.skip -Dspotbugs.skip`:
+Measured on a 16-core Windows machine on 2026-08-10, warm compile, `-Dmaven.pmd.skip -Dspotbugs.skip`:
 
 | Command | Classes | Tests | Wall clock |
 |---|---|---|---|
-| `mvn test` | 80 | 910 | 35s |
-| `mvn test -Pe2e` | 132 | 1486 | 61s |
+| `mvn test` | 88 | 957 | 41s |
+| `mvn test -Pe2e` | 142 | 1546 | 61s |
 
-Roughly 10s of either figure is compile, Error Prone and JaCoCo rather than tests — `mvn test
--DskipTests` costs 10s on the same machine — so the tests themselves go from ~51s to ~25s.
+Compile, Error Prone and JaCoCo account for the first few seconds of either figure rather than
+tests — `mvn test -DskipTests` costs 4.6s fully warm on the same machine — so the tests themselves
+go from ~36s to ~56s.
 
 **What is tagged, and why.** The 52 classes that took over 5s in the full-suite baseline of
 2026-08-06: 599.66s of the 704.15s the suite spent. The rule is cost, not category.
@@ -74,6 +75,8 @@ stop excluding the same one.
 | `YamlMergeShapeContractTest` | Each `PlatformRenderer.mergeShape()` still describes what its renderer writes, and no generated `.yaml` ships without one |
 | `MultiModuleWholeFileMergeTest` | The marker-free JSON/TOML outputs survive a reactor: sidecar bodies exist so the file is allowed to refresh at all, every module's guardrails are in the merged document, `.mentatconfig.json` stays valid JSON, and a new marker-free service whose content varies without a declared merge fails the build (#265) |
 | `GuardrailLifecycleEndToEndTest` | The second compile: editing an annotation's value replaces the old text everywhere, removing one drops it from the merged root and the whole-file JSON/TOML, and deleting a generated file opts that platform out permanently (and restoring it opts back in). Also pins the documented limitation that emptying a module of *every* annotation leaves its last contribution until its sidecar is deleted |
+| `GuardrailFileRecoveryEndToEndTest` | The generated file is still there but no longer looks the way VibeTags left it: the marker block deleted by a merge-conflict resolution, a start marker with no end from a half-applied patch, a file truncated to empty, an edit made *inside* the block, and a `.vibetags-cache` lost to `git clean` (output must stay byte-identical without it). As much a test of `WriteCache.allCachedFilesStable()` as of the writer — an unchanged annotation set is exactly when the short-circuit would skip past the damage |
+| `AnnotationTransitionEndToEndTest` | The element survives and what is true about it changes: the annotation *type* swapped on the same FQN (the old bucket must go, or the file states two contradictory things about one class), a class moved between modules in a reactor (the losing module's sidecar must drop it — the failure here is a duplicate, not an absence), a role renamed in `.vibetags-roles`, and the roles config deleted entirely (per-class fallback, old role files retired) |
 | *(CI step)* `example-all-tiers` | Not a JUnit class: the workflow builds the all-tiers example and asserts the split — six safety buckets inline at Tier 1 and no verbose bucket, a Tier-1 pointer naming both lower tiers per module, Tier-2 files that do not leak each other, role-grouped Tier-3 files with `paths:` front-matter, and a parameter-level rule |
 | `SourceSetIsolationEndToEndTest` | `compile` and `test-compile` are separate rounds over the same module: neither erases the other's guardrails or rule files, two source sets still render as one region, and a module's own aggregate merges across them (#330) |
 | `MultiModuleGranularRoleMergeTest` | A role matched in several modules resolves to one shared rule file: every module's guardrails survive, a one-module rebuild leaves the file byte-identical, reactor order does not change it, check mode agrees with generation, unrouted classes keep their per-class file, and the same merge covers two source sets of one module and a module's own nested rules (#365) |

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/AnnotationTransitionEndToEndTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/AnnotationTransitionEndToEndTest.java
@@ -1,0 +1,252 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Transitions the existing lifecycle tests do not reach: the annotated element survives, but what
+ * is true about it changes.
+ *
+ * <p>{@code RefactorAnnotatedElementTest} renames and deletes elements. {@code
+ * GuardrailLifecycleEndToEndTest} edits an attribute and removes an annotation. Between those two
+ * sit the transitions that keep the element and move it to a different <em>bucket</em>, a different
+ * <em>module</em>, or a different <em>rule file</em> — and each one is a two-writer problem, where
+ * the new location is written by a code path that has no reason to know about the old one.
+ *
+ * <ul>
+ *   <li><b>Swapping the annotation type.</b> The element's FQN never changes, so nothing about it
+ *       looks stale; only the bucket it renders into does. A cleanup keyed on the element rather
+ *       than on the bucket leaves the old rule in place, and the file then states two contradictory
+ *       things about the same class.</li>
+ *   <li><b>Moving a class between modules.</b> The merged root is assembled from per-module
+ *       sidecars, so a moved class is added by one module and has to be dropped by another — the
+ *       exact shape of #365 and #383, and the one where the failure is a duplicate rather than a
+ *       missing entry.</li>
+ *   <li><b>Editing {@code .vibetags-roles}.</b> Renaming a role renames its rule file. The old file
+ *       is now an orphan that no annotation points at, and the granular cleanup deletes by stem —
+ *       so whether it goes depends on machinery that a role rename does not obviously touch.</li>
+ * </ul>
+ */
+@Tag("e2e")
+class AnnotationTransitionEndToEndTest {
+
+    @AfterEach
+    void releaseLogHandle() {
+        VibeTagsLogger.shutdown();
+    }
+
+    // -----------------------------------------------------------------------
+    // The element keeps its name and changes its bucket
+    // -----------------------------------------------------------------------
+
+    @Test
+    void swappingTheAnnotationType_retiresTheOldBucket(@TempDir Path dir) throws Exception {
+        ProcessorTestHarness first = new ProcessorTestHarness(dir, false);
+        first.touchOptIn("CLAUDE.md");
+        first.touchOptIn(".cursorrules");
+        first.addSource("com.example.Ledger",
+            "package com.example;\n"
+                + "import se.deversity.vibetags.annotations.AIContext;\n"
+                + "@AIContext(focus = \"double-entry bookkeeping\", avoids = \"floating point\")\n"
+                + "public class Ledger {}\n");
+        first.compile();
+        assertTrue(first.readFile("CLAUDE.md").contains("double-entry bookkeeping"),
+            "precondition: the first annotation must be generated");
+
+        ProcessorTestHarness.awaitFilesystemTick(dir);
+        VibeTagsLogger.shutdown();
+
+        // Same class, same FQN, different annotation: the guidance becomes a lock.
+        ProcessorTestHarness second = new ProcessorTestHarness(dir, false);
+        second.touchOptIn("CLAUDE.md");
+        second.touchOptIn(".cursorrules");
+        second.addSource("com.example.Ledger",
+            "package com.example;\n"
+                + "import se.deversity.vibetags.annotations.AILocked;\n"
+                + "@AILocked(reason = \"Frozen pending the ledger rewrite\")\n"
+                + "public class Ledger {}\n");
+        second.compile();
+
+        for (String file : new String[]{"CLAUDE.md", ".cursorrules"}) {
+            String content = second.readFile(file);
+            assertTrue(content.contains("Frozen pending the ledger rewrite"),
+                file + " must carry the new annotation's rule");
+            assertFalse(content.contains("double-entry bookkeeping"),
+                file + " still carries the superseded annotation. The element never changed name, "
+                    + "so a cleanup keyed on the element sees nothing to remove — and the file now "
+                    + "tells an agent both to work on the class and not to touch it:\n" + content);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // The element keeps its name and changes module
+    // -----------------------------------------------------------------------
+
+    /**
+     * A class moves from one module to another in a reactor. Both modules recompile, as they would
+     * in the build that follows the move. The merged root has to end up with the guardrail once:
+     * the losing module's sidecar drops it, the gaining module's adds it.
+     *
+     * <p>The losing module keeps a second annotated class on purpose. A module emptied of
+     * <em>every</em> annotation is the documented no-op case pinned by
+     * {@code GuardrailLifecycleEndToEndTest} — testing the move through it would assert the known
+     * limitation instead of the merge.
+     */
+    @Test
+    void movingAnAnnotatedClassBetweenModules_leavesNoDuplicate(@TempDir Path root) throws Exception {
+        setUpReactor(root);
+
+        compileModule(root, "module-a",
+            source("module-a", "com.example.a.Engine", locked("com.example.a", "Engine", "Engine internals")),
+            source("module-a", "com.example.a.Keeper", locked("com.example.a", "Keeper", "Stays put")));
+        compileModule(root, "module-b",
+            source("module-b", "com.example.b.Cli", locked("com.example.b", "Cli", "CLI entry point")));
+
+        String before = Files.readString(root.resolve("CLAUDE.md"), StandardCharsets.UTF_8);
+        assertEquals(1, count(before, "com.example.a.Engine"),
+            "precondition: the class is in module-a exactly once:\n" + before);
+
+        ProcessorTestHarness.awaitFilesystemTick(root);
+        VibeTagsLogger.shutdown();
+
+        // The refactor: Engine moves to module-b, package and all. Both modules rebuild.
+        Files.delete(root.resolve("module-a/src/main/java/com/example/a/Engine.java"));
+        compileModule(root, "module-a",
+            source("module-a", "com.example.a.Keeper", locked("com.example.a", "Keeper", "Stays put")));
+        compileModule(root, "module-b",
+            source("module-b", "com.example.b.Cli", locked("com.example.b", "Cli", "CLI entry point")),
+            source("module-b", "com.example.b.Engine", locked("com.example.b", "Engine", "Engine internals")));
+
+        String after = Files.readString(root.resolve("CLAUDE.md"), StandardCharsets.UTF_8);
+        assertEquals(1, count(after, "Engine internals"),
+            "the moved guardrail must appear once. Two copies means the losing module's sidecar "
+                + "still claims a class it no longer compiles:\n" + after);
+        assertTrue(after.contains("com.example.b.Engine"), "the gaining module's FQN must be the live one");
+        assertFalse(after.contains("com.example.a.Engine"),
+            "the old FQN must be gone from the merged root:\n" + after);
+        assertTrue(after.contains("Stays put") && after.contains("CLI entry point"),
+            "neither module's remaining guardrails may be disturbed by the move");
+    }
+
+    // -----------------------------------------------------------------------
+    // The element keeps its name and changes rule file
+    // -----------------------------------------------------------------------
+
+    @Test
+    void renamingARoleInTheConfig_retiresTheOldRoleFile(@TempDir Path dir) throws Exception {
+        ProcessorTestHarness first = granular(dir, "api-endpoints = **/*Controller.java\n");
+        first.addSource("com.example.web.OrderController", controller());
+        first.compile();
+        assertTrue(first.fileExists(".cursor/rules/api-endpoints.mdc"),
+            "precondition: the role file is generated under its first name");
+
+        ProcessorTestHarness.awaitFilesystemTick(dir);
+        VibeTagsLogger.shutdown();
+
+        // The team renames the role. Same glob, same class, different file name.
+        ProcessorTestHarness second = granular(dir, "controllers = **/*Controller.java\n");
+        second.addSource("com.example.web.OrderController", controller());
+        second.compile();
+
+        assertTrue(second.fileExists(".cursor/rules/controllers.mdc"),
+            "the renamed role must produce its rule file");
+        assertTrue(second.readFile(".cursor/rules/controllers.mdc").contains("com.example.web.OrderController"),
+            "and must carry the class that routes to it");
+        assertFalse(second.fileExists(".cursor/rules/api-endpoints.mdc"),
+            "the old role file is an orphan no annotation points at any more. Left behind, the "
+                + "agent loads two rule files for the same class and the stale one never expires.");
+    }
+
+    @Test
+    void deletingTheRolesConfig_fallsBackToPerClassFilesAndRetiresTheRoleFile(@TempDir Path dir)
+            throws Exception {
+        ProcessorTestHarness first = granular(dir, "api-endpoints = **/*Controller.java\n");
+        first.addSource("com.example.web.OrderController", controller());
+        first.compile();
+        assertTrue(first.fileExists(".cursor/rules/api-endpoints.mdc"), "precondition: role grouping is on");
+
+        Files.delete(dir.resolve(".vibetags-roles"));
+        ProcessorTestHarness.awaitFilesystemTick(dir);
+        VibeTagsLogger.shutdown();
+
+        ProcessorTestHarness second = new ProcessorTestHarness(dir, false);
+        second.touchOptIn(".cursor/rules/.vibetags");
+        second.addSource("com.example.web.OrderController", controller());
+        second.compile();
+
+        assertTrue(second.fileExists(".cursor/rules/com-example-web-OrderController.mdc"),
+            "with no roles config the class falls back to its per-class rule file");
+        assertFalse(second.fileExists(".cursor/rules/api-endpoints.mdc"),
+            "turning role grouping off must retire the role files it produced, or the class is "
+                + "described twice — once per class and once by a role that no longer exists");
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static ProcessorTestHarness granular(Path dir, String rolesContent) throws IOException {
+        ProcessorTestHarness h = new ProcessorTestHarness(dir, false);
+        h.touchOptIn(".cursor/rules/.vibetags");
+        Files.writeString(dir.resolve(".vibetags-roles"), rolesContent, StandardCharsets.UTF_8);
+        return h;
+    }
+
+    private static String controller() {
+        return "package com.example.web;\n"
+            + "import se.deversity.vibetags.annotations.AILocked;\n"
+            + "@AILocked(reason = \"auth surface\")\n"
+            + "public class OrderController {}\n";
+    }
+
+    private static String locked(String pkg, String type, String reason) {
+        return "package " + pkg + ";\n"
+            + "import se.deversity.vibetags.annotations.AILocked;\n"
+            + "@AILocked(reason = \"" + reason + "\")\n"
+            + "public class " + type + " {}\n";
+    }
+
+    /** A module-relative source path paired with its content, for {@link #compileModule}. */
+    private record Src(String relativePath, String content) { }
+
+    private static Src source(String module, String fqn, String content) {
+        return new Src(module + "/src/main/java/" + fqn.replace('.', '/') + ".java", content);
+    }
+
+    private static void setUpReactor(Path root) throws IOException {
+        Files.createDirectories(root.resolve("module-a"));
+        Files.createDirectories(root.resolve("module-b"));
+        Files.createFile(root.resolve("CLAUDE.md"));
+    }
+
+    /** One module's compile into the shared reactor root, as a reactor pass would do it. */
+    private static void compileModule(Path root, String module, Src... sources) throws IOException {
+        ProcessorTestHarness harness = new ProcessorTestHarness(root, false);
+        Files.writeString(root.resolve(module).resolve("pom.xml"),
+            "<project><artifactId>" + module + "</artifactId></project>", StandardCharsets.UTF_8);
+        for (Src src : sources) {
+            harness.writeSourceFile(src.relativePath(), src.content());
+        }
+        harness.compile();
+        VibeTagsLogger.shutdown();
+    }
+
+    private static int count(String haystack, String needle) {
+        int n = 0;
+        for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) {
+            n++;
+        }
+        return n;
+    }
+}

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/GuardrailFileRecoveryEndToEndTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/GuardrailFileRecoveryEndToEndTest.java
@@ -1,0 +1,220 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import se.deversity.vibetags.processor.internal.GuardrailFileWriter;
+
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The other half of the file lifecycle: what happens when a generated file is still there but no
+ * longer looks the way VibeTags left it.
+ *
+ * <p>{@code GuardrailLifecycleEndToEndTest} covers the file being <em>deleted</em> — the opt-out.
+ * {@code WriteCacheProcessorIntegrationTest} covers an edit <em>outside</em> the markers being
+ * preserved. Neither covers the cases a real repository produces constantly: a merge conflict
+ * resolved by deleting the marker block, a half-applied patch that left a start marker with no end,
+ * a file truncated by a bad script, an edit made <em>inside</em> the block by someone who did not
+ * know it was generated, and a {@code .vibetags-cache} lost to {@code git clean}.
+ *
+ * <p>Each one is the same shape of failure as every multi-module defect so far: the build stays
+ * green, the file still exists, and the guardrails are quietly wrong. The cache short-circuit makes
+ * it worse — a run that decides nothing changed never looks at the damage, so these are tests of
+ * {@code WriteCache.allCachedFilesStable()} as much as of the writer.
+ */
+@Tag("e2e")
+class GuardrailFileRecoveryEndToEndTest {
+
+    private static final String REASON = "Reconciliation is load-bearing";
+
+    @AfterEach
+    void releaseLogHandle() {
+        VibeTagsLogger.shutdown();
+    }
+
+    /**
+     * The merge-conflict case: a human resolves a conflict in {@code CLAUDE.md} by deleting the
+     * whole marker block. The file still exists, so the platform is still opted in, and the block
+     * has to come back — without taking the hand-written half of the file with it.
+     */
+    @Test
+    void deletingTheMarkerBlock_reappendsIt_andKeepsTheHandWrittenContent(@TempDir Path dir) throws Exception {
+        compileOnce(dir);
+
+        Files.writeString(dir.resolve("CLAUDE.md"),
+            "# My Project\n\nHand-written onboarding notes that predate VibeTags.\n",
+            StandardCharsets.UTF_8);
+        settle(dir);
+
+        compileOnce(dir);
+
+        String after = Files.readString(dir.resolve("CLAUDE.md"), StandardCharsets.UTF_8);
+        assertTrue(after.contains("Hand-written onboarding notes that predate VibeTags."),
+            "deleting the marker block must not cost the human half of the file:\n" + after);
+        assertEquals(1, count(after, GuardrailFileWriter.MARKER_START_MD),
+            "exactly one marker block must be re-appended, not zero and not two:\n" + after);
+        assertTrue(after.contains(REASON),
+            "the re-appended block must carry the current guardrails, not an empty shell:\n" + after);
+    }
+
+    /**
+     * The half-applied-patch case: a start marker with no end. The writer documents this as
+     * "preserve the content before the start marker" and warns — an unrepaired file would keep the
+     * stale generated text forever, because nothing after a missing end marker can be replaced.
+     */
+    @Test
+    void aStartMarkerWithNoEndMarker_isRepairedAndWarnedAbout(@TempDir Path dir) throws Exception {
+        compileOnce(dir);
+
+        Files.writeString(dir.resolve("CLAUDE.md"),
+            "# My Project\n\nHand-written preamble.\n\n"
+                + GuardrailFileWriter.MARKER_START_MD + "\n"
+                + "Guardrails from three releases ago that nothing can replace.\n",
+            StandardCharsets.UTF_8);
+        settle(dir);
+
+        List<Diagnostic<? extends JavaFileObject>> diagnostics = compileReturningDiagnostics(dir);
+
+        String after = Files.readString(dir.resolve("CLAUDE.md"), StandardCharsets.UTF_8);
+        assertTrue(after.contains("Hand-written preamble."),
+            "content before the orphaned start marker is hand-authored and must survive:\n" + after);
+        assertFalse(after.contains("Guardrails from three releases ago"),
+            "content after an orphaned start marker is generated output that lost its end marker; "
+                + "leaving it in place is how a stale guardrail outlives the annotation:\n" + after);
+        assertEquals(1, count(after, GuardrailFileWriter.MARKER_START_MD),
+            "the repair must leave exactly one start marker:\n" + after);
+        assertEquals(1, count(after, GuardrailFileWriter.MARKER_END_MD),
+            "the repair must restore the missing end marker:\n" + after);
+        assertTrue(after.contains(REASON), "the repaired block must carry the current guardrails");
+
+        assertTrue(diagnostics.stream()
+                .anyMatch(d -> d.getMessage(null).contains("malformed markers")),
+            "a repair that silently rewrites a file the developer edited must say so: "
+                + "no 'malformed markers' diagnostic was emitted");
+    }
+
+    /** A file truncated to nothing is still an opt-in signal, so the next compile must refill it. */
+    @Test
+    void truncatingAGeneratedFileToEmpty_repopulatesIt(@TempDir Path dir) throws Exception {
+        compileOnce(dir);
+
+        Files.writeString(dir.resolve("CLAUDE.md"), "", StandardCharsets.UTF_8);
+        settle(dir);
+
+        compileOnce(dir);
+
+        String after = Files.readString(dir.resolve("CLAUDE.md"), StandardCharsets.UTF_8);
+        assertTrue(after.contains(REASON),
+            "an emptied file is an empty opt-in signal, exactly like a freshly touched one — "
+                + "the next compile must repopulate it:\n" + after);
+        assertEquals(1, count(after, GuardrailFileWriter.MARKER_START_MD),
+            "and must do so with one marker block:\n" + after);
+    }
+
+    /**
+     * An edit <em>inside</em> the markers is not hand-authored content — it is a developer editing
+     * generated output, usually without realising it. The next compile has to take it back, or the
+     * generated file and the annotations disagree with no way to tell which is right.
+     *
+     * <p>This is the case the fingerprint short-circuit is most likely to swallow: the annotations
+     * did not change, so the only thing standing between the tampered file and a skipped run is
+     * {@code allCachedFilesStable()}.
+     */
+    @Test
+    void anEditInsideTheMarkers_isRevertedOnTheNextCompile(@TempDir Path dir) throws Exception {
+        compileOnce(dir);
+
+        Path claude = dir.resolve("CLAUDE.md");
+        String generated = Files.readString(claude, StandardCharsets.UTF_8);
+        assertTrue(generated.contains(REASON), "precondition: the reason is generated in the first place");
+        Files.writeString(claude, generated.replace(REASON, "TAMPERED BY HAND"), StandardCharsets.UTF_8);
+        settle(dir);
+
+        compileOnce(dir);
+
+        String after = Files.readString(claude, StandardCharsets.UTF_8);
+        assertTrue(after.contains(REASON),
+            "the annotation is the source of truth; an in-block edit must be overwritten:\n" + after);
+        assertFalse(after.contains("TAMPERED BY HAND"),
+            "an unchanged annotation set must not let the fingerprint short-circuit skip past a "
+                + "modified output file:\n" + after);
+    }
+
+    /**
+     * {@code .vibetags-cache} is a build artifact — {@code git clean}, a CI cold clone or a
+     * {@code target/} wipe removes it routinely. Losing it must cost a rebuild, not a diff: if the
+     * cache is what makes output stable, then every cold CI run rewrites files and every developer
+     * with a warm cache disagrees with CI about what is committed.
+     */
+    @Test
+    void deletingTheWriteCache_reproducesByteIdenticalOutput(@TempDir Path dir) throws Exception {
+        compileOnce(dir);
+        String before = Files.readString(dir.resolve("CLAUDE.md"), StandardCharsets.UTF_8);
+
+        assertTrue(Files.deleteIfExists(dir.resolve(".vibetags-cache")),
+            "precondition: the cache file must exist to be deleted");
+        settle(dir);
+
+        compileOnce(dir);
+
+        assertEquals(before, Files.readString(dir.resolve("CLAUDE.md"), StandardCharsets.UTF_8),
+            "output must be a function of the annotations, not of a surviving cache file");
+        assertTrue(Files.exists(dir.resolve(".vibetags-cache")),
+            "the cache must be rebuilt so the run after a cold one can short-circuit again");
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static void compileOnce(Path dir) throws IOException {
+        harness(dir).compile();
+        VibeTagsLogger.shutdown();
+    }
+
+    private static List<Diagnostic<? extends JavaFileObject>> compileReturningDiagnostics(Path dir)
+            throws IOException {
+        List<Diagnostic<? extends JavaFileObject>> diagnostics =
+            harness(dir).compileReturningDiagnostics();
+        VibeTagsLogger.shutdown();
+        return diagnostics;
+    }
+
+    /** {@code CLAUDE.md} as the sole opt-in, so the assertions are about one file and one writer. */
+    private static ProcessorTestHarness harness(Path dir) throws IOException {
+        ProcessorTestHarness h = new ProcessorTestHarness(dir, false);
+        h.touchOptIn("CLAUDE.md");
+        h.addSource("com.example.Ledger",
+            "package com.example;\n"
+                + "import se.deversity.vibetags.annotations.AILocked;\n"
+                + "@AILocked(reason = \"" + REASON + "\")\n"
+                + "public class Ledger {}\n");
+        return h;
+    }
+
+    private static void settle(Path dir) throws IOException, InterruptedException {
+        ProcessorTestHarness.awaitFilesystemTick(dir);
+        VibeTagsLogger.shutdown();
+    }
+
+    private static int count(String haystack, String needle) {
+        int n = 0;
+        for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) {
+            n++;
+        }
+        return n;
+    }
+}


### PR DESCRIPTION
## What was missing

The lifecycle suite covered the annotation changing and the file being deleted. Two halves were not covered, and both fail the same way — green build, file still present, guardrails quietly wrong.

**`GuardrailFileRecoveryEndToEndTest`** — the file is still there but no longer looks the way VibeTags left it:

| Case | Why it happens in a real repo |
|---|---|
| Marker block deleted | A merge conflict resolved by deleting the whole block |
| Start marker with no end | A half-applied patch |
| File truncated to empty | A bad script; the file is still an opt-in signal |
| Edit made *inside* the markers | Someone who did not know the block was generated |
| `.vibetags-cache` deleted | `git clean`, a cold CI clone, a `target/` wipe |

The last two are the ones the short-circuit is most likely to swallow: the annotation set is unchanged, so `WriteCache.allCachedFilesStable()` is the only thing standing between the damaged file and a skipped run. The cache test also pins that output is a function of the annotations rather than of a surviving cache — otherwise cold CI and a warm developer machine disagree about what belongs in the commit.

**`AnnotationTransitionEndToEndTest`** — the element survives and what is true about it changes:

- **Annotation type swapped on the same FQN.** Nothing about the element looks stale; only the bucket it renders into does. A cleanup keyed on the element has nothing to remove, and the file can end up telling an agent both to work on the class and not to touch it.
- **Class moved between modules in a reactor.** The merged root is assembled from sidecars, so one module adds it and another must drop it — the #365 / #383 shape, except the failure is a duplicate rather than an absence. The losing module deliberately keeps a second annotated class, so this tests the merge rather than the documented empty-module no-op.
- **Role renamed in `.vibetags-roles`, and the config deleted.** Both orphan a rule file that no annotation points at any more; left behind, the agent loads two rule files for one class and the stale one never expires.

## Verification

All 9 pass. Green is not proof, so each mechanism was broken once and the tests confirmed red:

| Mutation | Result |
|---|---|
| Writer's append-at-end branch disabled | 3 of 5 recovery tests fail |
| Malformed-marker repair disabled | The 4th fails |
| `GranularRulesWriter.cleanupAll` made a no-op | Both role tests fail |
| Losing module's recompile skipped | Duplicate check fails, showing the two copies |

All mutations reverted; the production tree is unchanged by this PR. One test was **not** independently falsified: `deletingTheWriteCache_reproducesByteIdenticalOutput`, whose mechanism is the same whole-model rebuild that `OutputOrderDeterminismTest` already pins.

Two earlier mutation attempts — removing the size/mtime comparison in `allCachedFilesStable()`, and dropping `&& writeCache.allCachedFilesStable()` from the short-circuit condition — left the suite green. The recovery path survives both, so more than one layer has to fail before damage reaches a generated file.

## Docs

`docs/TESTS.md` indexes both classes. The fast/e2e split numbers had drifted in two directions at once — `TESTS.md` said 80/910 and 132/1486, `CLAUDE.md` said 87/957 and 140/1535. Re-measured on the same machine: **88 classes / 957 tests** fast, **142 classes / 1546 tests** with `-Pe2e`.

## Gates

`mvn test -Pe2e` 1546 passing, Checkstyle 0 violations, PMD/CPD pass, SpotBugs 0. `pre-commit` is not installed in this environment and did not run — its Checkstyle hook is covered by the Maven `validate` binding above, gitleaks and the whitespace fixers were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
