### PR TITLE
chore: prepare release v1.2.0

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1246,7 +1246,9 @@ Worth knowing:
 - **kapt, ECJ and JPMS need a hand.** Discovery needs the compiler's Tree API and the classpath;
   where either is missing VibeTags reports a `NOTE` rather than pretending it found nothing, and
   the manifests are supplied with `-Avibetags.manifest.dir=<dir>` or
-  `-Avibetags.manifest.packages=a.b,c.d`.
+  `-Avibetags.manifest.packages=a.b,c.d`. Plain Gradle needs none of that.
+- **Markers are resolved against `-Avibetags.root`.** A build that pins the root at a module
+  directory needs `.vibetags-transitive` in that directory, not only at the reactor root.
 
 ---
 

--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.1.1
+version: 1.2.0
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.0</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:1.1.1'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.1.1'
+compileOnly 'se.deversity.vibetags:vibetags-processor:1.2.0'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.0'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)
@@ -1066,7 +1066,7 @@ Use on: **class, method, field**
 @AIKeepInSync(mirrors = {"pom.xml:<version>", "README.md badge", "docs/CHANGELOG.md"},
               reason = "The release version is asserted in three places and drifts silently",
               enforcedBy = "ProjectFactsConsistencyTest")
-public static final String VERSION = "1.1.1";
+public static final String VERSION = "1.2.0";
 ```
 
 The element is free to change — the failure mode is a *partial* change that desyncs a mirror no compiler checks. `@AIContract` freezes one signature so it cannot change at all; neither it nor `@AISchemaSafe` expresses "edit A ⇒ you must also edit B". Mirrors routinely point outside the compilation unit, so VibeTags can only *name* them, not verify them.
@@ -1179,6 +1179,77 @@ mkdir -p .claude/rules .github/instructions
 
 ---
 
+## Transitive Guardrails — rules that arrive from a dependency
+
+An agent working in an application reads *that* application's `CLAUDE.md`, never the one belonging
+to a library it depends on. A library can publish its package-level guardrails, and any project
+that opts in renders them into its own AI configuration.
+
+Both halves are file-presence opt-ins, like everything else here. Neither file exists by default.
+
+**Publishing (the library).** Annotate `package-info.java`, then add `.vibetags-manifest`:
+
+```java
+// src/main/java/com/acme/crypto/api/package-info.java
+@AISecure(aspect = "Never construct a raw Cipher; go through CryptoManagerFactory.")
+@AIThreadSafe(strategy = AIThreadSafe.Strategy.IMMUTABLE,
+    note = "Every product of the factory is safe to share between threads.")
+package com.acme.crypto.api;
+
+import se.deversity.vibetags.annotations.AISecure;
+import se.deversity.vibetags.annotations.AIThreadSafe;
+```
+
+```bash
+# first non-comment line is the coordinate consumers will see
+echo "com.acme:crypto-core:2.4.0" > .vibetags-manifest
+```
+
+The build writes `vibetags/manifests/com.acme.crypto.api.json` into the class output and the normal
+`jar` task packages it. (Not `META-INF/` — javac's `CLASS_PATH` location skips archive directories
+whose names are not valid package identifiers, so a manifest there is unreadable from a processor.)
+
+**Consuming (the application).**
+
+```bash
+touch .vibetags-transitive
+```
+
+```markdown
+<!-- appended to CLAUDE.md, after everything your own code declares -->
+## Inherited Guardrails (dependencies)
+
+- `com.acme.crypto.api` (from com.acme:crypto-core:2.4.0)
+  - @AISecure: aspect=Never construct a raw Cipher; go through CryptoManagerFactory.
+
+## Inherited Context (dependencies)
+
+- `com.acme.crypto.api` (from com.acme:crypto-core:2.4.0)
+  - @AIThreadSafe: strategy=IMMUTABLE; note=Every product of the factory is safe to share between threads.
+```
+
+Worth knowing:
+
+- **The project's own rules come first, always.** The inherited block is appended last. That
+  ordering *is* the precedence model — the output is prose an agent reads, not a ruleset a compiler
+  applies, so a library cannot outrank the project consuming it.
+- **Every inherited rule names its artifact**, because a dependency is contributing text an agent
+  will act on and the reader has to see whose text it is.
+- **Only packages the compilation imports are looked up**, so a hundred instrumented dependencies
+  do not become a hundred pages of prompt. `-Avibetags.manifest.max=<n>` caps the advisory tier
+  further; the six safety buckets are never dropped, and a cap that drops anything says so.
+- **Only package-level annotations travel.** Class- and method-level guardrails stay local — a
+  consumer cannot act on a rule about a class it never sees. Thirteen annotations accept
+  `ElementType.PACKAGE`: `@AISecure`, `@AIPrivacy`, `@AICore`, `@AIAudit`, `@AIRegulation`,
+  `@AIArchitecture`, `@AIPublicAPI`, `@AIBannedApi`, `@AIThreadSafe`, `@AIImmutable`,
+  `@AIDeprecated`, `@AIContext`, `@AIStrictClasspath`.
+- **kapt, ECJ and JPMS need a hand.** Discovery needs the compiler's Tree API and the classpath;
+  where either is missing VibeTags reports a `NOTE` rather than pretending it found nothing, and
+  the manifests are supplied with `-Avibetags.manifest.dir=<dir>` or
+  `-Avibetags.manifest.packages=a.b,c.d`.
+
+---
+
 ## Advanced Configuration
 
 ### Processor options (Maven)
@@ -1203,6 +1274,14 @@ mkdir -p .claude/rules .github/instructions
             <arg>-Avibetags.check=true</arg>
             <!-- Opt-in enforcement: fail the build on a guarded signature change -->
             <arg>-Avibetags.enforce=locked,contract,publicapi</arg>
+            <!-- Transitive: coordinate published in this library's manifests -->
+            <arg>-Avibetags.manifest.origin=com.acme:crypto-core:2.4.0</arg>
+            <!-- Transitive: read manifests from a directory (kapt/ECJ/JPMS fallback) -->
+            <arg>-Avibetags.manifest.dir=build/vibetags-manifests</arg>
+            <!-- Transitive: look up these packages explicitly, when imports cannot be read -->
+            <arg>-Avibetags.manifest.packages=com.acme.crypto.api,com.acme.audit</arg>
+            <!-- Transitive: cap inherited advisory rules (safety buckets are never dropped) -->
+            <arg>-Avibetags.manifest.max=50</arg>
         </compilerArgs>
     </configuration>
 </plugin>

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.1.1</version>
+            <version>1.2.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.1.1</version>
+                        <version>1.2.0</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -94,7 +94,7 @@ touch CLAUDE.md .cursorrules AGENTS.md   # Claude, Cursor, Codex CLI — add whi
 Or let the companion CLI do it (and `vibetags doctor` checks your setup afterwards):
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.1.1 init --platforms claude,cursor
+jbang se.deversity.vibetags:vibetags-cli:1.2.0 init --platforms claude,cursor
 ```
 
 **3. Annotate your first class:**
@@ -123,8 +123,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.0')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -170,8 +170,8 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.1.1"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.1.1"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.0"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.0"))
 
     compileOnly("se.deversity.vibetags:vibetags-annotations")
     kapt("se.deversity.vibetags:vibetags-processor")
@@ -512,7 +512,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.1.1</version>
+            <version>1.2.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -537,7 +537,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.1.1</version>
+                        <version>1.2.0</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -553,8 +553,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.0')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -568,15 +568,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.0</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.1.1'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.1.1'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.0'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.0'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.
@@ -897,8 +897,8 @@ presence the processor honours (the processor itself never creates them), and
 `VIBETAGS-START`/`END` marker integrity. Run it without installing anything:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.1.1 init --list
-jbang se.deversity.vibetags:vibetags-cli:1.1.1 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.2.0 init --list
+jbang se.deversity.vibetags:vibetags-cli:1.2.0 doctor
 ```
 
 The platform list and marker rules are read from `vibetags-processor` at runtime, so the CLI

--- a/USAGE.md
+++ b/USAGE.md
@@ -336,7 +336,10 @@ Worth knowing before you turn it on:
 - **kapt, ECJ and JPMS need a hand.** Classpath discovery needs the compiler's Tree API and the
   classpath. Where either is missing, VibeTags says so as a `NOTE` rather than pretending it found
   nothing, and you supply the manifests with `-Avibetags.manifest.dir=<dir>` or
-  `-Avibetags.manifest.packages=a.b,c.d`.
+  `-Avibetags.manifest.packages=a.b,c.d`. Plain Gradle needs nothing: its environment wrapper is
+  unwrapped for you.
+- **The markers live at whatever `-Avibetags.root` resolves to.** If your build pins that at a
+  module directory, `.vibetags-transitive` belongs there too, not only at the reactor root.
 
 A working demonstration lives in [`example-multimodule/`](example-multimodule), where `core`
 publishes and `engine`, `cli` and `tests` inherit. Full details in

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -139,6 +139,12 @@ source-compatible: nothing that compiled before stops compiling.
   to a consumer's file and leaves nothing to restore. `pluginManagement` is deliberately untouched:
   declaring one repository there removes Gradle's implicit `gradlePluginPortal()`, which broke
   codekarta's shadow plugin on the first attempt.
+- **`DocumentationLinksTest` walked the build output it was running inside.** Its skip list
+  filtered the results of `Files.walk` instead of pruning the walk, so it still descended into
+  `build/`, `target/` and `.gradle/` while Gradle was writing there. A file that vanished between
+  the listing and the visit surfaced as `UncheckedIOException: NoSuchFileException` and failed a
+  test about links in documentation — red on CI, green everywhere else, and about nothing. It now
+  prunes those directories in a `FileVisitor`, which checks exactly the same files and is faster.
 
 ## [1.1.1] - 2026-08-12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -84,6 +84,21 @@ source-compatible: nothing that compiled before stops compiling.
   `tests` module now appears for exactly this reason.
 
 ### Fixed
+- **Transitive guardrails did nothing under Gradle.** Gradle hands every annotation processor an
+  `IncrementalProcessingEnvironment` rather than javac's own, and `Trees.instance` rejects anything
+  that is not javac's. Discovery therefore reported `transitive.skip reason=trees-unavailable` and
+  inherited nothing on every Gradle build — green, silent, and with the section simply missing from
+  the generated file. Found by wiring the feature up in `async-test-lib`, which publishes and
+  consumes with both build tools: Maven inherited two rules, Gradle inherited none from the same
+  sources.
+
+  VibeTags already had the answer. `SourcePositionResolver.treesFor` unwraps that same wrapper so
+  `@AILocked` positions survive a Gradle build; the new reader called `Trees.instance` directly and
+  the two drifted apart the moment the second one was written. Discovery now goes through
+  `treesFor`, which is one call site instead of two implementations.
+  `TransitiveGuardrailLifecycleE2ETest.aWrappedProcessingEnvironmentStillDiscoversManifests`
+  compiles through a Gradle-shaped wrapper and fails when the unwrap is bypassed — it was written
+  against the broken code first and reproduced it.
 - **A split package no longer misattributes its second artifact.** The inherited-rule block grouped
   bullets under one header per package, so when two artifacts published rules for the same package
   the second rendered under the first one's coordinate — telling the reader a constraint came from a
@@ -116,6 +131,14 @@ source-compatible: nothing that compiled before stops compiling.
   use VibeTags" from the skill alone would have said package annotations do not exist. It now
   carries the publish/consume walkthrough, the thirteen annotations that accept
   `ElementType.PACKAGE`, and the four `-Avibetags.manifest.*` options.
+- **`scripts/consumer-sweep.sh` can build a Gradle consumer that already mentions
+  `mavenLocal()`.** The injection it used skipped any build file containing that string, and
+  codekarta has one behind `if (project.hasProperty("useMavenLocal"))` — present in the text, off
+  in the build. The sweep injected nothing and reported codekarta FAIL for a resolution error that
+  said nothing about VibeTags. Gradle builds now get `--init-script` instead, which needs no edit
+  to a consumer's file and leaves nothing to restore. `pluginManagement` is deliberately untouched:
+  declaring one repository there removes Gradle's implicit `gradlePluginPortal()`, which broke
+  codekarta's shadow plugin on the first attempt.
 
 ## [1.1.1] - 2026-08-12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-08-13
+
+A minor release: guardrails a library declares on a package now reach the projects that depend on
+it. Both halves are file-presence opt-ins that do not exist by default, so upgrading changes nothing
+for a project that does not ask for it — `example/` and `example-multimodule-indexed/` regenerate
+byte-for-byte against 1.1.1. Thirteen annotations gained `ElementType.PACKAGE`, which is
+source-compatible: nothing that compiled before stops compiling.
+
 ### Added
 - **Transitive guardrails: package-level rules travel from a library into the projects that depend
   on it.** An agent working in an application reads the application's `CLAUDE.md`, not the one
@@ -101,6 +109,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   local annotations meant a project whose guardrails all come from dependencies wrote its files
   exactly once and then refused every update with "no annotations found in this module, preserving
   existing rules" — so a dependency upgrade could never reach the file.
+
+### Documentation
+- **The `vibetags-usage` skill documents transitive guardrails.** `USAGE.md` and `PROCESSOR.md`
+  gained the feature when it shipped; the packaged skill did not, so an agent answering "how do I
+  use VibeTags" from the skill alone would have said package annotations do not exist. It now
+  carries the publish/consume walkthrough, the thirteen annotations that accept
+  `ElementType.PACKAGE`, and the four `-Avibetags.manifest.*` options.
 
 ## [1.1.1] - 2026-08-12
 
@@ -2467,7 +2482,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/PIsberg/vibetags/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/PIsberg/vibetags/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/PIsberg/vibetags/compare/v1.0.3...v1.1.0
 [1.0.3]: https://github.com/PIsberg/vibetags/compare/v1.0.2...v1.0.3

--- a/docs/PROCESSOR.md
+++ b/docs/PROCESSOR.md
@@ -68,10 +68,22 @@ walk: `import a.b.C` probes `a.b` and `a`-rooted parents but never `a.b.C`, and
 class-name lookup is a guaranteed miss — one per import in the project, which is bounded but
 entirely avoidable.
 
-Where the Tree API is absent (kapt, ECJ, some Gradle workers) or the dependencies live on the
-module path rather than the classpath, discovery finds nothing and says so as a `NOTE` — unchecked
-is reported distinctly from clean. `-Avibetags.manifest.dir` and `-Avibetags.manifest.packages` are
-the supported ways through.
+Where the Tree API is absent (kapt, ECJ) or the dependencies live on the module path rather than
+the classpath, discovery finds nothing and says so as a `NOTE` — unchecked is reported distinctly
+from clean. `-Avibetags.manifest.dir` and `-Avibetags.manifest.packages` are the supported ways
+through.
+
+Gradle is **not** one of those cases, though it looks like one. It hands every processor an
+`IncrementalProcessingEnvironment` rather than javac's own, and `Trees.instance` rejects anything
+that is not javac's — so discovery reported "no Tree API" on every Gradle build and inherited
+nothing, with the build green and the section simply absent. Discovery goes through
+`SourcePositionResolver.treesFor`, which already unwraps that wrapper for `@AILocked` positions.
+`TransitiveGuardrailLifecycleE2ETest.aWrappedProcessingEnvironmentStillDiscoversManifests` compiles
+through a Gradle-shaped wrapper and fails if the unwrap is bypassed.
+
+One consequence worth stating: every marker is resolved against the resolved root, so a build that
+pins `-Avibetags.root` at a *module* directory (as a Gradle reactor often does per module) needs
+`.vibetags-transitive` in that module directory, not only at the reactor root.
 
 ### Check mode still publishes
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -61,7 +61,7 @@ stop excluding the same one.
 | `TransitiveSectionTest` | The inherited-guardrail appendix: attribution, tier order, and which platforms carry it (pinned both ways) |
 | `TransitiveFingerprintTest` | That inherited rules reach `BuildFingerprint` — the check the end-to-end test cannot make |
 | `TransitiveExampleCoverageTest` | That `example-multimodule/` still demonstrates the feature rather than quietly demonstrating nothing |
-| `TransitiveGuardrailLifecycleE2ETest` (`e2e`) | The whole lifecycle through a real `javac`: library compiled and jarred, consumer resolving it off the compile classpath. Includes the negative that shaped the design — a manifest under `META-INF/` is invisible |
+| `TransitiveGuardrailLifecycleE2ETest` (`e2e`) | The whole lifecycle through a real `javac`: library compiled and jarred, consumer resolving it off the compile classpath. Includes the negative that shaped the design — a manifest under `META-INF/` is invisible — and a compilation driven through a Gradle-shaped `ProcessingEnvironment` wrapper, which is what discovery silently failed on |
 | `AIGuardrailProcessorTest` | Processor configuration |
 | `AIGuardrailProcessorUnitTest` | Processor logic, opt-in, warning emission |
 | `AIIgnoreProcessorUnitTest` | `@AIIgnore` annotation definition and opt-in behaviour |

--- a/example-all-tiers/pom.xml
+++ b/example-all-tiers/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.1.1</vibetags.bom.version>
+    <vibetags.bom.version>1.2.0</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/example-groovy/build.gradle
+++ b/example-groovy/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.apache.groovy:groovy:5.0.8'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.0')
 
     // Annotations on compile, processor on the annotation-processor path only.
     compileOnly 'se.deversity.vibetags:vibetags-annotations'

--- a/example-kotlin/build.gradle.kts
+++ b/example-kotlin/build.gradle.kts
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and kapt configurations so neither needs an explicit version.
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.1.1"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.1.1"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.0"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.0"))
 
     // Annotations on compile, processor on the kapt path only — keeps the processor's
     // slf4j/logback off the consumer's compile classpath. compileOnly is enough:

--- a/example-multimodule-indexed/pom.xml
+++ b/example-multimodule-indexed/pom.xml
@@ -37,7 +37,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.1.1</vibetags.bom.version>
+    <vibetags.bom.version>1.2.0</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/example-multimodule/pom.xml
+++ b/example-multimodule/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.1.1</vibetags.bom.version>
+    <vibetags.bom.version>1.2.0</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/example-scala/build.gradle
+++ b/example-scala/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.scala-lang:scala-library:2.13.18'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.0')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.1.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.0')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.1.1</vibetags.bom.version>
+        <vibetags.bom.version>1.2.0</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/scripts/consumer-sweep.sh
+++ b/scripts/consumer-sweep.sh
@@ -99,15 +99,37 @@ bump() {
 # rather than diagnosing a resolution failure per repo. A missing curl is not fatal: assume
 # published, which is the behaviour this script had before.
 UNPUBLISHED=0
+GRADLE_INIT=""
 if command -v curl >/dev/null 2>&1; then
   if ! curl -sfI --max-time 20 \
        "https://repo1.maven.org/maven2/se/deversity/vibetags/vibetags-processor/${VERSION}/vibetags-processor-${VERSION}.pom" \
        >/dev/null 2>&1; then
     UNPUBLISHED=1
-    echo "note: ${VERSION} is not on Maven Central. Gradle builds that declare only"
-    echo "      mavenCentral() get a temporary mavenLocal() so they can resolve it; the file is"
-    echo "      restored afterwards. Install the processor locally first or the sweep tests nothing."
+    echo "note: ${VERSION} is not on Maven Central. Gradle builds get a temporary mavenLocal()"
+    echo "      through an init script so they can resolve it; no consumer file is edited."
+    echo "      Install the processor locally first or the sweep tests nothing."
     echo
+
+    # An init script rather than a rewrite of the consumer's build file. The rewrite this
+    # replaced skipped any file that already contained the string mavenLocal(), and codekarta
+    # has one behind `if (project.hasProperty("useMavenLocal"))` — present in the text, off in
+    # the build. The sweep therefore injected nothing and reported codekarta FAIL for a
+    # resolution error that says nothing about VibeTags.
+    #
+    # pluginManagement is deliberately left alone: declaring even one repository there removes
+    # Gradle's implicit gradlePluginPortal(), and codekarta's shadow plugin then resolves
+    # nowhere. Only dependency repositories need the local one.
+    GRADLE_INIT="$LOGDIR/mavenlocal-init.gradle"
+    cat > "$GRADLE_INIT" <<'INITEOF'
+beforeSettings { settings ->
+    settings.dependencyResolutionManagement.repositories.mavenLocal()
+}
+allprojects {
+    repositories {
+        mavenLocal()
+    }
+}
+INITEOF
   fi
 fi
 printf '%-22s %-8s %-9s %s\n' REPO RESULT EXIT NOTES
@@ -162,24 +184,14 @@ while IFS=: read -r repo tool mvncmd gradlecmd; do
   if [ -x "$work/mvnw" ]; then MVN=./mvnw; else MVN=mvn; fi
   if [ -x "$work/gradlew" ]; then GRADLE=./gradlew; else GRADLE=gradle; fi
 
-  # Gradle resolves only from the repositories a build declares, and several consumers declare
-  # mavenCentral() and nothing else. That is correct for them and fatal here: sweeping a version
-  # that has not been published yet means the artifact exists only in the local repository, so
-  # those builds die at dependency resolution without compiling a line. Reporting that as FAIL
-  # sends someone hunting a regression that cannot exist. Add mavenLocal() for the duration of
-  # the build instead, put the file back afterwards, and say so in the notes.
-  restored=""
-  if [ "$UNPUBLISHED" -eq 1 ]; then
-    for f in build.gradle build.gradle.kts; do
-      [ -f "$work/$f" ] || continue
-      grep -q 'mavenLocal()' "$work/$f" && continue
-      grep -q 'mavenCentral()' "$work/$f" || continue
-      cp "$work/$f" "$work/$f.sweepbak"
-      awk '{ if (!done && /mavenCentral\(\)/) { print; sub(/mavenCentral\(\)/, "mavenLocal()"); print; done=1 } else print }' \
-          "$work/$f.sweepbak" > "$work/$f"
-      restored="$restored $f"
-    done
-  fi
+  # Gradle resolves only from the repositories a build declares, and no consumer declares the
+  # local one for real. That is correct for them and fatal here: sweeping a version that has
+  # not been published yet means the artifact exists only in the local repository, so those
+  # builds die at dependency resolution without compiling a line. Reporting that as FAIL sends
+  # someone hunting a regression that cannot exist. $GRADLE_INIT supplies mavenLocal() from
+  # outside the build, so nothing the consumer owns is edited and nothing has to be restored.
+  ginit=""
+  [ -n "$GRADLE_INIT" ] && ginit="--init-script $GRADLE_INIT"
 
   log="$LOGDIR/$repo.log"
   status=0
@@ -189,18 +201,14 @@ while IFS=: read -r repo tool mvncmd gradlecmd; do
   # had finished. A sweep that silently covers two repos of five is worse than one that fails.
   case "$tool" in
     maven) (cd "$work" && $MVN -q $mvncmd) > "$log" 2>&1 </dev/null || status=$? ;;
-    gradle) (cd "$work" && $GRADLE -q $gradlecmd) > "$log" 2>&1 </dev/null || status=$? ;;
+    gradle) (cd "$work" && $GRADLE -q $ginit $gradlecmd) > "$log" 2>&1 </dev/null || status=$? ;;
     both)
       (cd "$work" && $MVN -q $mvncmd) > "$log" 2>&1 </dev/null || status=$?
       if [ "$status" -eq 0 ]; then
-        (cd "$work" && $GRADLE -q $gradlecmd) > "$log.gradle" 2>&1 </dev/null || status=$?
+        (cd "$work" && $GRADLE -q $ginit $gradlecmd) > "$log.gradle" 2>&1 </dev/null || status=$?
       fi
       ;;
   esac
-
-  # Put the injected repositories back before anything counts the working tree, so the
-  # injection never shows up as drift or as a touched file.
-  for f in $restored; do mv "$work/$f.sweepbak" "$work/$f"; done
 
   # Generated-guardrail drift, counted from `git diff --numstat` rather than `git status`.
   # status lists a file whose line endings changed even when its text did not, and on Windows
@@ -226,7 +234,7 @@ while IFS=: read -r repo tool mvncmd gradlecmd; do
     result=FAIL
   fi
   notes="log: $log"
-  [ -n "$restored" ] && notes="mavenLocal() injected for$restored; $notes"
+  [ -n "$ginit" ] && [ "$tool" != maven ] && notes="mavenLocal() via init script; $notes"
   [ "$eolonly" -gt 0 ] && notes="${eolonly} file(s) touched; $notes"
   [ "$drift" -gt 0 ] && notes="GUARDRAIL DRIFT in $drift file(s); $notes"
   printf '%-22s %-8s %-9s %s\n' "$repo" "$result" "$status" "$notes"

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.1.1</vibetags.bom.version>
+        <vibetags.bom.version>1.2.0</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.1.1'
+version = '1.2.0'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.1.1'
+            version = '1.2.0'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -39,12 +39,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.1.1&lt;/version&gt;
+                &lt;version&gt;1.2.0&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.1.1'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.1.1'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.0'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.0'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -36,7 +36,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.1.1&lt;/version&gt;
+                        &lt;version&gt;1.2.0&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.1.1')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.1.1')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.2.0')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.0')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-cli/pom.xml
+++ b/vibetags-cli/pom.xml
@@ -28,7 +28,7 @@
         reports the project's VibeTags health — build-tool wiring, active platforms,
         marker integrity. Run it without installing anything:
 
-            jbang se.deversity.vibetags:vibetags-cli:1.1.1 init --list
+            jbang se.deversity.vibetags:vibetags-cli:1.2.0 init --list
 
         The platform list and marker rules are read from vibetags-processor, so this
         tool cannot drift from what the processor actually does.

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.1.1</revision>
+        <revision>1.2.0</revision>
 
         <!-- release, not source/target: on a JDK newer than 21 (CI builds 21, 25 and 26)
              source/target compiles against the *running* JDK's API and javac warns that the

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.1.1'
+version = '1.2.0'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.1.1'
+            version = '1.2.0'
             from components.java
 
             pom {
@@ -78,7 +78,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.1.1'
+    api 'se.deversity.vibetags:vibetags-annotations:1.2.0'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.1'

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/TransitiveManifestReader.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/TransitiveManifestReader.java
@@ -52,11 +52,14 @@ import java.util.TreeSet;
  *
  * <h2>When the Tree API is missing</h2>
  *
- * <p>kapt, ECJ and Gradle's isolated compiler workers may expose no {@link Trees}. Discovery then
- * finds nothing, which is reported as unchecked rather than as a failure, and the build can supply
- * keys explicitly with {@code -Avibetags.manifest.packages} or a pre-extracted directory with
+ * <p>kapt and ECJ may expose no {@link Trees}. Discovery then finds nothing, which is reported as
+ * unchecked rather than as a failure, and the build can supply keys explicitly with
+ * {@code -Avibetags.manifest.packages} or a pre-extracted directory with
  * {@code -Avibetags.manifest.dir}. The same fallback covers JPMS builds, where dependencies are on
  * the module path and {@code CLASS_PATH} does not see them.
+ *
+ * <p>Gradle looks like that case and is not: it wraps the environment rather than hiding the trees,
+ * so discovery goes through {@link SourcePositionResolver#treesFor}, which unwraps it.
  */
 public final class TransitiveManifestReader {
 
@@ -268,7 +271,14 @@ public final class TransitiveManifestReader {
      * must find a manifest published for {@code com.acme.crypto}.
      */
     static Set<String> candidatesFrom(ProcessingEnvironment env, RoundEnvironment roundEnv) {
-        Trees trees = Trees.instance(env);
+        // Not Trees.instance(env): Gradle hands every processor an IncrementalProcessingEnvironment
+        // and Trees.instance rejects anything that is not javac's own, so discovery skipped itself
+        // on every Gradle build. SourcePositionResolver already had to solve this for @AILocked
+        // positions; using it here is what keeps the two from drifting apart again.
+        Trees trees = SourcePositionResolver.treesFor(env);
+        if (trees == null) {
+            throw new IllegalStateException("the compiler exposes no Tree API");
+        }
         List<ImportedName> imports = new ArrayList<>();
         Set<CompilationUnitTree> seen = new LinkedHashSet<>();
         for (Element root : roundEnv.getRootElements()) {

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/DocumentationLinksTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/DocumentationLinksTest.java
@@ -6,9 +6,12 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -18,7 +21,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -175,23 +177,42 @@ class DocumentationLinksTest {
         return out.toString();
     }
 
+    /**
+     * Every committed Markdown file, without ever entering a build-output directory.
+     *
+     * <p>The skip list prunes the walk rather than filtering its results. {@code Files.walk} is
+     * lazy, so filtering afterwards still descends into {@code build/}, {@code target/} and
+     * {@code .gradle/} — the three directories a build that is running this very test is writing
+     * and deleting inside. A file that vanished between the directory listing and the visit then
+     * surfaced as {@code UncheckedIOException: NoSuchFileException} and failed a test about links
+     * in documentation, on CI, roughly one Gradle run in three. Pruning is also the faster walk.
+     */
     private List<Path> markdownFiles() throws IOException {
-        try (Stream<Path> paths = Files.walk(REPO_ROOT)) {
-            return paths
-                .filter(p -> p.toString().endsWith(".md"))
-                .filter(DocumentationLinksTest::isNotInSkippedDirectory)
-                .sorted()
-                .toList();
-        }
-    }
-
-    private static boolean isNotInSkippedDirectory(Path p) {
-        for (Path part : p) {
-            if (SKIP_DIRS.contains(part.toString())) {
-                return false;
+        List<Path> found = new ArrayList<>();
+        Files.walkFileTree(REPO_ROOT, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                Path name = dir.getFileName();
+                return name != null && SKIP_DIRS.contains(name.toString())
+                    ? FileVisitResult.SKIP_SUBTREE : FileVisitResult.CONTINUE;
             }
-        }
-        return true;
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                if (file.toString().endsWith(".md")) {
+                    found.add(file);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException unreadable) {
+                // A file that disappeared under a concurrent build is not a documentation defect.
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        found.sort(null);
+        return found;
     }
 
     private static String read(Path p) throws IOException {

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
@@ -110,7 +110,12 @@ class ReleaseScriptCoverageTest {
         // This file, which quotes the same sort-order example a few lines above while explaining
         // why those tools are exempt. It flagged itself the moment it was committed, which is the
         // scan working: it reads `git ls-files`, so a file becomes visible when it becomes real.
-        "vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java");
+        "vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java",
+        // A design proposal, dated by the release it was written for. Its worked example shows a
+        // manifest stamped "vibetags/1.2.0" because 1.2.0 is the release that shipped the feature;
+        // rewriting it on every later release would make the document claim it proposed something
+        // that already existed.
+        "docs/proposals/transitive-guardrails.md");
 
     /** Build outputs and local scratch that are not part of the release. */
     private static final Set<String> IGNORED_SUFFIXES =

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/TransitiveGuardrailLifecycleE2ETest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/TransitiveGuardrailLifecycleE2ETest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.lang.model.SourceVersion;
 import javax.tools.DiagnosticCollector;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
@@ -408,6 +411,76 @@ class TransitiveGuardrailLifecycleE2ETest {
         return jar;
     }
 
+    /**
+     * A build tool that hands the processor a wrapped {@link ProcessingEnvironment} — which is
+     * every Gradle build there is.
+     *
+     * <p>Gradle passes {@code IncrementalProcessingEnvironment} so it can track the files a
+     * processor touches. {@code Trees.instance} rejects anything that is not javac's own
+     * environment, so discovery reported "no Tree API" and inherited nothing at all: the feature
+     * was Maven-only in practice, silently, with the build green and the file simply missing a
+     * section. Measured on async-test-lib, which publishes and consumes with both build tools.
+     *
+     * <p>The wrapper below is shaped like Gradle's — the delegate in a private field, nothing else
+     * — which is what the unwrap in {@code SourcePositionResolver.treesFor} looks for.
+     */
+    @Test
+    void aWrappedProcessingEnvironmentStillDiscoversManifests() throws Exception {
+        Path jar = buildLibraryJar(tmp, "com.acme:crypto-core:2.4.0");
+        Path app = consumerRoot(tmp, true);
+
+        List<String> options = new ArrayList<>(List.of("-classpath", classpathWith(jar)));
+        options.add("-Avibetags.root=" + app.toAbsolutePath());
+        Path classes = app.resolve("classes");
+        Files.createDirectories(classes);
+        run(classes, options, List.of(sourceFile(app, "app/App.java", CONSUMER_CLASS)),
+            new WrappingProcessor());
+
+        String claude = Files.readString(app.resolve("CLAUDE.md"), StandardCharsets.UTF_8);
+        assertTrue(claude.contains("Inherited Guardrails (dependencies)"),
+            "a wrapped environment must not disable discovery:\n" + report(app, "CLAUDE.md"));
+        assertTrue(claude.contains("Never construct a raw Cipher"), claude);
+    }
+
+    /** Delegates to the real processor, handing it a wrapped environment as Gradle does. */
+    private static final class WrappingProcessor implements Processor {
+        private final AIGuardrailProcessor delegate = new AIGuardrailProcessor();
+
+        @Override
+        public void init(ProcessingEnvironment processingEnv) {
+            delegate.init(new WrappedEnvironment(processingEnv));
+        }
+
+        @Override public java.util.Set<String> getSupportedOptions() { return delegate.getSupportedOptions(); }
+        @Override public java.util.Set<String> getSupportedAnnotationTypes() { return delegate.getSupportedAnnotationTypes(); }
+        @Override public SourceVersion getSupportedSourceVersion() { return delegate.getSupportedSourceVersion(); }
+
+        @Override
+        public boolean process(java.util.Set<? extends javax.lang.model.element.TypeElement> annotations,
+                               javax.annotation.processing.RoundEnvironment roundEnv) {
+            return delegate.process(annotations, roundEnv);
+        }
+
+        @Override
+        public Iterable<? extends javax.annotation.processing.Completion> getCompletions(
+                javax.lang.model.element.Element element,
+                javax.lang.model.element.AnnotationMirror annotation, javax.lang.model.element.ExecutableElement member,
+                String userText) {
+            return delegate.getCompletions(element, annotation, member, userText);
+        }
+    }
+
+    /** Shaped like Gradle's {@code IncrementalProcessingEnvironment}: the delegate in a field. */
+    private record WrappedEnvironment(ProcessingEnvironment delegate) implements ProcessingEnvironment {
+        @Override public java.util.Map<String, String> getOptions() { return delegate.getOptions(); }
+        @Override public javax.annotation.processing.Messager getMessager() { return delegate.getMessager(); }
+        @Override public javax.annotation.processing.Filer getFiler() { return delegate.getFiler(); }
+        @Override public javax.lang.model.util.Elements getElementUtils() { return delegate.getElementUtils(); }
+        @Override public javax.lang.model.util.Types getTypeUtils() { return delegate.getTypeUtils(); }
+        @Override public SourceVersion getSourceVersion() { return delegate.getSourceVersion(); }
+        @Override public java.util.Locale getLocale() { return delegate.getLocale(); }
+    }
+
     /** A consumer project root with CLAUDE.md opted in, and optionally transitive discovery too. */
     private static Path consumerRoot(Path base, boolean transitive) throws IOException {
         Path app = base.resolve("app");
@@ -438,7 +511,12 @@ class TransitiveGuardrailLifecycleE2ETest {
      * back (rather than a forwarding wrapper) keeps the CodeQL constraint the harness documents.
      */
     private static void run(Path classOutput, List<String> options, List<Path> sources) throws IOException {
-        List<String> errors = runAllowingFailure(classOutput, options, sources);
+        run(classOutput, options, sources, new AIGuardrailProcessor());
+    }
+
+    private static void run(Path classOutput, List<String> options, List<Path> sources,
+                            Processor processor) throws IOException {
+        List<String> errors = runAllowingFailure(classOutput, options, sources, processor);
         assertTrue(errors.isEmpty(), "compilation failed:\n  " + String.join("\n  ", errors));
     }
 
@@ -452,6 +530,12 @@ class TransitiveGuardrailLifecycleE2ETest {
      */
     private static List<String> runAllowingFailure(Path classOutput, List<String> options,
                                                    List<Path> sources) throws IOException {
+        return runAllowingFailure(classOutput, options, sources, new AIGuardrailProcessor());
+    }
+
+    private static List<String> runAllowingFailure(Path classOutput, List<String> options,
+                                                   List<Path> sources, Processor processor)
+            throws IOException {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         assertTrue(compiler != null, "run the tests on a JDK, not a JRE");
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
@@ -461,7 +545,7 @@ class TransitiveGuardrailLifecycleE2ETest {
             Iterable<? extends JavaFileObject> units = fm.getJavaFileObjectsFromPaths(sources);
             JavaCompiler.CompilationTask task =
                 compiler.getTask(null, fm, diagnostics, options, null, units);
-            task.setProcessors(List.of(new AIGuardrailProcessor()));
+            task.setProcessors(List.of(processor));
             ok = task.call();
         }
 


### PR DESCRIPTION
Prepares release **v1.2.0**, and carries two fixes the pre-release consumer sweep turned up.

## What ships

Guardrails a library declares on a package now reach the projects that depend on it (#404). Both
halves are file-presence opt-ins that do not exist by default — `.vibetags-manifest` to publish,
`.vibetags-transitive` to consume — so upgrading changes nothing for a project that does not ask for
it. Thirteen annotations gained `ElementType.PACKAGE`, which is source-compatible.

Full detail in [docs/CHANGELOG.md](docs/CHANGELOG.md).

## The bug the sweep found: transitive guardrails were dead under Gradle

The feature was wired up for real in two downstream repos rather than only in the examples:
`common-license-lib` annotates its licence package and publishes a manifest, `async-test-lib`
imports that package and consumes it. Maven inherited two rules. Gradle, from the same sources,
inherited none and logged `Transitive discovery skipped: no Tree API (IllegalArgumentException)`.

Gradle hands every processor an `IncrementalProcessingEnvironment`, and `Trees.instance` rejects
anything that is not javac's own. So discovery skipped itself on every Gradle build: green build, no
error, and the generated file simply missing its inherited section.

VibeTags already had the answer — `SourcePositionResolver.treesFor` unwraps that same wrapper so
`@AILocked` positions survive a Gradle-run javac. The new reader called `Trees.instance` directly and
the two drifted apart the moment the second was written. Discovery now goes through `treesFor`.

`TransitiveGuardrailLifecycleE2ETest.aWrappedProcessingEnvironmentStillDiscoversManifests` compiles
through a Gradle-shaped wrapper. Written against the broken code first: it fails with *"a wrapped
environment must not disable discovery"* on `Trees.instance(env)` and passes on `treesFor(env)`.

After the fix, async-test-lib's Gradle build logs `Transitive guardrails: 2 kept, 0 dropped, 32
lookups` and writes the block Maven had been writing all along.

## Consumer sweep, 1.2.0

| repo | result | notes |
|---|---|---|
| blindbean | **PASS** | Guardrail drift in 2 files — the `@AIIgnore(reason=…)` rendering added in 1.1.1. Expected; their committed files are stale because they are pinned at 1.0.3 |
| codekarta | **PASS** | Zero drift. Failed on the first run for a harness bug, fixed here |
| common-license-lib | **PASS** | Zero drift |
| skill3 | **PASS** | Zero drift |
| async-test-lib | **PASS on Maven, then a flaky test on Gradle** | Drift in 3 files, again the 1.1.1 `@AIIgnore` reason. The two failures seen (`MemoryModelValidatorTest`, `PlatformThreadPerTaskDetectorTest`) are thread-timing probes: both pass twice on the bumped tree and twice on the base when the machine is quiet |

Two harness defects fixed alongside:

- `scripts/consumer-sweep.sh` could not build codekarta's Gradle leg. Its `mavenLocal()` injection
  skipped any build file containing that string, and codekarta has one behind
  `if (project.hasProperty("useMavenLocal"))` — in the text, off in the build. Gradle builds now get
  `--init-script`, which edits no consumer file. `pluginManagement` is left alone deliberately:
  declaring one repository there removes Gradle's implicit `gradlePluginPortal()`.
- `DocumentationLinksTest` filtered the results of `Files.walk` instead of pruning the walk, so it
  descended into `build/`, `target/` and `.gradle/` while the Gradle build running it was writing
  there. That is the `NoSuchFileException` that failed Gradle JDK 21 on the previous commit.

## Also in this PR

The `vibetags-usage` skill never gained transitive guardrails when the feature shipped; an agent
answering "how do I use VibeTags" from the skill alone would have said package annotations do not
exist. It now carries the publish/consume walkthrough, the thirteen annotations that accept
`ElementType.PACKAGE`, and the four `-Avibetags.manifest.*` options — names checked against
`@SupportedOptions`, not copied from prose.

`USAGE.md`, `PROCESSOR.md` and the skill also said Gradle might need the manual fallback. It does
not; that sentence was describing the bug. They now also state that markers are resolved against
`-Avibetags.root`, so a build pinning the root at a module directory needs `.vibetags-transitive`
there — the second reason async-test-lib's first Gradle run inherited nothing.

## Verification

- `BuildVersionParityTest` 6/6; build in order annotations → processor → bom → cli → example, all
  exit 0; `example/` regenerates byte-for-byte, which is the evidence that the version does not leak
  into generated content.
- Full suite `-Pe2e`: **1905 tests, 0 failures**. Checkstyle, PMD and SpotBugs clean.
- `pre-commit run --all-files`: green except the `checkstyle` hook, which needs a Docker daemon and
  was **skipped, not passed**, locally. CI runs it.
- End-to-end evidence for the Gradle fix is a real consumer, not a fixture: manifest inside the
  installed jar (`vibetags/manifests/se.deversity.common.license.json`), inherited block in
  `async-test-lib/CLAUDE.md`, under both Maven and Gradle.

## Known, reported rather than changed

With `.vibetags-root-index` (lean indexed reactor root), the root aggregate keeps only the safety
digest, and `withTransitiveAppendix` deliberately excludes inherited rules from it. The module's own
`CLAUDE.md` carries them, but a platform that is not an indexable aggregate — `GEMINI.md` — shows the
inherited block at the root while `CLAUDE.md` does not. Consistent with the documented decision;
worth a second look, but not changed in a release PR.
