### PR TITLE
chore: prepare release v1.1.0

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.0.4
+version: 1.1.0
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.0.4</version>
+    <version>1.1.0</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:1.0.4'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.4'
+compileOnly 'se.deversity.vibetags:vibetags-processor:1.1.0'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.1.0'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)
@@ -1066,7 +1066,7 @@ Use on: **class, method, field**
 @AIKeepInSync(mirrors = {"pom.xml:<version>", "README.md badge", "docs/CHANGELOG.md"},
               reason = "The release version is asserted in three places and drifts silently",
               enforcedBy = "ProjectFactsConsistencyTest")
-public static final String VERSION = "1.0.4";
+public static final String VERSION = "1.1.0";
 ```
 
 The element is free to change — the failure mode is a *partial* change that desyncs a mirror no compiler checks. `@AIContract` freezes one signature so it cannot change at all; neither it nor `@AISchemaSafe` expresses "edit A ⇒ you must also edit B". Mirrors routinely point outside the compilation unit, so VibeTags can only *name* them, not verify them.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.4</version>
+            <version>1.1.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.4</version>
+                        <version>1.1.0</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -94,7 +94,7 @@ touch CLAUDE.md .cursorrules AGENTS.md   # Claude, Cursor, Codex CLI — add whi
 Or let the companion CLI do it (and `vibetags doctor` checks your setup afterwards):
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.0.4 init --platforms claude,cursor
+jbang se.deversity.vibetags:vibetags-cli:1.1.0 init --platforms claude,cursor
 ```
 
 **3. Annotate your first class:**
@@ -123,8 +123,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.4')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.4')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.0')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -170,8 +170,8 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.0.4"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.0.4"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.1.0"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.1.0"))
 
     compileOnly("se.deversity.vibetags:vibetags-annotations")
     kapt("se.deversity.vibetags:vibetags-processor")
@@ -512,7 +512,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.0.4</version>
+            <version>1.1.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -537,7 +537,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.0.4</version>
+                        <version>1.1.0</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -553,8 +553,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.4')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.4')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.0')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -568,15 +568,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.0.4</version>
+    <version>1.1.0</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.4'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.4'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.1.0'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.1.0'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.
@@ -897,8 +897,8 @@ presence the processor honours (the processor itself never creates them), and
 `VIBETAGS-START`/`END` marker integrity. Run it without installing anything:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.0.4 init --list
-jbang se.deversity.vibetags:vibetags-cli:1.0.4 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.1.0 init --list
+jbang se.deversity.vibetags:vibetags-cli:1.1.0 doctor
 ```
 
 The platform list and marker rules are read from `vibetags-processor` at runtime, so the CLI

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-08-11
+
+A minor rather than a patch because this release adds three JVM languages and a CLI, none of
+which changes the processor's behaviour for existing users. It also carries everything from
+1.0.4, which was prepared on 2026-08-08 but never tagged or published — there is no
+`v1.0.4` tag and no 1.0.4 on Maven Central, so consumers move from 1.0.3 straight to 1.1.0
+and get both sets of changes.
+
 ### Verified
 - **Every downstream consumer still builds against `main`, and a 1.0.4 load-test baseline says
   the work product did not move.** Both suites were run against the processor built from
@@ -161,7 +169,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   describe the stub, not the `.kt` file. KSP remains unsupported — it does not run JSR 269
   processors.
 
-## [1.0.4] - 2026-08-08
+## [1.0.4] - 2026-08-08 — prepared, never published; shipped as part of 1.1.0
 
 ### Fixed
 - **`.vibetags-locks` recorded absolute source paths, so a committed report differed on every
@@ -2250,8 +2258,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.0.4...HEAD
-[1.0.4]: https://github.com/PIsberg/vibetags/compare/v1.0.3...v1.0.4
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/PIsberg/vibetags/compare/v1.0.3...v1.1.0
 [1.0.3]: https://github.com/PIsberg/vibetags/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/PIsberg/vibetags/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/PIsberg/vibetags/compare/v1.0.0...v1.0.1

--- a/example-all-tiers/pom.xml
+++ b/example-all-tiers/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.0.4</vibetags.bom.version>
+    <vibetags.bom.version>1.1.0</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/example-groovy/build.gradle
+++ b/example-groovy/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.apache.groovy:groovy:5.0.8'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.4')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.4')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.0')
 
     // Annotations on compile, processor on the annotation-processor path only.
     compileOnly 'se.deversity.vibetags:vibetags-annotations'

--- a/example-kotlin/build.gradle.kts
+++ b/example-kotlin/build.gradle.kts
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and kapt configurations so neither needs an explicit version.
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.0.4"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.0.4"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.1.0"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.1.0"))
 
     // Annotations on compile, processor on the kapt path only — keeps the processor's
     // slf4j/logback off the consumer's compile classpath. compileOnly is enough:

--- a/example-multimodule-indexed/pom.xml
+++ b/example-multimodule-indexed/pom.xml
@@ -37,7 +37,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.0.4</vibetags.bom.version>
+    <vibetags.bom.version>1.1.0</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/example-multimodule/pom.xml
+++ b/example-multimodule/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.0.4</vibetags.bom.version>
+    <vibetags.bom.version>1.1.0</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/example-scala/build.gradle
+++ b/example-scala/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.scala-lang:scala-library:2.13.18'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.4')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.4')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.0')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.0.4')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.4')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.0')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.0.4</vibetags.bom.version>
+        <vibetags.bom.version>1.1.0</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/load-tests/results/1.0.4/env.txt
+++ b/load-tests/results/1.0.4/env.txt
@@ -19,6 +19,12 @@ none was found.
 Confirmed rather than assumed, via `mvn dependency:tree`:
     se.deversity.vibetags:vibetags-processor:jar:1.0.4:compile
 
+The folder is named for the version the measured jar actually reported. 1.0.4 was never
+tagged or published, and this code shipped as 1.1.0 — so this directory is the baseline for
+1.1.0's processor, recorded under the version string it carried when it was measured. It was
+not re-captured under the 1.1.0 version string, because re-running would have added a fresh
+draw of measurement noise without changing a line of the code under test.
+
 Files
 -----
 stress.txt              AnnotationVolumeStressTest, N=10..1000
@@ -93,6 +99,7 @@ exists for, and it reproduces even on a loud machine.
 
 Windows @TempDir cleanup
 ------------------------
-concurrent.xml reports errors="0". The cleanup failure that results/README.md documents as a
-standing Windows caveat was real through 0.8.0 and has not recurred since 0.9.7 — 0.9.7,
-1.0.0-RC9 and 1.0.4 all report errors="0".
+concurrent.xml reports errors="0". The cleanup failure that results/README.md used to document
+as a standing Windows caveat was real through 0.8.0 and has not recurred since 0.9.7 — 0.9.7,
+1.0.0-RC9 and 1.0.4 all report errors="0". The README was corrected in the same change that
+added this baseline.

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.0.4</vibetags.bom.version>
+        <vibetags.bom.version>1.1.0</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.4'
+version = '1.1.0'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.0.4'
+            version = '1.1.0'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -39,12 +39,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.0.4&lt;/version&gt;
+                &lt;version&gt;1.1.0&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.0.4'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.0.4'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.1.0'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.1.0'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -36,7 +36,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.0.4&lt;/version&gt;
+                        &lt;version&gt;1.1.0&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.0.4')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.0.4')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.1.0')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.0')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-cli/pom.xml
+++ b/vibetags-cli/pom.xml
@@ -28,7 +28,7 @@
         reports the project's VibeTags health — build-tool wiring, active platforms,
         marker integrity. Run it without installing anything:
 
-            jbang se.deversity.vibetags:vibetags-cli:1.0.4 init --list
+            jbang se.deversity.vibetags:vibetags-cli:1.1.0 init --list
 
         The platform list and marker rules are read from vibetags-processor, so this
         tool cannot drift from what the processor actually does.

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.0.4</revision>
+        <revision>1.1.0</revision>
 
         <!-- release, not source/target: on a JDK newer than 21 (CI builds 21, 25 and 26)
              source/target compiles against the *running* JDK's API and javac warns that the

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.0.4'
+version = '1.1.0'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.0.4'
+            version = '1.1.0'
             from components.java
 
             pom {
@@ -78,7 +78,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.0.4'
+    api 'se.deversity.vibetags:vibetags-annotations:1.1.0'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.1'


### PR DESCRIPTION
Prepares **v1.1.0**. Stacked on `chore/loadtests-and-regression-sweep` (#399), so that PR must
merge first — or this one supersedes it. Nothing is tagged and nothing is published; that step is
yours.

## Why 1.1.0 rather than 1.0.5

Three JVM languages and a CLI are additive, and nothing in the processor's behaviour changed for
existing users. A minor bump is what that means.

## 1.0.4 never shipped

`1.0.4` was prepared on 2026-08-08 (#390) but never tagged and never published — there is no
`v1.0.4` tag and Maven Central 404s for it. The CHANGELOG nonetheless carried a `[1.0.4]` section
and a comparison link to a tag that does not exist. This release folds that work in: consumers go
from 1.0.3 straight to 1.1.0 and get both sets of changes. The `[1.0.4]` heading is kept for the
detail but relabelled "prepared, never published; shipped as part of 1.1.0", and its dead
comparison link is gone.

**If you would rather 1.0.4 stayed a released version, say so** — that means tagging it from its
own commit before this goes out, and I would need to redo the CHANGELOG accordingly.

## What is in it

- **Kotlin support via kapt** (#394), **Groovy via joint-compilation stubs** (#397), and an honest
  matrix for Scala (Java sources only — scalac has no JSR 269) and Clojure (impossible in
  principle: no javac, and SOURCE retention is inexpressible).
- **`vibetags-cli`** (#395/#396) with `init` and `doctor`, plus the symlink guard (#398). Platform
  keys and marker strings come from the processor at runtime, so the CLI cannot drift from it.
- **`.vibetags-locks` path fix** and the reactor gate, from the unreleased 1.0.4 work.
- **A `load-tests` skill** and a captured baseline, plus three fixes to the consumer sweep.

## Verification

- Version bump via `scripts/set-version.sh 1.1.0`; `BuildVersionParityTest` green (6 tests), which
  is what proves no Gradle file, example pom or managed pom disagrees with `<revision>`.
- Ordered build green: `vibetags-annotations` → `vibetags` → `vibetags-bom` → `vibetags-cli`, then
  `example` compiles against the freshly installed BOM — the real end-to-end check.
- Leftover-version sweep clean: the only hit was `load-tests/.flattened-pom.xml`, a gitignored
  build artifact.
- Consumer sweep: all five repos PASS against this code, no guardrail drift.
- Load-test baseline: `OutputSize` byte-identical to 1.0.0-RC9, allocation within the 0.6 % noise
  floor of 1.0.3.
- `pre-commit` **NOT RUN** — not installed in this environment.

## Not done, deliberately

No tag, no GitHub release, no publish. Creating the release triggers `publish.yml` and pushes
signed artifacts to Maven Central, which cannot be undone. Merge this when CI is green and tell me
to cut the release, and I will generate the notes for your review first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNVSHBAiAphMbBorcibX8F
