### PR TITLE
docs: the consumer bumps target 1.1.0, not the version that never shipped

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,7 +36,8 @@ and get both sets of changes.
   their first Gradle run failed to resolve an unpublished 1.0.4 and never reached `compileJava`.
   That is a publication artifact, not a regression: with `mavenLocal()` injected for the
   duration of the run — reverted afterwards, nothing committed — both build clean. Their real
-  bumps cannot be opened until 1.0.4 is published.
+  bumps target 1.1.0, since 1.0.4 was never published, and cannot be opened until 1.1.0 is on
+  Maven Central.
 
   **Load-test baseline** (`load-tests/results/1.0.4/`), measured on JDK 26, i7-1260P, cap
   `-Dstress.max.classes=1000`:


### PR DESCRIPTION
One sentence in the 1.1.0 changelog tells readers the downstream consumer bumps "cannot be opened
until 1.0.4 is published". 1.0.4 was never tagged and never published — folding it into 1.1.0 is
precisely what this release does — so as written that is a wait for something that will never
happen.

Caught while generating the release notes, where the sentence would have gone onto the public
release page. My miss: I folded 1.0.4 into 1.1.0 without re-reading the paragraphs that referred
to 1.0.4 as a future publication.

One line. Merge it before I tag `v1.1.0`, or tell me to publish as-is and I will say so plainly
rather than quietly shipping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNVSHBAiAphMbBorcibX8F
