### PR TITLE
docs: add a Mentioned in Publications section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ matrix is in [USAGE.md](USAGE.md#other-jvm-languages-groovy-scala-clojure).
 - [Advanced Features & Annotation Reference](#-advanced-features--annotation-reference) → full guide in **[USAGE.md](USAGE.md)**
 - [Contributing](#-contributing)
 - [Project Components](#-project-components)
+- [Mentioned in Publications](#-mentioned-in-publications)
 - [License](#-license)
 
 ## 🎯 What is VibeTags?
@@ -909,6 +910,16 @@ Technical reference for the annotation processor internals. Read this before con
 
 ### [.claude/skills/vibetags-usage/SKILL.md](.claude/skills/vibetags-usage/SKILL.md)
 A Claude Code skill that gives your AI assistant a full working knowledge of VibeTags — annotation semantics, valid combinations, processor configuration, and troubleshooting. Activate it in Claude Code with `/vibetags-usage`.
+
+## 📕 Mentioned in Publications
+
+**[Vibe Architecture: Designing, Scaling, and Guardrailing Large-Scale Systems in the Age of AI
+Orchestration](https://www.amazon.com/dp/B0HF3MLBB8)** by Peter Isberg (first edition, 2026).
+
+Chapter 4, "Annotation-Driven Design", uses VibeTags as its worked example: the per-element
+annotation vocabulary, the granular `.claude/rules/` layout, and the scoped-rules index that the
+book reports cutting one real reactor's always-loaded context from 537 to 137 lines. VibeTags also
+appears in the chapters on context budgets, spec-driven development, and multi-agent CI.
 
 ## 💛 Support VibeTags
 


### PR DESCRIPTION
## Why

VibeTags is the worked example in Chapter 4 of *Vibe Architecture*, and nothing in the repository said so. A reader arriving from the book had no way back to the project, and a reader arriving from GitHub had no pointer to the longer argument behind the annotation vocabulary and the scoped-rules index.

## What

A new `## 📕 Mentioned in Publications` section between *Project Components* and *Support VibeTags*, plus the matching table-of-contents entry.

## Provenance of the claims

- Verified against the manuscript's own front matter: title, subtitle, author, "first edition, 2026" (`00_Front_Matter/00_imprint.md`, `00_cover.md`) and the chapter number and title (`01_toc.md`).
- Attributed, not asserted: the 537 to 137 line figure is the book's claim about one reactor, so the README says "the book reports".
- The Amazon link is the canonical `/dp/` form with the search tracking parameters stripped.

## Verification

`ProjectFactsConsistencyTest` (5 tests) and `AnnotationReferenceTest` (4 tests), the two suites that read `README.md`, both pass locally. CI has no link checker, so the URL itself is unvalidated by the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJBcfHNV4TkKHrgUZanvqv
