### PR TITLE
chore: bump async-test-lib 1.9.0 -> 1.9.2

### DIFF
--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -88,7 +88,7 @@
         <junit.platform.version>6.1.2</junit.platform.version>
         <mockito.version>5.23.0</mockito.version>
         <archunit.version>1.5.0</archunit.version>
-        <async-test-lib.version>1.9.0</async-test-lib.version>
+        <async-test-lib.version>1.9.2</async-test-lib.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <jmh.version>1.37</jmh.version>
 

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.5.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:6.1.2'
     // Concurrency-test harness, matching pom.xml. Resolves from Maven Central like any other dep.
-    testImplementation 'se.deversity.async-test-lib:async-test-lib:1.9.0'
+    testImplementation 'se.deversity.async-test-lib:async-test-lib:1.9.2'
     testImplementation 'org.mockito:mockito-core:5.23.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.23.0'
     // Test-only, matching pom.xml. The processor writes six YAML documents but must not gain a


### PR DESCRIPTION
Downstream regression sweep for async-test-lib 1.9.2. 1.9.1 was never swept here, so this bump covers both patch releases.

Both build systems declare the dependency separately, so **both are bumped in the same commit** — `vibetags-parent/pom.xml` (property) and `vibetags/build.gradle` (literal). Bumping one would leave the Maven and Gradle tiers on different detector engines.

## Verified

```
mvn -B test -Pe2e                 -> 1905 tests, 0 failures, 0 errors
./gradlew --no-daemon test -Pe2e  -> 1905 tests, 0 failures, 0 errors
```

`vibetags-annotations` was `mvn install`ed first so both builds resolve it from `~/.m2`.

## Async classes that actually ran

All five, green in both tiers:

| Class | Result |
|---|---|
| `GuardrailFileWriterAsyncTest` | 1/1 |
| `ModuleSidecarAsyncTest` | 1/1 |
| `VibeTagsLoggerAsyncTest` | 1/1 |
| `VibeTagsLoggerConcurrencyTest` | 1/1 |
| `WriteCacheAsyncTest` | 1/1 |

`-Pe2e` is not optional here: three of these carry `@Tag("e2e")`, so a plain `mvn test` runs only `WriteCacheAsyncTest` and would sign the bump off having exercised a fraction of the async surface.

## Artifact provenance

The `1.9.2` jars cached in `~/.m2` were **local builds masquerading as the release** — sha1 `2d65ca7c…` locally against `35084a6b…` on Central for `async-test-lib`, and the agent and analysis modules likewise. All three were moved aside and refetched from Maven Central with sha1 verified before this run. This matters more here than elsewhere because `mavenLocal()` sits above `mavenCentral()` in this build, so Gradle inherits the same poisoning.

No source changes were needed. 1.9.2 is a drop-in upgrade for this repo.