### PR TITLE
fix: correctness hunt 2026-08-16, five bugs with red-then-green tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Verified by `WriteFileFrontMatterTest` (hand content between header and block, and after it,
   survives) and `RoleBasedGranularEndToEndTest.editingARolesGlobs_reachesTheExistingRuleFilesFrontmatter`,
   both red before the fix.
+- **A departed module's rule files no longer cost the survivors their short-circuit.** 1.2.1
+  started deleting the rule files of a module that left the reactor, by name and straight through
+  `Files.deleteIfExists`, and the write cache went on tracking them. A cached entry whose file is
+  missing means "an output still to be rewritten", so every later build of every surviving module
+  ran the full content build and file compare, over a file no round would ever write again.
+  Deletions now go through `GuardrailFileWriter.deleteIfExists`, which invalidates the entry
+  (and, in dry-run, reports the removal instead of performing it). Verified by
+  `ProjectLifecycleEndToEndTest.moduleRemovedFromTheReactor_doesNotCostTheSurvivorsTheirShortCircuit`,
+  red before the fix; `GuardrailFileWriterLogContractTest` pins the new `delete.commit` /
+  `delete.skip reason=dry-run` events.
 
 ### Added
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A granular rule file's front matter now follows its inputs.** The `globs:` / `paths:` /
+  `applyTo:` list at the top of a rule file is rendered from `.vibetags-roles` (and, for
+  mirrors, `.vibetags-mirror`), but the writer treated the header already on disk as
+  hand-authored and kept it: adding a glob to a role, or a member to an FQN-only role, changed
+  the fingerprint, re-rendered the file, and left its scope exactly as first written. Check mode
+  passed on the stale file for the same reason. A header VibeTags renders is now refreshed like
+  the block; a hand-written header on a file whose renderer emits none is preserved as before.
+  Verified by `WriteFileFrontMatterTest` (hand content between header and block, and after it,
+  survives) and `RoleBasedGranularEndToEndTest.editingARolesGlobs_reachesTheExistingRuleFilesFrontmatter`,
+  both red before the fix.
+
 ### Added
 
 - Repository alignment with the practices taught in *Vibe Architecture* (audit recorded in

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ProjectLifecycleEndToEndTest.moduleRemovedFromTheReactor_doesNotCostTheSurvivorsTheirShortCircuit`,
   red before the fix; `GuardrailFileWriterLogContractTest` pins the new `delete.commit` /
   `delete.skip reason=dry-run` events.
+- **Check mode's orphan sweep follows the same jurisdiction rule as generation.** The #383 fix
+  taught `generateFiles()` that a reactor module round may not sweep the shared root's granular
+  directory, because on a cold clone every sibling's committed rule file is unclaimed. Check mode
+  kept the unconditional sweep, so the same cold-clone module round reported each sibling's rule
+  file as drift: a claim that a normal compile would delete files it leaves alone. `checkFiles()`
+  now sweeps only when the round compiles the root itself, and mirrors the departed-module
+  removal that generation does perform (through the dry-run writer, so the file is named, not
+  touched). The documented cold-clone limitation for merged aggregates is unchanged: build once,
+  then check. Verified by `CheckModeTest.checkMode_onAColdCloneModuleRound_agreesWithGeneration`
+  (red before the fix) and `checkMode_reportsADepartedModulesRuleFileAsDrift` (the bound, kept
+  green through it).
 
 ### Added
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unidentifiable-module warning that runs before generation reads the departed stems, now read
   through `ModuleSidecar.peekAll`, which leaves the file where it is. Verified by
   `CheckModeTest.checkMode_doesNotPruneADepartedModulesSidecar`, red before the fix.
+- **A glob that does not compile in `.vibetags-roles` no longer stops the whole build's output.**
+  `RoleConfig.load` compiled every glob eagerly and let the `PatternSyntaxException` (an unclosed
+  `{` group is the easy typo) escape into the top of the generate phase, where the processor's
+  outer guard downgraded it to a WARNING: no file, sidecar or mirror was written for that build,
+  and nothing said why. A matcher that cannot compile now matches nothing; the unclosed brace
+  still swallows the rest of its own line, and every other line routes as before. Verified by
+  `RoleConfigTest.malformedGlob_isSkipped_notThrown`, an error before the fix.
 
 ### Added
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   then check. Verified by `CheckModeTest.checkMode_onAColdCloneModuleRound_agreesWithGeneration`
   (red before the fix) and `checkMode_reportsADepartedModulesRuleFileAsDrift` (the bound, kept
   green through it).
+- **Check mode no longer prunes a departed module's sidecar.** `ModuleSidecar.readAll` deletes a
+  sidecar whose module directory is gone, and check mode read through it. One check-mode run
+  after a module left the reactor (the first thing CI does) deleted that module's sidecar, the
+  only record of the rule files it wrote, so the next real build had nothing to act on and the
+  departed module's rule files stayed in the repository for good. Check mode, and the
+  unidentifiable-module warning that runs before generation reads the departed stems, now read
+  through `ModuleSidecar.peekAll`, which leaves the file where it is. Verified by
+  `CheckModeTest.checkMode_doesNotPruneADepartedModulesSidecar`, red before the fix.
 
 ### Added
 

--- a/docs/LOAD-BEARING.md
+++ b/docs/LOAD-BEARING.md
@@ -51,7 +51,7 @@ Generated content is written between markers so a file can hold hand-authored co
 - **Hash comments** (.cursorrules, .aiexclude, ignore files): `# VIBETAGS-START` / `# VIBETAGS-END`
 - **No markers** (JSON/TOML config files): complete overwrite
 
-YAML front-matter in `.mdc`/`.md` files is preserved — markers go after the front-matter block. Files written by an older VibeTags (without markers) are migrated on the next compile.
+YAML front-matter in `.mdc`/`.md` files sits before the markers. A hand-written header on a file whose renderer emits none (`CLAUDE.md`, a Junie or Void rules file) is preserved untouched. A header VibeTags renders itself (the `globs:` / `paths:` / `applyTo:` list of a granular rule file, the Claude skill's `name`/`description`) is generated content and is refreshed on every update like the block, so a role that gains a glob or an FQN-only role that gains a member reaches the file's scope (`WriteFileFrontMatterTest`, `RoleBasedGranularEndToEndTest`). Files written by an older VibeTags (without markers) are migrated on the next compile.
 
 ### Output files
 

--- a/docs/PROCESSOR.md
+++ b/docs/PROCESSOR.md
@@ -219,6 +219,14 @@ mvn -B clean compile && mvn -B compile -Dvibetags.check=true
 CI does exactly this — the check step runs after the ordinary build, not instead of it. Single-module
 projects are unaffected: one module is the whole project, so the first compile already sees everything.
 
+The verdict names exactly the files a real round would write or delete, under the same rules. Two of
+those rules matter in a reactor: a module round never sweeps the shared root's granular directory
+for orphans (issue #383, so a cold-clone check no longer lists every sibling's committed rule file
+on top of the merged aggregates), and a module that has left the reactor has its rule files reported
+for removal, because the next real build of any survivor removes them
+(`CheckModeTest.checkMode_onAColdCloneModuleRound_agreesWithGeneration`,
+`checkMode_reportsADepartedModulesRuleFileAsDrift`).
+
 ## Machine-readable lock report (`.vibetags-locks`)
 
 An opt-in pseudo-platform (service key `locks_report`, touch `.vibetags-locks` to enable) that emits

--- a/example-all-tiers/billing/.claude/rules/domain-model.md
+++ b/example-all-tiers/billing/.claude/rules/domain-model.md
@@ -1,5 +1,5 @@
 ---
-paths: ["**/*Entry.java"]
+paths: ["**/*Entry.java", "**/*Rules.java"]
 ---
 
 <!-- VIBETAGS-START -->

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
@@ -1041,7 +1041,10 @@ public class AIGuardrailProcessor extends AbstractProcessor {
         // Same order as generateFiles: the departed stems are read before readAll, which prunes
         // the stale sidecars that are the only record of them.
         Set<String> departedStems = ModuleSidecar.staleGranularStems(root);
-        List<ModuleSidecar> allSidecars = new java.util.ArrayList<>(ModuleSidecar.readAll(root));
+        // peekAll, not readAll: check mode writes nothing, and that includes the pruning of a
+        // stale sidecar — which is the only record of a departed module's rule files, and belongs
+        // to the real build that acts on it.
+        List<ModuleSidecar> allSidecars = new java.util.ArrayList<>(ModuleSidecar.peekAll(root));
         if (collector.anyAnnotationsFound()) {
             boolean replaced = false;
             for (int i = 0; i < allSidecars.size(); i++) {
@@ -1260,7 +1263,9 @@ public class AIGuardrailProcessor extends AbstractProcessor {
         if (moduleIdOverride != null) return;
         if (!ModuleSidecar.isUnidentifiableModule(compilationRoot, root)) return;
         List<String> named = new java.util.ArrayList<>();
-        for (ModuleSidecar existing : ModuleSidecar.readAll(root)) {
+        // A read for a diagnostic, and it runs before generateFiles() reads the departed stems:
+        // pruning here would throw that record away first.
+        for (ModuleSidecar existing : ModuleSidecar.peekAll(root)) {
             if (!existing.getModuleId().equals(moduleId)) {
                 named.add(existing.getModuleId());
             }

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
@@ -1038,6 +1038,9 @@ public class AIGuardrailProcessor extends AbstractProcessor {
         mySidecar.setGranularStems(myStems);
         mySidecar.setElementIds(collector.model().elementIds());
         buildSafetyDigests(activeServices, checkRootRoles).forEach(mySidecar::putIndexDigest);
+        // Same order as generateFiles: the departed stems are read before readAll, which prunes
+        // the stale sidecars that are the only record of them.
+        Set<String> departedStems = ModuleSidecar.staleGranularStems(root);
         List<ModuleSidecar> allSidecars = new java.util.ArrayList<>(ModuleSidecar.readAll(root));
         if (collector.anyAnnotationsFound()) {
             boolean replaced = false;
@@ -1085,7 +1088,18 @@ public class AIGuardrailProcessor extends AbstractProcessor {
             checkGranular.writeAll(built.elementRules, serviceFiles, activeServices, checkRootRoles,
                 ModuleSidecar.mergeGranular(allSidecars)));
         writtenQNames.addAll(ModuleSidecar.granularStemsFrom(allSidecars, moduleId, null));
-        checkGranular.cleanupAll(serviceFiles, activeServices, writtenQNames);
+        // The two removals generateFiles performs, under the same rules, so the verdict names
+        // exactly the files a real round would delete. The orphan sweep is bound by the #383
+        // jurisdiction rule: a module round cannot tell an orphan from a sibling it has not been
+        // shown, and on a cold clone that is every sibling — an unconditional dry-run sweep here
+        // reported all of their committed rule files as drift and failed a healthy build. The
+        // departed-module removal is not bound by it, for the reason given there.
+        if (maySweepRoot(compilationRoot)) {
+            checkGranular.cleanupAll(serviceFiles, activeServices, writtenQNames);
+        }
+        Set<String> orphanedByDeparture = new java.util.LinkedHashSet<>(departedStems);
+        orphanedByDeparture.removeAll(writtenQNames);
+        checkGranular.removeStems(serviceFiles, activeServices, orphanedByDeparture);
 
         // Per-module (nested) output — dry-run so check mode verifies module-scoped files too.
         // Null messager: the summary note would be misleading in a verification pass.
@@ -1152,6 +1166,17 @@ public class AIGuardrailProcessor extends AbstractProcessor {
             }
         }
         return digests;
+    }
+
+    /**
+     * Whether this round may sweep the shared root's granular directories for orphans: only a
+     * round compiling the root itself, never a reactor module round (issue #383). {@code
+     * generateFiles()} carries the same predicate inline, because its body is locked; {@code
+     * CheckModeTest.checkMode_onAColdCloneModuleRound_agreesWithGeneration} is what keeps the two
+     * in step, and the reasoning is at the sweep in {@code generateFiles()}.
+     */
+    private boolean maySweepRoot(Path compilationRoot) {
+        return moduleIdentity == null || compilationRoot.equals(root);
     }
 
     /**

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GranularRulesWriter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GranularRulesWriter.java
@@ -308,14 +308,11 @@ public final class GranularRulesWriter {
                 continue;
             }
             for (String stem : stems) {
-                Path file = dir.resolve(stem + f.extension);
-                try {
-                    if (java.nio.file.Files.deleteIfExists(file)) {
-                        removed.add(stem);
-                    }
-                } catch (java.io.IOException ignored) {
-                    // A rule file we cannot delete stays; the next build tries again. Failing a
-                    // compile over housekeeping would be the larger bug.
+                // Through the writer, never Files.deleteIfExists: the writer invalidates the
+                // cache entry (a recorded file that is missing pins the short-circuit off) and,
+                // in dry-run, reports the removal instead of performing it.
+                if (fileWriter.deleteIfExists(dir.resolve(stem + f.extension))) {
+                    removed.add(stem);
                 }
             }
         }

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailFileWriter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailFileWriter.java
@@ -260,7 +260,8 @@ public final class GuardrailFileWriter {
             if (end == -1) {
                 messager.printMessage(Diagnostic.Kind.WARNING,
                     "VibeTags: malformed markers in " + path + " (no end marker). Preserving content before start marker.");
-                String before = stripLegacyVibeTagsBlock(existing.substring(0, start).stripTrailing());
+                String before = withRenderedFrontMatter(
+                    stripLegacyVibeTagsBlock(existing.substring(0, start).stripTrailing()), frontMatter);
                 String finalContent = (!before.isEmpty() ? before + "\n\n" : "") + wrappedBody + "\n";
                 if (contentMatches(existing, finalContent)) {
                     debug("write.skip file={} reason=identical-bytes markers=malformed", fileName);
@@ -272,7 +273,8 @@ public final class GuardrailFileWriter {
                 return true;
             }
             end += markerEnd.length();
-            String before = stripLegacyVibeTagsBlock(existing.substring(0, start).stripTrailing());
+            String before = withRenderedFrontMatter(
+                stripLegacyVibeTagsBlock(existing.substring(0, start).stripTrailing()), frontMatter);
             String after = existing.substring(end).stripLeading();
 
             StringBuilder sb = new StringBuilder();
@@ -320,7 +322,7 @@ public final class GuardrailFileWriter {
             // Section missing or non-VibeTags file: append at end
             String updated = existing.isEmpty()
                 ? (frontMatter.isEmpty() ? "" : frontMatter + "\n\n") + wrappedBody + "\n"
-                : existing.stripTrailing() + "\n\n" + wrappedBody + "\n";
+                : withRenderedFrontMatter(existing.stripTrailing(), frontMatter) + "\n\n" + wrappedBody + "\n";
             if (contentMatches(existing, updated)) return false;
 
             if (!hasNewRules && !existing.isEmpty()) {
@@ -348,6 +350,39 @@ public final class GuardrailFileWriter {
         writeAndCache(filePath, content, content);
         messager.printMessage(Diagnostic.Kind.NOTE, "VibeTags: Updated " + fileName);
         return true;
+    }
+
+    /**
+     * Puts the front matter this round rendered where the file's current one is.
+     *
+     * <p>A YAML header VibeTags renders — the {@code globs:} / {@code paths:} / {@code applyTo:}
+     * list of a granular rule file, the {@code name}/{@code description} of the Claude skill — is
+     * generated content that the format forces to sit <em>outside</em> the markers, at the top of
+     * the file. It changes when its inputs change: a role in {@code .vibetags-roles} gains a glob,
+     * an FQN-only role gains a member, a mirror adds a target glob. Keeping the on-disk header
+     * across an update therefore froze the rule's scope at the first write while the fingerprint,
+     * the sidecar and check mode all believed the file had been refreshed. So when the rendered
+     * content carries a header and the file's leading block is one, the rendered header replaces
+     * it; anything else before the marker is hand-authored and stays.
+     *
+     * <p>When the renderer emits no header ({@code frontMatter} is empty), a header the file
+     * carries is a hand-written one — CLAUDE.md, a Junie or Void rules file — and is preserved
+     * untouched, as before.
+     *
+     * @param before      the file's content ahead of the start marker (or the whole file when
+     *                    there is none), legacy block already stripped
+     * @param frontMatter the rendered header, {@code ""} when the content has none
+     */
+    private static String withRenderedFrontMatter(String before, String frontMatter) {
+        if (frontMatter.isEmpty() || !before.startsWith("---")) {
+            return before;
+        }
+        int close = before.indexOf("---", 3);
+        if (close == -1) {
+            return before; // an unterminated header is not one we wrote; leave it alone
+        }
+        String rest = before.substring(close + 3).stripLeading();
+        return rest.isEmpty() ? frontMatter : frontMatter + "\n\n" + rest;
     }
 
     /**

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailFileWriter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailFileWriter.java
@@ -641,6 +641,46 @@ public final class GuardrailFileWriter {
         }
     }
 
+    /**
+     * Deletes {@code file} if it exists, keeping the write cache and the dry-run ledger in step.
+     *
+     * <p>Every removal of a file this writer may have recorded goes through here rather than
+     * through {@code Files.deleteIfExists} directly. The cache reads a recorded file that is
+     * missing as an output still to be rewritten and refuses the fingerprint short-circuit until
+     * it is — which, for a file no round will ever write again, is forever. A departed module's
+     * rule files were the case that showed it: deleted by name behind the cache's back, they cost
+     * every later build of the surviving modules a full round. In dry-run the file is left alone
+     * and reported as a change, which is what lets check mode see the deletions a real round
+     * would perform.
+     *
+     * @return {@code true} if the file existed — and, outside dry-run, was deleted
+     */
+    public boolean deleteIfExists(Path file) {
+        if (dryRun) {
+            if (!Files.exists(file)) {
+                return false;
+            }
+            debug("delete.skip file={} reason=dry-run", name(file));
+            dryRunChanges.add(file.toString());
+            return true;
+        }
+        try {
+            if (!Files.deleteIfExists(file)) {
+                return false;
+            }
+            debug("delete.commit file={}", name(file));
+            if (writeCache != null) {
+                writeCache.invalidate(file);
+            }
+            return true;
+        } catch (IOException e) {
+            // A file we cannot delete stays; the next build tries again. Failing a compile over
+            // housekeeping would be the larger bug.
+            debug("delete.skip file={} reason=io-error detail={}", name(file), e.toString());
+            return false;
+        }
+    }
+
     private void scrubGranularFile(Path p) {
         try {
             String content = Files.readString(p, StandardCharsets.UTF_8);

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
@@ -589,6 +589,21 @@ public final class ModuleSidecar {
      * output; the next incremental build picks it up because the sidecar stamp will have changed.
      */
     public static List<ModuleSidecar> readAll(Path root) {
+        return readAll(root, true);
+    }
+
+    /**
+     * {@link #readAll(Path)} without its side effect: a malformed or stale sidecar is left out of
+     * the result but stays on disk. For readers that must not write — check mode above all, whose
+     * promise is that it touches nothing VibeTags manages, and whose pruning of a departed
+     * module's sidecar threw away the only record of the rule files that module wrote, so the
+     * next real build could no longer remove them (see {@link #staleGranularStems}).
+     */
+    public static List<ModuleSidecar> peekAll(Path root) {
+        return readAll(root, false);
+    }
+
+    private static List<ModuleSidecar> readAll(Path root, boolean prune) {
         if (!Files.isDirectory(root)) return new ArrayList<>();
         List<ModuleSidecar> result = new ArrayList<>();
         try (Stream<Path> stream = Files.list(root)) {
@@ -615,7 +630,7 @@ public final class ModuleSidecar {
                           return;
                       }
                       if (s == null) {
-                          tryDelete(p);
+                          if (prune) tryDelete(p);
                           return;
                       }
                       if (s == FUTURE_VERSION) {
@@ -628,7 +643,7 @@ public final class ModuleSidecar {
                       if (!s.modulePath.isEmpty() && !"_root_".equals(s.modulePath)) {
                           Path moduleDir = root.resolve(s.modulePath);
                           if (!Files.isDirectory(moduleDir)) {
-                              tryDelete(p);
+                              if (prune) tryDelete(p);
                               return;
                           }
                       }

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/model/RoleConfig.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/model/RoleConfig.java
@@ -84,8 +84,18 @@ public final class RoleConfig {
                     continue;
                 }
                 if (isGlob(t)) {
+                    Pattern pattern;
+                    try {
+                        pattern = globToRegex(t);
+                    } catch (java.util.regex.PatternSyntaxException malformed) {
+                        // A glob that does not compile (an unclosed brace group is the usual one)
+                        // matches nothing. Throwing here reached the top of the generate phase and
+                        // stopped every output of the build over one typo; the file's other
+                        // matchers are unaffected by it and keep routing.
+                        continue;
+                    }
                     globs.add(t);
-                    globPatterns.add(globToRegex(t));
+                    globPatterns.add(pattern);
                 } else {
                     fqns.add(t);
                 }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/CheckModeTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/CheckModeTest.java
@@ -225,6 +225,36 @@ class CheckModeTest {
         assertTrue(Files.exists(bRule), "reported, not removed: check mode writes nothing");
     }
 
+    /**
+     * Check mode touches nothing VibeTags manages, and the sidecars are the record of the build:
+     * {@code readAll} prunes a sidecar whose module directory is gone, and check mode used to read
+     * through it. One check-mode run after a module left the reactor deleted that module's sidecar,
+     * and with it the only record of the rule files it wrote — so the next real build had nothing
+     * to act on and the departed module's rule files stayed in the repository for good.
+     */
+    @Test
+    void checkMode_doesNotPruneADepartedModulesSidecar(@TempDir Path root) throws Exception {
+        Files.createDirectories(root.resolve(".claude/rules"));
+        compileModule(root, "module-a", "com.example.a.AlphaService", lockedIn("com.example.a", "AlphaService"));
+        compileModule(root, "module-b", "com.example.b.BetaService", lockedIn("com.example.b", "BetaService"));
+        Path bRule = root.resolve(".claude/rules/com-example-b-BetaService.md");
+        Path bSidecar = root.resolve(".vibetags-mod-module-b");
+        assertTrue(Files.exists(bRule) && Files.exists(bSidecar), "precondition: module-b's file and sidecar exist");
+
+        deleteRecursively(root.resolve("module-b"));
+        ProcessorTestHarness.awaitFilesystemTick(root);
+        checkModule(root, "module-a", "com.example.a.AlphaService", lockedIn("com.example.a", "AlphaService"));
+
+        assertTrue(Files.exists(bSidecar),
+            "check mode must not delete the departed module's sidecar: it writes nothing, and the "
+                + "sidecar is the only record of which rule files that module wrote");
+
+        compileModule(root, "module-a", "com.example.a.AlphaService", lockedIn("com.example.a", "AlphaService"));
+        assertFalse(Files.exists(bRule),
+            "the next real build must still be able to remove the departed module's rule file");
+        assertFalse(Files.exists(bSidecar), "and it is the real build that prunes the sidecar");
+    }
+
     // -----------------------------------------------------------------------
     // Unit: dry-run GuardrailFileWriter
     // -----------------------------------------------------------------------

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/CheckModeTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/CheckModeTest.java
@@ -13,8 +13,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -164,6 +166,66 @@ class CheckModeTest {
     }
 
     // -----------------------------------------------------------------------
+    // End-to-end: check mode must reproduce generation's cleanup, no more and no less
+    // -----------------------------------------------------------------------
+
+    /**
+     * A reactor module round may not sweep the shared root's granular directory: on a cold clone
+     * the sidecars are gitignored, so every sibling's committed rule file is unclaimed and a sweep
+     * deletes them (issue #383). Generation learned that rule; check mode kept the unconditional
+     * sweep, so the very same cold-clone round reported every sibling's rule file as drift and
+     * failed a build in which nothing was wrong. A check verdict is only worth anything if it
+     * reproduces generation exactly.
+     */
+    @Test
+    void checkMode_onAColdCloneModuleRound_agreesWithGeneration(@TempDir Path root) throws Exception {
+        Files.createDirectories(root.resolve(".claude/rules"));
+        compileModule(root, "module-a", "com.example.a.AlphaService", lockedIn("com.example.a", "AlphaService"));
+        compileModule(root, "module-b", "com.example.b.BetaService", lockedIn("com.example.b", "BetaService"));
+        Path bRule = root.resolve(".claude/rules/com-example-b-BetaService.md");
+        assertTrue(Files.exists(bRule), "precondition: both modules' rule files exist");
+
+        // Cold clone: no sidecars, no cache — the state a CI runner sees.
+        deleteVibeTagsState(root);
+        compileModule(root, "module-a", "com.example.a.AlphaService", lockedIn("com.example.a", "AlphaService"));
+        assertTrue(Files.exists(bRule),
+            "precondition: generation on a cold clone leaves the sibling's rule file alone (#383)");
+
+        deleteVibeTagsState(root);
+        List<String> errors = errors(checkModule(root, "module-a", "com.example.a.AlphaService",
+            lockedIn("com.example.a", "AlphaService")));
+
+        assertTrue(errors.isEmpty(),
+            "check mode must agree with generation on a cold clone, but reported: " + errors);
+        assertTrue(Files.exists(bRule), "and must not have touched the sibling's file either");
+    }
+
+    /**
+     * The bound on the rule above, kept green through it. A sidecar whose module directory is gone
+     * names the rule files that module wrote, and generation removes those on the next build of any
+     * survivor. Check mode must report that removal as drift, or a departed module's stale rule
+     * files pass check forever.
+     */
+    @Test
+    void checkMode_reportsADepartedModulesRuleFileAsDrift(@TempDir Path root) throws Exception {
+        Files.createDirectories(root.resolve(".claude/rules"));
+        compileModule(root, "module-a", "com.example.a.AlphaService", lockedIn("com.example.a", "AlphaService"));
+        compileModule(root, "module-b", "com.example.b.BetaService", lockedIn("com.example.b", "BetaService"));
+        Path bRule = root.resolve(".claude/rules/com-example-b-BetaService.md");
+        assertTrue(Files.exists(bRule), "precondition: both modules' rule files exist");
+
+        deleteRecursively(root.resolve("module-b"));
+        ProcessorTestHarness.awaitFilesystemTick(root);
+        List<String> errors = errors(checkModule(root, "module-a", "com.example.a.AlphaService",
+            lockedIn("com.example.a", "AlphaService")));
+
+        assertTrue(errors.stream().anyMatch(m -> m.contains(CHECK_FAILED)
+                && m.contains(".claude/rules/com-example-b-BetaService.md")),
+            "generation would remove the departed module's rule file, so check mode must name it: " + errors);
+        assertTrue(Files.exists(bRule), "reported, not removed: check mode writes nothing");
+    }
+
+    // -----------------------------------------------------------------------
     // Unit: dry-run GuardrailFileWriter
     // -----------------------------------------------------------------------
 
@@ -219,6 +281,56 @@ class CheckModeTest {
             .filter(d -> d.getKind() == Diagnostic.Kind.ERROR)
             .map(d -> d.getMessage(null))
             .collect(Collectors.toList());
+    }
+
+    private static String lockedIn(String pkg, String type) {
+        return "package " + pkg + ";\n"
+            + "import se.deversity.vibetags.annotations.AILocked;\n"
+            + "@AILocked(reason = \"" + type + " is load-bearing\")\n"
+            + "public class " + type + " {}\n";
+    }
+
+    /** One module's compile into the shared reactor root, as a reactor pass would do it. */
+    private static void compileModule(Path root, String module, String fqn, String source) throws IOException {
+        moduleHarness(root, module, fqn, source).compile();
+        VibeTagsLogger.shutdown();
+    }
+
+    /** The same round in check mode, returning its diagnostics. */
+    private static List<Diagnostic<? extends JavaFileObject>> checkModule(
+            Path root, String module, String fqn, String source) throws IOException {
+        List<Diagnostic<? extends JavaFileObject>> diags =
+            moduleHarness(root, module, fqn, source).compileReturningDiagnostics(CHECK_OPTION);
+        VibeTagsLogger.shutdown();
+        return diags;
+    }
+
+    private static ProcessorTestHarness moduleHarness(Path root, String module, String fqn, String source)
+            throws IOException {
+        ProcessorTestHarness harness = new ProcessorTestHarness(root, false);
+        Files.createDirectories(root.resolve(module));
+        Files.writeString(root.resolve(module).resolve("pom.xml"),
+            "<project><artifactId>" + module + "</artifactId></project>", StandardCharsets.UTF_8);
+        harness.writeSourceFile(module + "/src/main/java/" + fqn.replace('.', '/') + ".java", source);
+        return harness;
+    }
+
+    /** What a fresh clone lacks: the gitignored sidecars, cache and log. */
+    private static void deleteVibeTagsState(Path root) throws IOException {
+        try (Stream<Path> files = Files.list(root)) {
+            for (Path p : files.filter(f -> f.getFileName().toString().startsWith(".vibetags-")
+                    || f.getFileName().toString().equals("vibetags.log")).toList()) {
+                Files.deleteIfExists(p);
+            }
+        }
+    }
+
+    private static void deleteRecursively(Path dir) throws IOException {
+        try (Stream<Path> files = Files.walk(dir)) {
+            for (Path p : files.sorted(Comparator.reverseOrder()).toList()) {
+                Files.deleteIfExists(p);
+            }
+        }
     }
 
     /** Writes a minimal valid {@code .vibetags-mod-<id>} sidecar with one service body. */

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ProjectLifecycleEndToEndTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ProjectLifecycleEndToEndTest.java
@@ -382,6 +382,46 @@ class ProjectLifecycleEndToEndTest {
     }
 
     /**
+     * And the removal must not cost the survivors their short-circuit. A departed module's rule
+     * files are deleted by name, outside the marker-aware writer, and the write cache went on
+     * tracking them: a cached entry whose file is missing reads as "an output still to be
+     * rewritten", so every later build of the surviving module ran in full, over a file no round
+     * would ever write again. Two rebuilds, as in the steady-state test: the first after the
+     * departure does the removal, and the one after it has nothing left to do.
+     */
+    @Test
+    void moduleRemovedFromTheReactor_doesNotCostTheSurvivorsTheirShortCircuit(@TempDir Path root)
+            throws Exception {
+        Files.createFile(root.resolve("CLAUDE.md"));
+        Files.createDirectories(root.resolve(".claude/rules"));
+        compileModule(root, "module-core", "com.example.core.IrNode",
+            locked("com.example.core", "IrNode", "Core IR node"));
+        compileModule(root, "module-cli", "com.example.cli.Cli",
+            locked("com.example.cli", "Cli", "CLI entry point"));
+        Path cliRule = root.resolve(".claude/rules/com-example-cli-Cli.md");
+        assertTrue(Files.exists(cliRule), "the module's rule file must be generated first");
+
+        deleteRecursively(root.resolve("module-cli"));
+        ProcessorTestHarness.awaitFilesystemTick(root);
+        VibeTagsLogger.shutdown();
+        compileModule(root, "module-core", "com.example.core.IrNode",
+            locked("com.example.core", "IrNode", "Core IR node"));
+        assertFalse(Files.exists(cliRule), "precondition: the departure build removes the rule file");
+
+        Path coreSidecar = root.resolve(".vibetags-mod-module-core");
+        long sidecarMtime = Files.getLastModifiedTime(coreSidecar).toMillis();
+        ProcessorTestHarness.awaitFilesystemTick(root);
+        VibeTagsLogger.shutdown();
+        compileModule(root, "module-core", "com.example.core.IrNode",
+            locked("com.example.core", "IrNode", "Core IR node"));
+
+        assertEquals(sidecarMtime, Files.getLastModifiedTime(coreSidecar).toMillis(),
+            "a rebuild with nothing changed after the departure must short-circuit before the "
+                + "sidecar write. If it does not, the cache is still tracking the rule file the "
+                + "departure build deleted, and it will keep forcing a full round on every build");
+    }
+
+    /**
      * The bound on the rule above: only stems no surviving module claims are removed. A role file
      * written by several modules is shared, so a departure has to rewrite it rather than delete it,
      * or removing one module from a reactor takes its co-authors' guardrails with it.

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/RoleBasedGranularEndToEndTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/RoleBasedGranularEndToEndTest.java
@@ -185,4 +185,30 @@ class RoleBasedGranularEndToEndTest {
         assertTrue(Files.readString(module.resolve(".cursor/rules/api-endpoints.mdc"))
                 .contains("com.example.web.OrderController"));
     }
+
+    /**
+     * The globs a role file declares are what make the editor load it, and they are rendered from
+     * {@code .vibetags-roles}. Editing that config is therefore a change to the rule file, not just
+     * to the config: the fingerprint already notices it (the roles hash is folded in), and the
+     * writer must then let the new front matter through rather than keep the file's old one.
+     */
+    @Test
+    void editingARolesGlobs_reachesTheExistingRuleFilesFrontmatter(@TempDir Path dir) throws Exception {
+        ProcessorTestHarness h = harness(dir, "web = **/*Controller.java\n");
+        h.addSource("com.example.web.OrderController", ORDER_CONTROLLER);
+        h.compile();
+        assertTrue(h.readFile(".cursor/rules/web.mdc").contains("globs: [\"**/*Controller.java\"]"),
+            "precondition: the role file starts out with the role's first glob");
+
+        ProcessorTestHarness.awaitFilesystemTick(dir);
+        Files.writeString(dir.resolve(".vibetags-roles"),
+            "web = **/*Controller.java, **/*Endpoint.java\n", StandardCharsets.UTF_8);
+        h.compile();
+
+        String web = h.readFile(".cursor/rules/web.mdc");
+        assertTrue(web.contains("globs: [\"**/*Controller.java\", \"**/*Endpoint.java\"]"),
+            "a glob added to the role must reach the existing file's front matter, or the rule "
+                + "silently keeps applying to the old set of files:\n" + web);
+        assertTrue(web.contains("com.example.web.OrderController"), "the body must still be there:\n" + web);
+    }
 }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/RoleConfigTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/RoleConfigTest.java
@@ -91,6 +91,28 @@ class RoleConfigTest {
         assertEquals("hooks", roles.roleFor(type("com.example.webhooks.Handler")).orElse(null));
     }
 
+    /**
+     * A glob that does not compile — an unclosed brace group is the easy one to type — used to
+     * throw a {@code PatternSyntaxException} out of {@code load}, which the processor calls at
+     * the top of its generate phase: one typo in {@code .vibetags-roles} silently stopped every
+     * output of that build (files, sidecar, mirrors), downgraded to a WARNING nobody reads. A
+     * matcher that cannot compile matches nothing. The unclosed brace swallows the rest of its
+     * own line (the tokenizer cannot know where the group was meant to end), which is the cost
+     * of the typo; the next line is untouched by it and still routes.
+     */
+    @Test
+    void malformedGlob_isSkipped_notThrown(@TempDir Path dir) throws IOException {
+        RoleConfig roles = write(dir,
+            "api = **/*{Controller,Service.java, **/*Endpoint.java",
+            "models = **/*Entity.java");
+        assertEquals("models", roles.roleFor(type("com.example.data.ProductEntity")).orElse(null),
+            "the line after the typo still routes");
+        assertTrue(roles.roleFor(type("com.example.web.OrderController")).isEmpty(),
+            "the malformed matcher matches nothing rather than something surprising");
+        assertTrue(roles.globsFor("api").isEmpty(),
+            "and it is not written into any rule file's frontmatter either");
+    }
+
     @Test
     void commentsAndBlankLines_ignored(@TempDir Path dir) throws IOException {
         RoleConfig roles = write(dir,

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/WriteFileFrontMatterTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/WriteFileFrontMatterTest.java
@@ -122,4 +122,83 @@ class WriteFileFrontMatterTest {
         assertFalse(result.contains("<!-- VIBETAGS-START -->"),
             "Hash-marker file must not get HTML markers");
     }
+
+    /**
+     * The front matter VibeTags renders is generated content, not a hand-written header: it
+     * carries the {@code globs:} / {@code paths:} / {@code applyTo:} list that decides when the
+     * editor loads the file at all. When the rendered list changes (a role in
+     * {@code .vibetags-roles} gains a glob, an FQN-only role gains a member, a mirror adds a
+     * target glob) the file's own front matter has to follow, or the rule keeps applying to the
+     * old set of files while every other trace of the change says otherwise. Hand-authored lines
+     * around the block stay where they are: they are the content the markers exist to protect.
+     */
+    @Test
+    void mdcFile_update_refreshesRenderedFrontMatter_andKeepsHandContentAroundTheBlock(
+            @TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("web.mdc");
+        String existing =
+            "---\n" +
+            "description: \"AI rules for role web\"\n" +
+            "globs: [\"**/*Controller.java\"]\n" +
+            "alwaysApply: false\n" +
+            "---\n\n" +
+            "Hand note between the header and the block.\n\n" +
+            "<!-- VIBETAGS-START -->\nold rules\n<!-- VIBETAGS-END -->\n\n" +
+            "Hand note after the block.\n";
+        Files.writeString(file, existing, StandardCharsets.UTF_8);
+
+        String rendered =
+            "---\n" +
+            "description: \"AI rules for role web\"\n" +
+            "globs: [\"**/*Controller.java\", \"**/*Endpoint.java\"]\n" +
+            "alwaysApply: false\n" +
+            "---\n\n" +
+            "# Rules for web\n\n## Locked Status\n- **Reason**: refreshed\n";
+
+        AIGuardrailProcessor p = new AIGuardrailProcessor();
+        assertTrue(p.writeFileIfChanged(file.toString(), rendered, true),
+            "a changed front matter is a change to the file");
+        String result = Files.readString(file, StandardCharsets.UTF_8);
+
+        assertTrue(result.startsWith("---\ndescription: \"AI rules for role web\"\n"
+                + "globs: [\"**/*Controller.java\", \"**/*Endpoint.java\"]\nalwaysApply: false\n---\n"),
+            "the rendered front matter must replace the stale one, at the top of the file:\n" + result);
+        assertFalse(result.contains("globs: [\"**/*Controller.java\"]\n"),
+            "the stale glob list must be gone:\n" + result);
+        int frontMatterEnd = result.indexOf("---", 3);
+        int handBefore = result.indexOf("Hand note between the header and the block.");
+        int markerStart = result.indexOf("<!-- VIBETAGS-START -->");
+        int markerEnd = result.indexOf("<!-- VIBETAGS-END -->");
+        int handAfter = result.indexOf("Hand note after the block.");
+        assertTrue(frontMatterEnd < handBefore && handBefore < markerStart,
+            "hand content between the front matter and the block must stay there:\n" + result);
+        assertTrue(markerEnd < handAfter, "hand content after the block must survive:\n" + result);
+        assertTrue(result.contains("refreshed") && !result.contains("old rules"),
+            "the block itself must be refreshed as before:\n" + result);
+    }
+
+    /**
+     * The other half of the rule. A file whose renderer emits no front matter — CLAUDE.md, a
+     * Junie or Void rules file — may carry a hand-written YAML header, and that header is
+     * hand-authored content outside the markers: it must be preserved exactly as before.
+     */
+    @Test
+    void mdFile_update_keepsHandFrontMatter_whenRenderedContentHasNone(@TempDir Path tempDir)
+            throws IOException {
+        Path file = tempDir.resolve("CLAUDE.md");
+        String existing =
+            "---\n" +
+            "title: My project notes\n" +
+            "---\n\n" +
+            "<!-- VIBETAGS-START -->\nold rules\n<!-- VIBETAGS-END -->\n";
+        Files.writeString(file, existing, StandardCharsets.UTF_8);
+
+        AIGuardrailProcessor p = new AIGuardrailProcessor();
+        assertTrue(p.writeFileIfChanged(file.toString(), "# Rules\n- refreshed\n", true));
+        String result = Files.readString(file, StandardCharsets.UTF_8);
+
+        assertTrue(result.startsWith("---\ntitle: My project notes\n---\n"),
+            "a hand-written header the renderer knows nothing about must survive:\n" + result);
+        assertTrue(result.contains("refreshed") && !result.contains("old rules"));
+    }
 }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/internal/GuardrailFileWriterLogContractTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/internal/GuardrailFileWriterLogContractTest.java
@@ -119,6 +119,33 @@ class GuardrailFileWriterLogContractTest {
     }
 
     /**
+     * A removal is a decision like any other. The rule files of a departed module are deleted by
+     * name, and that deletion is what invalidates their cache entries; without the event there is
+     * no way to tell from the log whether a missing file was removed by VibeTags or by hand.
+     */
+    @Test
+    @DisplayName("a deletion is logged as a commit, and a dry-run deletion as a skip with its reason")
+    void deletionsAreLoggedLikeWrites(@TempDir Path dir) throws IOException {
+        Path file = dir.resolve("com-example-Gone.md");
+        Files.writeString(file, HEADER + "\nrule\n");
+
+        GuardrailFileWriter dryRun = new GuardrailFileWriter(HEADER, null, logger, null, true);
+        assertTrue(dryRun.deleteIfExists(file), "dry-run reports the file it would have removed");
+        assertTrue(Files.exists(file), "and leaves it in place");
+        assertTrue(logged("delete.skip file=com-example-Gone.md reason=dry-run"),
+            "the dry-run must say why nothing was deleted: " + events());
+        assertEquals(List.of(file.toString()), dryRun.dryRunChanges(),
+            "check mode reads the removal off the same ledger as the writes");
+
+        GuardrailFileWriter writer = new GuardrailFileWriter(HEADER, null, logger);
+        assertTrue(writer.deleteIfExists(file));
+        assertFalse(Files.exists(file));
+        assertTrue(logged("delete.commit file=com-example-Gone.md"),
+            "a real deletion is a commit event: " + events());
+        assertFalse(writer.deleteIfExists(file), "a second delete of a missing file is a quiet no-op");
+    }
+
+    /**
      * Placeholder integrity, asserted at runtime because nothing can assert it statically.
      *
      * <p>Every event this writer emits goes through {@code debug(String event, Object... args)},


### PR DESCRIPTION
## Why

A correctness hunt under the `correctness-hunt` work order: baseline the suite, hunt with the named lenses, failing test first, one commit per bug. Five bugs, each with a test that was red before its fix and green after; one confirmed bug escalated unfixed because its fix reinterprets persisted baseline keys; a set of suspicions from a lens sweep, unverified and uncommitted.

Baseline before touching anything: `mvn test -Pe2e` from `vibetags/` at `8be75dd`, 1927 tests, 0 failures, 0 errors, 0 skipped, BUILD SUCCESS.

## Bugs fixed (one commit each)

| # | Commit | File | Defect | Failure scenario | Fix |
|---|--------|------|--------|------------------|-----|
| 1 | `1a6fd50` | `GuardrailFileWriter.writeWithMarkers` | The YAML front matter VibeTags renders (`globs:`/`paths:`/`applyTo:`) was never refreshed: the writer rebuilt an existing file from the header on disk and discarded the rendered one. Check mode passed on the stale file for the same reason. | `web = **/*Controller.java` in `.vibetags-roles`, compile, add `, **/*Endpoint.java`, compile again: fingerprint changes, file is re-rendered, `.cursor/rules/web.mdc` still says `globs: ["**/*Controller.java"]`. Same for an FQN-only role gaining a member (derived globs) and a mirror gaining a target glob. | When the rendered content carries a header and the file's leading block is one, the rendered header replaces it (marker, malformed-marker and append branches, so the file does not flip between compiles). Hand content between header and block, and after the block, untouched. A hand-written header on a file whose renderer emits none (CLAUDE.md, Junie, Void) is preserved as before. |
| 2 | `e792318` | `GranularRulesWriter.removeStems` | Departed-module rule files (1.2.1) were deleted through `Files.deleteIfExists`, behind the write cache. A cached entry whose file is missing means "output still to be rewritten", so every later build of every surviving module ran in full, forever. | Two-module reactor, `.claude/rules` at the root, delete module B, rebuild A (removes B's rule file), rebuild A unchanged: no short-circuit; A's sidecar rewritten on every build. | Deletions go through new `GuardrailFileWriter.deleteIfExists`: invalidates the cache entry, logs `delete.commit`, in dry-run records the path (`delete.skip reason=dry-run`) so check mode can see removals. |
| 3 | `acca88f` | `AIGuardrailProcessor.checkFiles` | The #383 jurisdiction rule (a module round never sweeps the shared root's granular dir) reached `generateFiles()` only; check mode kept the unconditional `cleanupAll`, so a cold-clone module round reported every sibling's committed rule file as drift, a claim that a compile would delete files it leaves alone. | Same reactor, delete the gitignored `.vibetags-*` state, run `-Avibetags.check=true` on module A only: `check failed, 1 file out of date: .claude/rules/com-example-b-BetaService.md`. Generation on the same state touches nothing. | `checkFiles()` sweeps under the same predicate (private helper; `generateFiles()` is locked and keeps its inline copy) and mirrors the departed-module removal through the dry-run writer, so a departed module's rule files are still named as drift. Departed stems read before `readAll`, same order as generation. The documented cold-clone limitation for merged aggregates is unchanged. |
| 4 | `70c6681` | `AIGuardrailProcessor.checkFiles`, `ModuleSidecar` | Check mode read sidecars through `readAll`, which prunes a sidecar whose module directory is gone. One check-mode run after a module departure deleted the only record of that module's rule files; the next real build could no longer remove them. | Delete module B, run check mode on A first (what CI does), then a real build of A: `.vibetags-mod-module-b` gone after the check, B's rule file stays forever. | `ModuleSidecar.peekAll` (readAll without the pruning side effect), used by `checkFiles()` and by `warnIfModuleUnidentifiable()`, which `generateFiles()` calls before it reads the departed stems. |
| 5 | `bc8e404` | `RoleConfig.load` | Every glob compiled eagerly; a `PatternSyntaxException` (unclosed `{`) escaped to the top of the generate phase and the outer guard downgraded it to a WARNING: that build wrote no file, sidecar or mirror. | `api = **/*{Controller,Service.java` in `.vibetags-roles`: `PatternSyntaxException: Unclosed group`, all output silently off. | A matcher that cannot compile matches nothing and is dropped; the unclosed brace still swallows the rest of its own line, every other line routes. |

Tests, all in the existing suites and style (`@Tag("e2e")` classes where they already were): `WriteFileFrontMatterTest` (+2), `RoleBasedGranularEndToEndTest` (+1), `ProjectLifecycleEndToEndTest` (+1), `GuardrailFileWriterLogContractTest` (+1, pins `delete.commit`/`delete.skip reason=dry-run`), `CheckModeTest` (+3), `RoleConfigTest` (+1). Each commit message names which of its assertions were red before the fix.

## Escalated, confirmed, not fixed (data-meaning change)

**Enum constants get a bare-name element path, so two enums' `ACTIVE` are one element.** `ElementNaming.elementPath` prepends the enclosing type only for `FIELD | METHOD | CONSTRUCTOR`; `ENUM_CONSTANT` (and `RECORD_COMPONENT`) fall through to `element.toString()`. Reproduced with a probe (not committed): `enum Status { @AILocked ACTIVE }` and `enum Mode { @AILocked ACTIVE }` in one compile render `<file path="ACTIVE">` once; the second constant's guardrail is dropped from every output (`TaggedElement.equals` is path+kind, buckets are sets), and the enforcement key `locked` + tab + `ACTIVE` collides too. The fix is one condition in `ElementNaming` (treat `ENUM_CONSTANT` and `RECORD_COMPONENT` like `FIELD`, in `elementPath` and `displayName`), but it changes the keys already persisted in a consumer's `.vibetags-baseline` and the paths in `.vibetags-locks` for any annotated enum constant: an existing `ACTIVE` line becomes "approved but absent" on the next enforcing build. Under the hunt rules that is a compatibility decision, so it is handed over here rather than committed. Recommended: apply the fix in a minor release and note in the changelog that consumers with guardrails on enum constants run `-Avibetags.baseline.update=true` once.

## Suspicions, unresolved

From a lens sweep of `MirrorWriter`, `MirrorConfig`, `RoleConfig`, `EnforcementBaseline`, `GuardrailEnforcer`, `ElementSignature`. Read, not reproduced; no test, so none is counted:

- `MirrorWriter:95-101` with `GuardrailFileWriter.cleanupGranularDirectory(dir, ext, exclude, filePrefix)`: the mirror cleanup prefix is `mirrored-` + moduleId + `-`, and module ids keep hyphens, so module `payments` cleaning its own mirrors matches `mirrored-payments-api-*` written by module `payments-api` and scrubs them (`siblingMirrors_doNotCleanUpEachOther` uses `app-fhe` and `app-runtime`, which are not prefixes of each other). Held back: the fix is either a delimiter change (renames files already on disk) or a sibling-aware exclusion; both are compatibility calls.
- `MirrorWriter:76`: mirrors key on `computeModuleId(moduleRoot, root)`, not the source-set-scoped id sidecars use, so a test-compile round of the same module (when the processor runs in it, e.g. under `.vibetags-transitive`) writes one stem and cleans up the main round's mirrors. Issue #330's shape, for mirrors.
- `EnforcementBaseline:133-136`: `-Avibetags.baseline.update=true` with a family subset removes every line of the module and re-adds only the selected families; a later `-Avibetags.enforce=all` then passes vacuously for the erased ones. May be the intended trade-off.
- `MirrorWriter:71-84`: mirrored files have no cleanup owner once the mirror config is removed, the module excluded, or the source module renamed.
- `RoleConfig:185-188` with `GranularRulesWriter.defaultGlob`: nested types reconstruct a source path that does not exist (`FooController/Request.java`, glob `**/Request.java`), so their rule file never loads by path scoping. May be an accepted limitation.
- `RoleConfig:93-94,131-138`: duplicate role names on two lines merge members into one file whose frontmatter carries only the first line's globs.
- Low: a BOM on the first line of `.vibetags-roles` or `.vibetags-mirror` survives `trim()`; `sanitizeId` maps distinct non-ASCII module names to the same `__`; `EnforcementBaseline.update` is an unlocked read-modify-write under `mvn -T`.

## Verification

- [x] `mvn test -Pe2e` from `vibetags/` on the finished branch: 1936 tests, 0 failures, 0 errors, 0 skipped, BUILD SUCCESS (151 classes; the baseline was 1927 at `8be75dd`)
- [x] `mvn clean compile -Pself-annotate -Dvibetags.selfcheck=true` on the finished branch: exit 0, `git status` clean afterwards (this repo's own generated files unchanged)
- [x] `example-multimodule`, `example-multimodule-indexed`, `example-all-tiers`: `mvn clean compile` then `-Dvibetags.check=true`, locally on the finished branch: all three build and check green (exit 0). The all-tiers build regenerated one committed file, `billing/.claude/rules/domain-model.md`, whose `paths:` had frozen at `**/*Entry.java` while `.vibetags-roles` says `**/*Entry.java, **/*Rules.java`: bug 1 in this repo's own example, committed as `d629d84`
- [x] `pre-commit run --all-files` after `git add`: passed (gitleaks, end-of-file-fixer, trailing-whitespace) (checkstyle hook skipped locally, it needs Docker; the Maven checkstyle gate in CI covers it)
- [x] Docs updated in this PR: `docs/CHANGELOG.md` (Unreleased, Fixed, five entries), `docs/LOAD-BEARING.md` (front-matter rule), `docs/PROCESSOR.md` (check-mode cleanup rules)
- Not run: the consumer regression suite (`consumer-sweep.sh`). Nothing here changes an annotation or a public API; bug 1 changes what a rebuild may write for a consumer whose role globs drifted, which is the correction landing.

## Provenance and prompt lineage

- Author: agent (Claude Fable 5), not yet human-reviewed
- Session: https://claude.ai/code/session_017dzgbxavEPwuqmrDvf3AxG
- Load-bearing intent: "go on a bughunt and write tests to prove it both not working and when it is fixed", executed under `.claude/skills/correctness-hunt`; mid-hunt: "continue but dont waste too many tokens fix the bugs you found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dzgbxavEPwuqmrDvf3AxG
