### PR TITLE
chore: prepare release v1.2.1

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.2.0
+version: 1.2.1
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:1.2.0'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.0'
+compileOnly 'se.deversity.vibetags:vibetags-processor:1.2.1'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.1'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)
@@ -1066,7 +1066,7 @@ Use on: **class, method, field**
 @AIKeepInSync(mirrors = {"pom.xml:<version>", "README.md badge", "docs/CHANGELOG.md"},
               reason = "The release version is asserted in three places and drifts silently",
               enforcedBy = "ProjectFactsConsistencyTest")
-public static final String VERSION = "1.2.0";
+public static final String VERSION = "1.2.1";
 ```
 
 The element is free to change — the failure mode is a *partial* change that desyncs a mirror no compiler checks. `@AIContract` freezes one signature so it cannot change at all; neither it nor `@AISchemaSafe` expresses "edit A ⇒ you must also edit B". Mirrors routinely point outside the compilation unit, so VibeTags can only *name* them, not verify them.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.0</version>
+                        <version>1.2.1</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -94,7 +94,7 @@ touch CLAUDE.md .cursorrules AGENTS.md   # Claude, Cursor, Codex CLI — add whi
 Or let the companion CLI do it (and `vibetags doctor` checks your setup afterwards):
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.0 init --platforms claude,cursor
+jbang se.deversity.vibetags:vibetags-cli:1.2.1 init --platforms claude,cursor
 ```
 
 **3. Annotate your first class:**
@@ -123,8 +123,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.0')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.0')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.1')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -170,8 +170,8 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.0"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.0"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.1"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.1"))
 
     compileOnly("se.deversity.vibetags:vibetags-annotations")
     kapt("se.deversity.vibetags:vibetags-processor")
@@ -512,7 +512,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -537,7 +537,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.0</version>
+                        <version>1.2.1</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -553,8 +553,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.0')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.0')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.1')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -568,15 +568,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.0'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.0'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.1'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.1'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.
@@ -897,8 +897,8 @@ presence the processor honours (the processor itself never creates them), and
 `VIBETAGS-START`/`END` marker integrity. Run it without installing anything:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.0 init --list
-jbang se.deversity.vibetags:vibetags-cli:1.2.0 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.2.1 init --list
+jbang se.deversity.vibetags:vibetags-cli:1.2.1 doctor
 ```
 
 The platform list and marker rules are read from `vibetags-processor` at runtime, so the CLI

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-08-14
+
+A patch release of lifecycle fixes, all found by testing the project's timeline rather than a single
+compile: what happens over months as a repository is rebuilt, opted into, and reshaped around its
+annotations. Nothing here changes an API or an annotation, and `example/`, `example-multimodule/`
+and `example-multimodule-indexed/` regenerate byte-for-byte against 1.2.0.
+
+Three of the four fixes change what a build writes, so a first build on 1.2.1 may update files that
+1.2.0 had frozen: a withdrawn dependency rule finally leaves, and a deleted module's rule files
+finally go. That is the correction landing, not churn.
+
 ### Added
 - **Lifecycle coverage: the project's timeline, not one compile.** `ProjectLifecycleEndToEndTest`
   (7 tests) and `OnboardingLifecycleTest` (2 tests, `vibetags-cli`) cover the transitions a
@@ -2593,7 +2604,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/PIsberg/vibetags/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/PIsberg/vibetags/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/PIsberg/vibetags/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/PIsberg/vibetags/compare/v1.0.3...v1.1.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -88,6 +88,15 @@ finally go. That is the correction landing, not churn.
   that notices, because rendering a module's body needs that module's annotations, so the build now
   emits a WARNING naming the file, the modules missing from it, and the remedy.
 
+- **`ProjectFactsConsistencyTest` no longer fails on a file that vanishes mid-walk.** It walked the
+  repository with `Files.walk`, which throws out of its iterator when a listed path can no longer be
+  stat'ed. The repository is a live directory while the suite runs: the JVM writes
+  `.attach_pid<n>` into the working directory when an agent self-attaches, which Mockito's inline
+  mock maker does from tests running in parallel with this one, and removes it immediately. On Linux
+  CI the race was reliable enough to fail every Maven job; on Windows it never appeared, which is
+  how it reached CI unnoticed. The walk now skips entries it cannot read, and the drift detection is
+  unchanged — verified by planting a document with a wrong count and watching it fail.
+
 - **A module deleted from a reactor now takes its granular rule files with it.** The aggregates
   already forgot it as soon as any sibling recompiled, but `.claude/rules/<its-class>.md` waited for
   a compilation rooted at the reactor root, and a rule file loads by glob: an agent kept reading a

--- a/example-all-tiers/pom.xml
+++ b/example-all-tiers/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.2.0</vibetags.bom.version>
+    <vibetags.bom.version>1.2.1</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/example-groovy/build.gradle
+++ b/example-groovy/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.apache.groovy:groovy:5.0.8'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.0')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.0')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.1')
 
     // Annotations on compile, processor on the annotation-processor path only.
     compileOnly 'se.deversity.vibetags:vibetags-annotations'

--- a/example-kotlin/build.gradle.kts
+++ b/example-kotlin/build.gradle.kts
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and kapt configurations so neither needs an explicit version.
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.0"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.0"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.1"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.1"))
 
     // Annotations on compile, processor on the kapt path only — keeps the processor's
     // slf4j/logback off the consumer's compile classpath. compileOnly is enough:

--- a/example-multimodule-indexed/pom.xml
+++ b/example-multimodule-indexed/pom.xml
@@ -37,7 +37,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.2.0</vibetags.bom.version>
+    <vibetags.bom.version>1.2.1</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/example-multimodule/pom.xml
+++ b/example-multimodule/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.2.0</vibetags.bom.version>
+    <vibetags.bom.version>1.2.1</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/example-scala/build.gradle
+++ b/example-scala/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.scala-lang:scala-library:2.13.18'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.0')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.0')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.1')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.0')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.0')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.1')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.2.0</vibetags.bom.version>
+        <vibetags.bom.version>1.2.1</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.2.0</vibetags.bom.version>
+        <vibetags.bom.version>1.2.1</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.2.0'
+version = '1.2.1'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.2.0'
+            version = '1.2.1'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -39,12 +39,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.2.0&lt;/version&gt;
+                &lt;version&gt;1.2.1&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.0'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.0'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.1'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.1'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -36,7 +36,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.2.0&lt;/version&gt;
+                        &lt;version&gt;1.2.1&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.2.0')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.0')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.2.1')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.1')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-cli/pom.xml
+++ b/vibetags-cli/pom.xml
@@ -28,7 +28,7 @@
         reports the project's VibeTags health — build-tool wiring, active platforms,
         marker integrity. Run it without installing anything:
 
-            jbang se.deversity.vibetags:vibetags-cli:1.2.0 init --list
+            jbang se.deversity.vibetags:vibetags-cli:1.2.1 init --list
 
         The platform list and marker rules are read from vibetags-processor, so this
         tool cannot drift from what the processor actually does.

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.2.0</revision>
+        <revision>1.2.1</revision>
 
         <!-- release, not source/target: on a JDK newer than 21 (CI builds 21, 25 and 26)
              source/target compiles against the *running* JDK's API and javac warns that the

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.2.0'
+version = '1.2.1'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.2.0'
+            version = '1.2.1'
             from components.java
 
             pom {
@@ -78,7 +78,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.2.0'
+    api 'se.deversity.vibetags:vibetags-annotations:1.2.1'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.1'

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ProjectFactsConsistencyTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ProjectFactsConsistencyTest.java
@@ -6,9 +6,12 @@ import se.deversity.vibetags.processor.internal.ServiceRegistry;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -75,6 +78,40 @@ class ProjectFactsConsistencyTest {
         "(?:all|the)\\s+(\\d+)\\s+(?:Java\\s+|VibeTags\\s+)?annotations?\\b"
             + "|(?<![\\d.])(\\d+)\\s+(?:Java\\s+|VibeTags\\s+)?annotation\\b[^.\\n]*?\\bin total\\b");
 
+    /**
+     * Every {@code .md} file under {@code root}, tolerating a file that disappears mid-walk.
+     *
+     * <p>{@link Files#walk} throws {@link java.io.UncheckedIOException} out of its iterator when a
+     * path it has listed can no longer be stat'ed, which fails the test with a
+     * {@code NoSuchFileException} for a file nobody cares about. The repository is a live directory
+     * while the suite runs: the JVM writes {@code .attach_pid<n>} into the working directory when an
+     * agent self-attaches — Mockito's inline mock maker does exactly that, from tests running in
+     * parallel with this one — and deletes it again immediately. On Linux CI the race is reliable
+     * enough to fail every job; on Windows it is invisible, which is why it reached CI unnoticed.
+     *
+     * <p>Skipping unreadable entries is right rather than merely convenient: this test is about
+     * what the committed documents claim, and a path that vanished during the walk is not one of
+     * them.
+     */
+    private static List<Path> markdownFilesUnder(Path root) throws IOException {
+        List<Path> found = new ArrayList<>();
+        Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                if (file.toString().endsWith(".md")) {
+                    found.add(file);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        return found;
+    }
+
     @Test
     void noDocRestatesADifferentAnnotationCount() throws IOException {
         Path annotationsDir = REPO_ROOT.resolve(
@@ -89,28 +126,26 @@ class ProjectFactsConsistencyTest {
         }
 
         List<String> drifted = new ArrayList<>();
-        try (Stream<Path> docs = Files.walk(REPO_ROOT)) {
-            for (Path doc : docs.filter(p -> p.toString().endsWith(".md")).toList()) {
-                String rel = REPO_ROOT.relativize(doc).toString().replace('\\', '/');
-                if (rel.contains("/target/") || rel.contains("/node_modules/")
-                    || rel.startsWith("target/") || HISTORICAL_DOCS.contains(rel)) {
-                    continue;
-                }
-                String text;
-                try {
-                    text = Files.readString(doc, StandardCharsets.UTF_8);
-                } catch (IOException notText) {
-                    continue;
-                }
-                Matcher m = PROSE_COUNT.matcher(text);
-                while (m.find()) {
-                    String captured = m.group(1) != null ? m.group(1) : m.group(2);
-                    int stated = Integer.parseInt(captured);
-                    if (stated != actual) {
-                        int line = (int) text.substring(0, m.start()).chars()
-                            .filter(c -> c == '\n').count() + 1;
-                        drifted.add(rel + ":" + line + " says \"" + m.group() + "\"");
-                    }
+        for (Path doc : markdownFilesUnder(REPO_ROOT)) {
+            String rel = REPO_ROOT.relativize(doc).toString().replace('\\', '/');
+            if (rel.contains("/target/") || rel.contains("/node_modules/")
+                || rel.startsWith("target/") || HISTORICAL_DOCS.contains(rel)) {
+                continue;
+            }
+            String text;
+            try {
+                text = Files.readString(doc, StandardCharsets.UTF_8);
+            } catch (IOException notText) {
+                continue;
+            }
+            Matcher m = PROSE_COUNT.matcher(text);
+            while (m.find()) {
+                String captured = m.group(1) != null ? m.group(1) : m.group(2);
+                int stated = Integer.parseInt(captured);
+                if (stated != actual) {
+                    int line = (int) text.substring(0, m.start()).chars()
+                        .filter(c -> c == '\n').count() + 1;
+                    drifted.add(rel + ":" + line + " says \"" + m.group() + "\"");
                 }
             }
         }


### PR DESCRIPTION
Prepares the 1.2.1 release. Merge when CI is green; the GitHub release is cut from `main` afterwards.

## What is in it

A patch release of lifecycle fixes, all found by testing the project's **timeline** rather than a single compile — what happens over months as a repository is rebuilt, opted into, and reshaped around its annotations.

**Added**
- `ProjectLifecycleEndToEndTest` and `OnboardingLifecycleTest`: day zero with nothing opted in, repeated no-change builds, a module deleted or renamed out of a reactor, and `init` → compile → `doctor`.
- Withdrawal coverage for transitive guardrails, plus two dependencies at once.

**Fixed**
- An inherited guardrail could never be withdrawn from a project with no annotations of its own.
- The fingerprint short-circuit could never fire, in any build that writes a sidecar. Fixing it exposed two latent hazards, now guarded: module identity was missing from the fingerprint, and a skipped round never prunes a stale sidecar.
- A platform opted into after a module last compiled now warns and names the modules missing from the file.
- A module deleted from a reactor now takes its granular rule files with it.

## Version scope

Patch. No API or annotation changed. Three of the four fixes do change what a build *writes*, so a consumer's first build on 1.2.1 may update files that 1.2.0 had frozen — a withdrawn dependency rule finally leaves, a deleted module's rule files finally go. That is the correction landing, not churn, and it is called out at the top of the changelog entry.

## Verification

- `BuildVersionParityTest` green — no Gradle file, example pom or managed pom disagrees with `<revision>`.
- Ordered build green: annotations → processor → bom → cli, then `example`, `example-multimodule` and `example-multimodule-indexed` all compile against the freshly installed 1.2.1 BOM.
- **No generated guardrail file drifted in any of the three examples.** Worth checking rather than assuming: the processor version feeds `BuildFingerprint`, so 1.2.1 invalidates every consumer's fingerprint and the entire generate phase reruns. It produces identical bytes.
- `mvn verify -Pe2e` green: 158 classes, 1922 tests, with checkstyle, PMD, CPD, SpotBugs and JaCoCo.
- `pre-commit` is not installed on this machine and **did not run**.

## Deliberately left at 1.2.0

Each is exempted by name in `ReleaseScriptCoverageTest`, so the sweep is clean rather than incomplete: `load-tests/` (pinned independently so benchmarks can compare across versions), `docs/proposals/transitive-guardrails.md` (a proposal dated by the release that shipped its feature — rewriting it would make it claim it proposed something that already existed), and the generated `.flattened-pom.xml` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZjwxsH4ixfuzGEd6znBGt
