### PR TITLE
chore: prepare release v1.1.1

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.1.0
+version: 1.1.1
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:1.1.0'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.1.0'
+compileOnly 'se.deversity.vibetags:vibetags-processor:1.1.1'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.1.1'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)
@@ -1066,7 +1066,7 @@ Use on: **class, method, field**
 @AIKeepInSync(mirrors = {"pom.xml:<version>", "README.md badge", "docs/CHANGELOG.md"},
               reason = "The release version is asserted in three places and drifts silently",
               enforcedBy = "ProjectFactsConsistencyTest")
-public static final String VERSION = "1.1.0";
+public static final String VERSION = "1.1.1";
 ```
 
 The element is free to change — the failure mode is a *partial* change that desyncs a mirror no compiler checks. `@AIContract` freezes one signature so it cannot change at all; neither it nor `@AISchemaSafe` expresses "edit A ⇒ you must also edit B". Mirrors routinely point outside the compilation unit, so VibeTags can only *name* them, not verify them.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.1</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.1.0</version>
+                        <version>1.1.1</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -94,7 +94,7 @@ touch CLAUDE.md .cursorrules AGENTS.md   # Claude, Cursor, Codex CLI — add whi
 Or let the companion CLI do it (and `vibetags doctor` checks your setup afterwards):
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.1.0 init --platforms claude,cursor
+jbang se.deversity.vibetags:vibetags-cli:1.1.1 init --platforms claude,cursor
 ```
 
 **3. Annotate your first class:**
@@ -123,8 +123,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.0')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.0')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.1')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -170,8 +170,8 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.1.0"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.1.0"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.1.1"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.1.1"))
 
     compileOnly("se.deversity.vibetags:vibetags-annotations")
     kapt("se.deversity.vibetags:vibetags-processor")
@@ -512,7 +512,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.1</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -537,7 +537,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.1.0</version>
+                        <version>1.1.1</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -553,8 +553,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.0')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.0')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.1')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -568,15 +568,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.1.0'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.1.0'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.1.1'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.1.1'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.
@@ -897,8 +897,8 @@ presence the processor honours (the processor itself never creates them), and
 `VIBETAGS-START`/`END` marker integrity. Run it without installing anything:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.1.0 init --list
-jbang se.deversity.vibetags:vibetags-cli:1.1.0 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.1.1 init --list
+jbang se.deversity.vibetags:vibetags-cli:1.1.1 doctor
 ```
 
 The platform list and marker rules are read from `vibetags-processor` at runtime, so the CLI

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-08-12
+
+A patch release that changes generated output. Four renderers were dropping annotations they
+already had formatting for, and `@AIIgnore`'s reason never reached a file at all. Projects using
+any of the affected annotations will see new sections appear on the next build. No annotation,
+option or public API changed.
+
 ### Fixed
 - **`Platform.GEMINI_GRANULAR` had no arm in `PlatformRendererRegistry`.** `findRenderer` listed
   twelve of the thirteen `*_GRANULAR` constants by hand, so `getRenderer(GEMINI_GRANULAR)` threw
@@ -2365,7 +2372,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/PIsberg/vibetags/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/PIsberg/vibetags/compare/v1.0.3...v1.1.0
 [1.0.3]: https://github.com/PIsberg/vibetags/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/PIsberg/vibetags/compare/v1.0.1...v1.0.2

--- a/example-all-tiers/pom.xml
+++ b/example-all-tiers/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.1.0</vibetags.bom.version>
+    <vibetags.bom.version>1.1.1</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/example-groovy/build.gradle
+++ b/example-groovy/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.apache.groovy:groovy:5.0.8'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.0')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.0')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.1')
 
     // Annotations on compile, processor on the annotation-processor path only.
     compileOnly 'se.deversity.vibetags:vibetags-annotations'

--- a/example-kotlin/build.gradle.kts
+++ b/example-kotlin/build.gradle.kts
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and kapt configurations so neither needs an explicit version.
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.1.0"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.1.0"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.1.1"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.1.1"))
 
     // Annotations on compile, processor on the kapt path only — keeps the processor's
     // slf4j/logback off the consumer's compile classpath. compileOnly is enough:

--- a/example-multimodule-indexed/pom.xml
+++ b/example-multimodule-indexed/pom.xml
@@ -37,7 +37,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.1.0</vibetags.bom.version>
+    <vibetags.bom.version>1.1.1</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/example-multimodule/pom.xml
+++ b/example-multimodule/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.1.0</vibetags.bom.version>
+    <vibetags.bom.version>1.1.1</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/example-scala/build.gradle
+++ b/example-scala/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.scala-lang:scala-library:2.13.18'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.0')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.0')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.1')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.0')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.0')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.1')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.1.0</vibetags.bom.version>
+        <vibetags.bom.version>1.1.1</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.1.0</vibetags.bom.version>
+        <vibetags.bom.version>1.1.1</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.1.0'
+version = '1.1.1'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.1.0'
+            version = '1.1.1'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -39,12 +39,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.1.0&lt;/version&gt;
+                &lt;version&gt;1.1.1&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.1.0'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.1.0'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.1.1'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.1.1'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -36,7 +36,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.1.0&lt;/version&gt;
+                        &lt;version&gt;1.1.1&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.1.0')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.0')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.1.1')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.1')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-cli/pom.xml
+++ b/vibetags-cli/pom.xml
@@ -28,7 +28,7 @@
         reports the project's VibeTags health — build-tool wiring, active platforms,
         marker integrity. Run it without installing anything:
 
-            jbang se.deversity.vibetags:vibetags-cli:1.1.0 init --list
+            jbang se.deversity.vibetags:vibetags-cli:1.1.1 init --list
 
         The platform list and marker rules are read from vibetags-processor, so this
         tool cannot drift from what the processor actually does.

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.1.0</revision>
+        <revision>1.1.1</revision>
 
         <!-- release, not source/target: on a JDK newer than 21 (CI builds 21, 25 and 26)
              source/target compiles against the *running* JDK's API and javac warns that the

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.1.0'
+version = '1.1.1'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.1.0'
+            version = '1.1.1'
             from components.java
 
             pom {
@@ -78,7 +78,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.1.0'
+    api 'se.deversity.vibetags:vibetags-annotations:1.1.1'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.1'


### PR DESCRIPTION
Prepares the 1.1.1 release: `<revision>` bumped to 1.1.1 plus every file that cannot inherit it, and the CHANGELOG's `[Unreleased]` section closed as `[1.1.1] - 2026-08-12`.

## Why a patch that changes generated output

1.1.1 carries the fixes merged in #402. Three of them change what lands in consumers' files:

- **Four renderers dropped annotations they already had formatting for.** Codex and Qwen were missing 17 of the 44 annotations, Open Interpreter and Aider 12 — everything added after `@AISecure`. Each renderer hand-listed the buckets it walked, and the lists stopped being extended while the annotation set kept growing. `AnnotationSections.newestAnnotationSections(Platform)` is now the single list all four take.
- **`@AIIgnore(reason = "...")` never reached any file.** The formatter did not read the annotation, so the reason went nowhere on all 37 platforms. It now renders wherever the platform's output is prose; the path-list platforms are deliberately unchanged.
- **`Platform.GEMINI_GRANULAR` had no arm in `PlatformRendererRegistry`.** Latent rather than shipped — the content builder filters `*_granular` keys before the registry is asked — but one refactor away from a crash.

No annotation, option or public API changed, which is why this is a patch and not a minor. Projects using `@AICallersOnly`, `@AISandboxOnly`, `@AIMemoryBudget`, `@AIPure`, `@AIDomainModel`, `@AIExtensible`, `@AIInputSanitized`, `@AISecureLogging`, `@AIExplain`, `@AIPrototype`, `@AISunset`, `@AITemporary`, `@AIGenerated`, `@AILoadBearing`, `@AIBannedApi`, `@AIThreadAffinity` or `@AIKeepInSync` will see new sections appear on the next build. That is the fix, not a side effect.

Also in 1.1.1: three gates over code PIT showed nothing was watching (`CoreRulesEveryRuleFiresTest`, `IgnoreFileHeaderNamesTest`, `GranularRendererDropsNoAnnotationTest`), and the mutation workflow now runs `-Pe2e` — it had been scoring the fast tier and reporting it as the project's number. The README badge moves 56% → 80%.

## Verification

| Gate | Result |
|---|---|
| `BuildVersionParityTest` | green, 6 tests — fails if any Gradle file, example pom or managed pom disagrees with `<revision>` |
| Ordered build `vibetags-annotations` → `vibetags` → `vibetags-bom` → `vibetags-cli` → `example` | green |
| Processor test suite (fast tier) | 94 classes, 1208 tests, 0 failures, 0 errors |
| `example` compile against the installed 1.1.1 BOM | green, no diff in the committed guardrail files |
| Old-version sweep | only `.flattened-pom.xml` build artifacts and the 1.1.0 CHANGELOG entry remain, both expected |
| `pre-commit run --all-files` | **not run** — `pre-commit` is not installed in this environment and no workflow invokes it. Trailing-whitespace and end-of-file were checked by hand across all 18 changed files; no `.java` changed, so Checkstyle has nothing new to see |

`load-tests/pom.xml` is deliberately untouched: its `<processor.version>` is pinned independently so benchmarks can compare across versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CafvYsJXekS6AHJMvna59L
