### PR TITLE
chore: bump every third-party pin to its latest stable release, plus a bump-dependencies script and skill

### DIFF
--- a/.claude/skills/bump-dependencies/SKILL.md
+++ b/.claude/skills/bump-dependencies/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: bump-dependencies
+description: Bump every third-party dependency, plugin and toolchain pin in VibeTags to its latest stable release, mirror the pins Gradle cannot inherit, verify with the real gates, and open the PR. Use when the user says "bump dependencies", "update dependencies", "dependency update", "upgrade deps", "are we on the latest versions", or before a release.
+---
+
+# Bump dependencies
+
+Every third-party version lives once, as a `<name.version>` property in
+`vibetags-parent/pom.xml`; the managed poms inherit it and `BuildVersionParityTest` fails
+the build if a literal creeps back in or a Gradle coordinate drifts. What that test cannot
+see is whether the pinned version is *current*, which is what this skill is for.
+
+## Step 1 - Branch, then report
+
+```bash
+git fetch origin && git checkout -b chore/bump-dependencies-$(date +%F) origin/main
+scripts/bump-dependencies.sh            # read-only; add --include-prereleases to see betas
+```
+
+The script prints one line per property with its Maven Central latest, then the toolchains
+pinned outside the parent (Gradle wrapper, Kotlin, Groovy, Scala 2.13). It exits 2 if the
+parent gains a `*.version` property the script has no Maven Central path for: add the path
+to its `PINS` table in the same change, so the report can never silently go stale.
+
+## Step 2 - Decide
+
+- Apply stable releases only. Never an alpha, beta, milestone (`M1`), RC or `-ea`, even
+  when Maven Central marks it `<latest>`; the report already hides them by default.
+- Read the release notes of anything with a major bump before applying it. Plugins that
+  change how the build runs (compiler, surefire, enforcer, spotbugs, pmd, error-prone,
+  nullaway) can turn a green build red for reasons unrelated to the code; that is not a
+  reason to skip them, it is a reason to run the full gates below.
+- Kotlin: `example-kotlin` uses kapt; a Kotlin bump is verified by that example's Gradle
+  build, nothing less.
+
+## Step 3 - Apply, including the mirrors
+
+Edit the property in `vibetags-parent/pom.xml`. Then the places that cannot inherit it:
+
+| Pin | Also lives in |
+|-----|---------------|
+| `junit.version`, `junit.platform.version`, `mockito.version`, `archunit.version`, `async-test-lib.version`, `snakeyaml.version`, `logback.version`, `slf4j.version`, `jspecify.version` | `vibetags/build.gradle` (coordinates; `BuildVersionParityTest` enforces) |
+| `pmd.version` | `toolVersion` in `vibetags/build.gradle` and `vibetags-annotations/build.gradle` (enforced) |
+| `maven-compiler-plugin.version` | literals in `example/pom.xml`, `example-multimodule/pom.xml`, `example-multimodule-indexed/pom.xml`, `example-all-tiers/pom.xml`, `tools/demo/pom.xml` (consumer poms; keep them in step) |
+| Gradle wrapper | `gradle/wrapper/gradle-wrapper.properties` in `vibetags`, `vibetags-annotations`, `example`, `example-kotlin`, `example-groovy`, `example-scala`; the version named in `docs/DEPENDENCIES.md` |
+| Kotlin | `example-kotlin/build.gradle.kts` (`jvm` and `kapt`), the snippets in `README.md` and `example-kotlin/README.md` |
+| Groovy, Scala | `example-groovy/build.gradle`, `example-scala/build.gradle` (Scala stays on the 2.13 line: the example is about Java-only support) |
+| pre-commit hook revs | `python -m pre_commit autoupdate`; the `checkstyle` hook runs in Docker, so unless Docker is available revert its rev and say so - an unverifiable bump is not a verified one |
+
+Never touch `<revision>`: that is the VibeTags release version, owned by `scripts/set-version.sh`
+and the `release` skill.
+
+## Step 4 - Verify with the gates CI runs
+
+From the repo root, in this order (each depends on the previous install):
+
+```bash
+(cd vibetags-annotations && mvn -B install -DskipTests)
+(cd vibetags && mvn -B clean install -Pe2e)          # the whole suite; BuildVersionParityTest is in it
+(cd vibetags-bom && mvn -B install) && (cd vibetags-cli && mvn -B install)
+(cd load-tests && mvn -B test-compile)
+(cd vibetags && ./gradlew clean compileTestJava --no-daemon)   # the Gradle side resolves the new pins
+(cd example-kotlin && ./gradlew clean build --no-daemon)       # kapt against the new Kotlin
+(cd example-groovy && ./gradlew clean build --no-daemon)
+(cd example-scala && ./gradlew clean build --no-daemon)
+(cd example && ./gradlew clean build --no-daemon)
+git add -A && SKIP=checkstyle python -m pre_commit run --all-files
+```
+
+Report each result as passed, failed (with the output) or not run. A Gradle build that
+was not run because a toolchain was missing is "not run", never "passed". A tool bump that
+turns a static-analysis gate red may be the tool, not the code: rerun on the JDK CI uses
+before concluding a defect.
+
+## Step 5 - Record and hand over
+
+- `docs/CHANGELOG.md`, under `[Unreleased]` / `Changed`: one entry listing every pin that
+  moved, old and new, and which gates verified it.
+- Commit, push, open the PR with the report output and the verification list in the body,
+  then follow CI until it is green. Do not merge.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,11 @@ repos:
   hooks:
   - id: checkstyle
 - repo: https://github.com/gitleaks/gitleaks
-  rev: v8.16.3
+  rev: v8.30.0
   hooks:
   - id: gitleaks
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v6.0.0
   hooks:
   # The code-karta SVGs under docs/diagrams/codekarta/ are generator output, byte for byte,
   # and the benchmark logs under load-tests/results/ are frozen measurement records.

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ Kotlin classes and functions unchanged. VibeTags runs under [kapt](https://kotli
 
 ```kotlin
 plugins {
-    kotlin("jvm") version "2.3.21"
-    kotlin("kapt") version "2.3.21"
+    kotlin("jvm") version "2.4.10"
+    kotlin("kapt") version "2.4.10"
 }
 
 dependencies {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Every third-party pin moved to its latest stable release** (2026-08-16), the rest were
+  already current: JUnit 6.1.2 to 6.1.3 (Jupiter and Platform), Logback 1.6.1 to 1.6.3,
+  async-test-lib 1.9.2 to 1.9.3, maven-enforcer-plugin 3.6.0 to 3.6.3, Gradle wrapper 9.6.1 to
+  9.7.0 in all six wrappers, Kotlin 2.3.21 to 2.4.10 in `example-kotlin` and the README
+  snippets, Groovy 5.0.8 to 5.1.0 in `example-groovy`, pre-commit hooks gitleaks v8.16.3 to
+  v8.30.0 and pre-commit-hooks v4.4.0 to v6.0.0 (`pre-commit-java` left at v0.2.4: its
+  checkstyle hook runs in Docker and could not be verified here). Pre-releases on Maven Central
+  (maven-compiler-plugin 4.0.0-beta-4, maven-surefire-plugin 3.6.0-M1, slf4j 2.1.0-alpha1,
+  maven-jar/source-plugin 4.0.0-beta-1) were deliberately not applied. Verified by the whole
+  suite (`mvn clean install -Pe2e`, 1936 tests), the bom, cli and load-tests builds, the Gradle
+  build of `vibetags`, and the Gradle builds of `example`, `example-kotlin` (kapt),
+  `example-groovy` and `example-scala`.
+- **`scripts/bump-dependencies.sh` and the `bump-dependencies` skill.** The script reports every
+  parent-pom property against Maven Central (stable releases only unless asked), plus the Gradle
+  wrapper, Kotlin, Groovy and Scala pins, and fails if the parent gains a version property it has
+  no path for. The skill is the procedure around it: what mirrors each pin, which gates verify a
+  bump, and what to hand over.
+
 ### Fixed
 
 - **A granular rule file's front matter now follows its inputs.** The `globs:` / `paths:` /

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -97,7 +97,7 @@ so what consumers download is self-contained.
 - **GitHub Actions** are pinned to commit SHAs, not tags, with the human-readable version in a
   trailing comment. Dependabot proposes the bumps. Pinning is what the OSSF Scorecard
   Pinned-Dependencies check wants, and it is also the only form that cannot be moved under you.
-- **Gradle wrapper**, `gradle-9.6.1-bin.zip` in three subprojects. The checked-in
+- **Gradle wrapper**, `gradle-9.7.0-bin.zip` in three subprojects. The checked-in
   `gradle-wrapper.jar` files are validated against Gradle's published checksums by
   `.github/workflows/gradle-wrapper-validation.yml`, which must run on every push to main for
   Scorecard's Binary-Artifacts check to accept them.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -162,6 +162,12 @@ The `consumer-regression-suite` skill drives this and covers how to read the res
 particular, that a failure is not a regression until it has been shown to pass on the
 consumer's existing pinned version.
 
+While the tree is being prepared, `scripts/bump-dependencies.sh` reports which third-party
+pins in `vibetags-parent/pom.xml` (and the Gradle wrapper, Kotlin, Groovy and Scala pins in the
+examples) have a newer stable release. Applying them is its own PR, before the release branch,
+driven by the `bump-dependencies` skill; a release should not be the first build on a new
+plugin version.
+
 ### 1. Prepare the release
 
 Create a new branch from `main` (or your default branch):

--- a/example-groovy/build.gradle
+++ b/example-groovy/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.apache.groovy:groovy:5.0.8'
+    implementation 'org.apache.groovy:groovy:5.1.0'
 
     // BOM is the single source of truth for vibetags-* versions.
     implementation platform('se.deversity.vibetags:vibetags-bom:1.2.1')

--- a/example-groovy/gradle/wrapper/gradle-wrapper.properties
+++ b/example-groovy/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/example-kotlin/README.md
+++ b/example-kotlin/README.md
@@ -19,8 +19,8 @@ directory (`CLAUDE.md`, `.cursorrules`) are regenerated on every build.
 
 ```kotlin
 plugins {
-    kotlin("jvm") version "2.3.21"
-    kotlin("kapt") version "2.3.21"
+    kotlin("jvm") version "2.4.10"
+    kotlin("kapt") version "2.4.10"
 }
 
 dependencies {

--- a/example-kotlin/build.gradle.kts
+++ b/example-kotlin/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "2.3.21"
-    kotlin("kapt") version "2.3.21"
+    kotlin("jvm") version "2.4.10"
+    kotlin("kapt") version "2.4.10"
 }
 
 group = "se.deversity.vibetags.example"

--- a/example-kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/example-kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/example-scala/gradle/wrapper/gradle-wrapper.properties
+++ b/example-scala/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/example/gradle/wrapper/gradle-wrapper.properties
+++ b/example/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/scripts/bump-dependencies.sh
+++ b/scripts/bump-dependencies.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Reports every third-party version pin in this repository that has a newer stable release.
+#
+# Read-only: it changes nothing. Applying, verifying and the places each pin is mirrored are
+# in .claude/skills/bump-dependencies/SKILL.md, which is the procedure this script serves.
+#
+#   scripts/bump-dependencies.sh                       # stable releases only
+#   scripts/bump-dependencies.sh --include-prereleases # also alpha/beta/M/RC (never applied by default)
+#
+# Every version pin lives in vibetags-parent/pom.xml as a <name.version> property, so the table
+# below maps each property to the Maven Central path whose maven-metadata.xml is authoritative.
+# The versions-maven-plugin was tried first and cannot link the properties that only appear in
+# plugin configuration (error-prone, nullaway, findsecbugs, pitest-junit5), so the table is the
+# source of truth and the script fails loudly if the pom gains a property the table lacks.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PARENT="$ROOT/vibetags-parent/pom.xml"
+INCLUDE_PRE=0
+[ "${1:-}" = "--include-prereleases" ] && INCLUDE_PRE=1
+
+# property → Maven Central group/artifact path
+PINS="
+jspecify.version                        org/jspecify/jspecify
+slf4j.version                           org/slf4j/slf4j-api
+logback.version                         ch/qos/logback/logback-classic
+junit.version                           org/junit/jupiter/junit-jupiter
+junit.platform.version                  org/junit/platform/junit-platform-launcher
+mockito.version                         org/mockito/mockito-core
+archunit.version                        com/tngtech/archunit/archunit-junit5
+async-test-lib.version                  se/deversity/async-test-lib/async-test-lib
+snakeyaml.version                       org/yaml/snakeyaml
+jmh.version                             org/openjdk/jmh/jmh-core
+maven-compiler-plugin.version           org/apache/maven/plugins/maven-compiler-plugin
+maven-surefire-plugin.version           org/apache/maven/plugins/maven-surefire-plugin
+maven-jar-plugin.version                org/apache/maven/plugins/maven-jar-plugin
+maven-source-plugin.version             org/apache/maven/plugins/maven-source-plugin
+maven-javadoc-plugin.version            org/apache/maven/plugins/maven-javadoc-plugin
+maven-shade-plugin.version              org/apache/maven/plugins/maven-shade-plugin
+exec-maven-plugin.version               org/codehaus/mojo/exec-maven-plugin
+flatten-maven-plugin.version            org/codehaus/mojo/flatten-maven-plugin
+maven-pmd-plugin.version                org/apache/maven/plugins/maven-pmd-plugin
+pmd.version                             net/sourceforge/pmd/pmd-java
+maven-checkstyle-plugin.version         org/apache/maven/plugins/maven-checkstyle-plugin
+spotbugs-maven-plugin.version           com/github/spotbugs/spotbugs-maven-plugin
+maven-enforcer-plugin.version           org/apache/maven/plugins/maven-enforcer-plugin
+findsecbugs-plugin.version              com/h3xstream/findsecbugs/findsecbugs-plugin
+jacoco-maven-plugin.version             org/jacoco/jacoco-maven-plugin
+pitest-maven.version                    org/pitest/pitest-maven
+pitest-junit5-plugin.version            org/pitest/pitest-junit5-plugin
+error-prone.version                     com/google/errorprone/error_prone_core
+nullaway.version                        com/uber/nullaway/nullaway
+cyclonedx-maven-plugin.version          org/cyclonedx/cyclonedx-maven-plugin
+central-publishing-maven-plugin.version org/sonatype/central/central-publishing-maven-plugin
+maven-gpg-plugin.version                org/apache/maven/plugins/maven-gpg-plugin
+"
+
+prop() { sed -n "s:.*<$1>\(.*\)</$1>.*:\1:p" "$PARENT" | head -n1; }
+
+# Newest version listed on Maven Central, pre-releases dropped unless asked for. The metadata
+# lists versions in publication order, so the last surviving line is the newest.
+latest() {
+  local versions
+  versions="$(curl -sf "https://repo1.maven.org/maven2/$1/maven-metadata.xml" \
+    | grep -o '<version>[^<]*</version>' | sed 's/<[^>]*>//g')" || { echo "?"; return; }
+  if [ "$INCLUDE_PRE" = 0 ]; then
+    versions="$(printf '%s\n' "$versions" | grep -viE -- '-(alpha|beta|rc|m|ea|cr|pre|snapshot)[-.]?[0-9]*$' || true)"
+  fi
+  printf '%s\n' "$versions" | tail -n1
+}
+
+updates=0
+printf '%-40s %-12s %-12s\n' "property" "pinned" "latest"
+while read -r name path; do
+  [ -z "$name" ] && continue
+  current="$(prop "$name")"
+  if [ -z "$current" ]; then
+    echo "ERROR: $name is in this script's table but not in $PARENT" >&2; exit 2
+  fi
+  newest="$(latest "$path")"
+  if [ "$newest" != "$current" ] && [ "$newest" != "?" ]; then
+    printf '%-40s %-12s %-12s  <- update\n' "$name" "$current" "$newest"; updates=$((updates + 1))
+  else
+    printf '%-40s %-12s %-12s\n' "$name" "$current" "$newest"
+  fi
+done <<< "$PINS"
+
+# A property added to the pom but not to the table would otherwise never be reported.
+for p in $(grep -o '<[a-zA-Z0-9.-]*\.version>' "$PARENT" | tr -d '<>' | sort -u); do
+  if ! grep -q "^$p " <<< "$PINS"; then
+    echo "ERROR: $PARENT declares $p but this script has no Maven Central path for it" >&2; exit 2
+  fi
+done
+
+echo
+echo "Toolchains pinned outside the parent pom:"
+wrapper="$(sed -n 's:.*gradle-\(.*\)-bin.zip:\1:p' "$ROOT/vibetags/gradle/wrapper/gradle-wrapper.properties")"
+gradle_now="$(curl -sf https://services.gradle.org/versions/current | sed -n 's|.*"version" : "\([^"]*\)".*|\1|p')"
+printf '%-40s %-12s %-12s%s\n' "gradle wrapper (6 files)" "$wrapper" "$gradle_now" "$([ "$wrapper" != "$gradle_now" ] && echo '  <- update')"
+kotlin="$(sed -n 's:.*kotlin("jvm") version "\([^"]*\)".*:\1:p' "$ROOT/example-kotlin/build.gradle.kts")"
+kotlin_now="$(latest org/jetbrains/kotlin/kotlin-stdlib)"
+printf '%-40s %-12s %-12s%s\n' "kotlin (example-kotlin + README snippets)" "$kotlin" "$kotlin_now" "$([ "$kotlin" != "$kotlin_now" ] && echo '  <- update')"
+groovy="$(sed -n "s|.*org.apache.groovy:groovy:\([^']*\)'.*|\1|p" "$ROOT/example-groovy/build.gradle")"
+groovy_now="$(latest org/apache/groovy/groovy)"
+printf '%-40s %-12s %-12s%s\n' "groovy (example-groovy)" "$groovy" "$groovy_now" "$([ "$groovy" != "$groovy_now" ] && echo '  <- update')"
+scala="$(sed -n "s|.*org.scala-lang:scala-library:\([^']*\)'.*|\1|p" "$ROOT/example-scala/build.gradle")"
+scala_now="$(curl -sf https://repo1.maven.org/maven2/org/scala-lang/scala-library/maven-metadata.xml | grep -o '<version>2\.13\.[0-9]*</version>' | sed 's/<[^>]*>//g' | tail -n1)"
+printf '%-40s %-12s %-12s%s\n' "scala 2.13 line (example-scala)" "$scala" "$scala_now" "$([ "$scala" != "$scala_now" ] && echo '  <- update')"
+echo
+echo "pre-commit hook revs: run 'python -m pre_commit autoupdate' (no dry-run exists); the checkstyle"
+echo "hook needs Docker to verify, so revert its rev unless you can run it."
+echo
+echo "$updates Maven property update(s) available. Applying: .claude/skills/bump-dependencies/SKILL.md"

--- a/vibetags-annotations/gradle/wrapper/gradle-wrapper.properties
+++ b/vibetags-annotations/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -80,15 +80,15 @@
         <!-- Third-party runtime/compile dependencies -->
         <jspecify.version>1.0.1</jspecify.version>
         <slf4j.version>2.0.18</slf4j.version>
-        <logback.version>1.6.1</logback.version>
+        <logback.version>1.6.3</logback.version>
 
         <!-- Test dependencies. Keep in step with vibetags/build.gradle and
              load-tests/pom.xml; BuildVersionParityTest enforces it. -->
-        <junit.version>6.1.2</junit.version>
-        <junit.platform.version>6.1.2</junit.platform.version>
+        <junit.version>6.1.3</junit.version>
+        <junit.platform.version>6.1.3</junit.platform.version>
         <mockito.version>5.23.0</mockito.version>
         <archunit.version>1.5.0</archunit.version>
-        <async-test-lib.version>1.9.2</async-test-lib.version>
+        <async-test-lib.version>1.9.3</async-test-lib.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <jmh.version>1.37</jmh.version>
 
@@ -107,7 +107,7 @@
         <pmd.version>7.26.0</pmd.version>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
         <spotbugs-maven-plugin.version>4.10.3.0</spotbugs-maven-plugin.version>
-        <maven-enforcer-plugin.version>3.6.0</maven-enforcer-plugin.version>
+        <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
         <findsecbugs-plugin.version>1.14.0</findsecbugs-plugin.version>
         <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
         <pitest-maven.version>1.25.9</pitest-maven.version>

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -85,12 +85,12 @@ dependencies {
 
     // Logging: SLF4J API + Logback file appender for vibetags.log
     implementation 'org.slf4j:slf4j-api:2.0.18'
-    implementation 'ch.qos.logback:logback-classic:1.6.1'
+    implementation 'ch.qos.logback:logback-classic:1.6.3'
 
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.5.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter:6.1.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter:6.1.3'
     // Concurrency-test harness, matching pom.xml. Resolves from Maven Central like any other dep.
-    testImplementation 'se.deversity.async-test-lib:async-test-lib:1.9.2'
+    testImplementation 'se.deversity.async-test-lib:async-test-lib:1.9.3'
     testImplementation 'org.mockito:mockito-core:5.23.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.23.0'
     // Test-only, matching pom.xml. The processor writes six YAML documents but must not gain a
@@ -99,7 +99,7 @@ dependencies {
     // right" is not the property that matters - "the tool reading it sees every module's
     // guardrails" is, and only a parser shows that.
     testImplementation 'org.yaml:snakeyaml:2.6'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.3'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/vibetags/gradle/wrapper/gradle-wrapper.properties
+++ b/vibetags/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
## Why

Every third-party pin in the repository, moved to its latest stable release in one PR, and a script plus skill so the next bump is a report and a procedure rather than a hunt through the poms.

Applied: JUnit 6.1.2 to 6.1.3 (Jupiter and Platform), Logback 1.6.1 to 1.6.3, async-test-lib 1.9.2 to 1.9.3, maven-enforcer-plugin 3.6.0 to 3.6.3, Gradle wrapper 9.6.1 to 9.7.0 (six wrappers), Kotlin 2.3.21 to 2.4.10 (`example-kotlin` and the README snippets), Groovy 5.0.8 to 5.1.0, pre-commit hooks gitleaks v8.16.3 to v8.30.0 and pre-commit-hooks v4.4.0 to v6.0.0. Every other parent-pom property (28 of 32) was already at its latest release; the report output is below.

Not applied, on purpose: pre-releases Maven Central marks as latest (maven-compiler-plugin 4.0.0-beta-4, maven-surefire-plugin 3.6.0-M1, slf4j 2.1.0-alpha1, maven-jar/source-plugin 4.0.0-beta-1), and pre-commit-java v0.6.37, whose checkstyle hook runs in Docker and could not be verified here (unverifiable is not verified).

New: `scripts/bump-dependencies.sh` (read-only report: each parent property against Maven Central, stable only unless `--include-prereleases`, plus the wrapper, Kotlin, Groovy and Scala 2.13 pins; exits 2 if the parent gains a `*.version` property it has no path for) and `.claude/skills/bump-dependencies/SKILL.md` (mirrors per pin, the gates, hand-over). `docs/RELEASING.md` step 0 points at both. The versions-maven-plugin was tried first and cannot link the properties that only appear in plugin configuration (error-prone, nullaway, findsecbugs, pitest-junit5), which is why the script carries the mapping.

## Verification

- [x] `mvn test -Pe2e` from `vibetags/` (as `mvn clean install -Pe2e`, on the bumped tree): 1936 tests, 0 failures, 0 errors, 0 skipped, BUILD SUCCESS; `BuildVersionParityTest` is in it
- [x] `vibetags-annotations` install, `vibetags-bom` and `vibetags-cli` install, `load-tests` test-compile: all exit 0
- [x] `./gradlew clean compileTestJava --no-daemon` in `vibetags` on Gradle 9.7.0: BUILD SUCCESSFUL
- [x] `./gradlew clean build --no-daemon` in `example`, `example-kotlin` (kapt on Kotlin 2.4.10), `example-groovy` (5.1.0), `example-scala`: all BUILD SUCCESSFUL
- [x] `pre-commit run --all-files` after `git add`: gitleaks v8.30.0, end-of-file-fixer and trailing-whitespace v6.0.0 passed; checkstyle hook skipped (Docker)
- [x] `scripts/bump-dependencies.sh` proven to flag a stale pin (junit.version set back to 6.1.2 reported `<- update`) and to report 0 updates on the bumped tree
- [x] Docs: `docs/CHANGELOG.md` (Unreleased / Changed), `docs/DEPENDENCIES.md` (wrapper version), `docs/RELEASING.md` (step 0)
- Not run: `mvn clean compile -Pself-annotate` (no annotation on this repo's sources changed); the consumer regression suite (no API change; the JUnit/Logback bumps are test and runtime-scope pins consumers do not inherit)

## Provenance and prompt lineage

- Author: agent (Claude Fable 5), not yet human-reviewed
- Session: https://claude.ai/code/session_017dzgbxavEPwuqmrDvf3AxG
- Load-bearing intent: "bump all dependecies to latest perhaps create a skill that does it"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dzgbxavEPwuqmrDvf3AxG
