### PR TITLE
chore: bump async-test-lib 1.7.3 -> 1.9.0 in both builds

### DIFF
--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -88,7 +88,7 @@
         <junit.platform.version>6.1.2</junit.platform.version>
         <mockito.version>5.23.0</mockito.version>
         <archunit.version>1.5.0</archunit.version>
-        <async-test-lib.version>1.7.3</async-test-lib.version>
+        <async-test-lib.version>1.9.0</async-test-lib.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <jmh.version>1.37</jmh.version>
 

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.5.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:6.1.2'
     // Concurrency-test harness, matching pom.xml. Resolves from Maven Central like any other dep.
-    testImplementation 'se.deversity.async-test-lib:async-test-lib:1.7.3'
+    testImplementation 'se.deversity.async-test-lib:async-test-lib:1.9.0'
     testImplementation 'org.mockito:mockito-core:5.23.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.23.0'
     // Test-only, matching pom.xml. The processor writes six YAML documents but must not gain a


### PR DESCRIPTION
Downstream regression sweep for async-test-lib 1.9.0.

- Both declaration sites bumped together (vibetags-parent/pom.xml property + vibetags/build.gradle literal), per the invariant noted beside each.
- Artifact provenance: preflight sha1 check found no local impostor jars; both builds resolved the published 1.9.0 from Central (mavenLocal poisoning ruled out).
- Maven: `mvn -B test -Pe2e` - **1546 tests, 0 failures, 0 errors** (the e2e profile matters: three of the four @AsyncTest classes are e2e-tagged and a plain `mvn test` would exercise a quarter of the async surface).
- Gradle: `./gradlew --no-daemon test -Pe2e` - BUILD SUCCESSFUL.
- Async surface verified executed in both builds: GuardrailFileWriterAsyncTest, ModuleSidecarAsyncTest, VibeTagsLoggerAsyncTest, WriteCacheAsyncTest.
- No source changes needed: 1.8.0/1.9.0 only add DetectorType constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTegtPZwgxhtifqkCDjRpB
