### PR TITLE
chore: prepare release v1.2.2

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.2.1
+version: 1.2.2
 ---
 
 # VibeTags Usage Guide
@@ -17,15 +17,15 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-processor</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:1.2.1'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.1'
+compileOnly 'se.deversity.vibetags:vibetags-processor:1.2.2'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.2'
 ```
 
 ### 2. Opt in to AI platforms (file-presence model)
@@ -1066,7 +1066,7 @@ Use on: **class, method, field**
 @AIKeepInSync(mirrors = {"pom.xml:<version>", "README.md badge", "docs/CHANGELOG.md"},
               reason = "The release version is asserted in three places and drifts silently",
               enforcedBy = "ProjectFactsConsistencyTest")
-public static final String VERSION = "1.2.1";
+public static final String VERSION = "1.2.2";
 ```
 
 The element is free to change — the failure mode is a *partial* change that desyncs a mirror no compiler checks. `@AIContract` freezes one signature so it cannot change at all; neither it nor `@AISchemaSafe` expresses "edit A ⇒ you must also edit B". Mirrors routinely point outside the compilation unit, so VibeTags can only *name* them, not verify them.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.1</version>
+                        <version>1.2.2</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -94,7 +94,7 @@ touch CLAUDE.md .cursorrules AGENTS.md   # Claude, Cursor, Codex CLI — add whi
 Or let the companion CLI do it (and `vibetags doctor` checks your setup afterwards):
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.1 init --platforms claude,cursor
+jbang se.deversity.vibetags:vibetags-cli:1.2.2 init --platforms claude,cursor
 ```
 
 **3. Annotate your first class:**
@@ -123,8 +123,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.2')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -170,8 +170,8 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.1"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.1"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.2"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.2"))
 
     compileOnly("se.deversity.vibetags:vibetags-annotations")
     kapt("se.deversity.vibetags:vibetags-processor")
@@ -513,7 +513,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -538,7 +538,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.1</version>
+                        <version>1.2.2</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -554,8 +554,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.2')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -569,15 +569,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.1'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.1'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.2'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.2'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.
@@ -898,8 +898,8 @@ presence the processor honours (the processor itself never creates them), and
 `VIBETAGS-START`/`END` marker integrity. Run it without installing anything:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.1 init --list
-jbang se.deversity.vibetags:vibetags-cli:1.2.1 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.2.2 init --list
+jbang se.deversity.vibetags:vibetags-cli:1.2.2 doctor
 ```
 
 The platform list and marker rules are read from `vibetags-processor` at runtime, so the CLI

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2] - 2026-08-16
+
 ### Changed
 
 - **Every third-party pin moved to its latest stable release** (2026-08-16), the rest were
@@ -2719,7 +2721,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.2.2...HEAD
+[1.2.2]: https://github.com/PIsberg/vibetags/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/PIsberg/vibetags/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/PIsberg/vibetags/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/PIsberg/vibetags/compare/v1.1.0...v1.1.1

--- a/example-all-tiers/pom.xml
+++ b/example-all-tiers/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.2.1</vibetags.bom.version>
+    <vibetags.bom.version>1.2.2</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/example-groovy/build.gradle
+++ b/example-groovy/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.apache.groovy:groovy:5.1.0'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.2')
 
     // Annotations on compile, processor on the annotation-processor path only.
     compileOnly 'se.deversity.vibetags:vibetags-annotations'

--- a/example-kotlin/build.gradle.kts
+++ b/example-kotlin/build.gradle.kts
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and kapt configurations so neither needs an explicit version.
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.1"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.1"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.2"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.2"))
 
     // Annotations on compile, processor on the kapt path only — keeps the processor's
     // slf4j/logback off the consumer's compile classpath. compileOnly is enough:

--- a/example-multimodule-indexed/pom.xml
+++ b/example-multimodule-indexed/pom.xml
@@ -37,7 +37,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.2.1</vibetags.bom.version>
+    <vibetags.bom.version>1.2.2</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/example-multimodule/pom.xml
+++ b/example-multimodule/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.2.1</vibetags.bom.version>
+    <vibetags.bom.version>1.2.2</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/example-scala/build.gradle
+++ b/example-scala/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.scala-lang:scala-library:2.13.18'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.2')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.2')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.2.1</vibetags.bom.version>
+        <vibetags.bom.version>1.2.2</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.2.1</vibetags.bom.version>
+        <vibetags.bom.version>1.2.2</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.2.1'
+version = '1.2.2'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.2.1'
+            version = '1.2.2'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -39,12 +39,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.2.1&lt;/version&gt;
+                &lt;version&gt;1.2.2&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.1'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.1'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.2'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.2'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -36,7 +36,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.2.1&lt;/version&gt;
+                        &lt;version&gt;1.2.2&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.2.1')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.1')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.2.2')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.2')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-cli/pom.xml
+++ b/vibetags-cli/pom.xml
@@ -28,7 +28,7 @@
         reports the project's VibeTags health — build-tool wiring, active platforms,
         marker integrity. Run it without installing anything:
 
-            jbang se.deversity.vibetags:vibetags-cli:1.2.1 init --list
+            jbang se.deversity.vibetags:vibetags-cli:1.2.2 init --list
 
         The platform list and marker rules are read from vibetags-processor, so this
         tool cannot drift from what the processor actually does.

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.2.1</revision>
+        <revision>1.2.2</revision>
 
         <!-- release, not source/target: on a JDK newer than 21 (CI builds 21, 25 and 26)
              source/target compiles against the *running* JDK's API and javac warns that the

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.2.1'
+version = '1.2.2'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.2.1'
+            version = '1.2.2'
             from components.java
 
             pom {
@@ -78,7 +78,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.2.1'
+    api 'se.deversity.vibetags:vibetags-annotations:1.2.2'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.1'

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
@@ -115,7 +115,11 @@ class ReleaseScriptCoverageTest {
         // manifest stamped "vibetags/1.2.0" because 1.2.0 is the release that shipped the feature;
         // rewriting it on every later release would make the document claim it proposed something
         // that already existed.
-        "docs/proposals/transitive-guardrails.md");
+        "docs/proposals/transitive-guardrails.md",
+        // Explanatory prose about pitest-junit5-plugin's own release history (its actual pin
+        // lives in ${pitest-junit5-plugin.version} in the parent pom). Coincidentally equals a
+        // VibeTags release number from time to time; it is not a VibeTags coordinate.
+        "vibetags/pom.xml");
 
     /** Build outputs and local scratch that are not part of the release. */
     private static final Set<String> IGNORED_SUFFIXES =


### PR DESCRIPTION

### Changed

- **Every third-party pin moved to its latest stable release** (2026-08-16), the rest were
  already current: JUnit 6.1.2 to 6.1.3 (Jupiter and Platform), Logback 1.6.1 to 1.6.3,
  async-test-lib 1.9.2 to 1.9.3, maven-enforcer-plugin 3.6.0 to 3.6.3, Gradle wrapper 9.6.1 to
  9.7.0 in all six wrappers, Kotlin 2.3.21 to 2.4.10 in `example-kotlin` and the README
  snippets, Groovy 5.0.8 to 5.1.0 in `example-groovy`, pre-commit hooks gitleaks v8.16.3 to
  v8.30.0 and pre-commit-hooks v4.4.0 to v6.0.0 (`pre-commit-java` left at v0.2.4: its
  checkstyle hook runs in Docker and could not be verified here). Pre-releases on Maven Central
  (maven-compiler-plugin 4.0.0-beta-4, maven-surefire-plugin 3.6.0-M1, slf4j 2.1.0-alpha1,
  maven-jar/source-plugin 4.0.0-beta-1) were deliberately not applied. Verified by the whole
  suite (`mvn clean install -Pe2e`, 1936 tests), the bom, cli and load-tests builds, the Gradle
  build of `vibetags`, and the Gradle builds of `example`, `example-kotlin` (kapt),
  `example-groovy` and `example-scala`.
- **`scripts/bump-dependencies.sh` and the `bump-dependencies` skill.** The script reports every
  parent-pom property against Maven Central (stable releases only unless asked), plus the Gradle
  wrapper, Kotlin, Groovy and Scala pins, and fails if the parent gains a version property it has
  no path for. The skill is the procedure around it: what mirrors each pin, which gates verify a
  bump, and what to hand over.

### Fixed

- **A granular rule file's front matter now follows its inputs.** The `globs:` / `paths:` /
  `applyTo:` list at the top of a rule file is rendered from `.vibetags-roles` (and, for
  mirrors, `.vibetags-mirror`), but the writer treated the header already on disk as
  hand-authored and kept it: adding a glob to a role, or a member to an FQN-only role, changed
  the fingerprint, re-rendered the file, and left its scope exactly as first written. Check mode
  passed on the stale file for the same reason. A header VibeTags renders is now refreshed like
  the block; a hand-written header on a file whose renderer emits none is preserved as before.
  Verified by `WriteFileFrontMatterTest` (hand content between header and block, and after it,
  survives) and `RoleBasedGranularEndToEndTest.editingARolesGlobs_reachesTheExistingRuleFilesFrontmatter`,
  both red before the fix.
- **A departed module's rule files no longer cost the survivors their short-circuit.** 1.2.1
  started deleting the rule files of a module that left the reactor, by name and straight through
  `Files.deleteIfExists`, and the write cache went on tracking them. A cached entry whose file is
  missing means "an output still to be rewritten", so every later build of every surviving module
  ran the full content build and file compare, over a file no round would ever write again.
  Deletions now go through `GuardrailFileWriter.deleteIfExists`, which invalidates the entry
  (and, in dry-run, reports the removal instead of performing it). Verified by
  `ProjectLifecycleEndToEndTest.moduleRemovedFromTheReactor_doesNotCostTheSurvivorsTheirShortCircuit`,
  red before the fix; `GuardrailFileWriterLogContractTest` pins the new `delete.commit` /
  `delete.skip reason=dry-run` events.
- **Check mode's orphan sweep follows the same jurisdiction rule as generation.** The #383 fix
  taught `generateFiles()` that a reactor module round may not sweep the shared root's granular
  directory, because on a cold clone every sibling's committed rule file is unclaimed. Check mode
  kept the unconditional sweep, so the same cold-clone module round reported each sibling's rule
  file as drift: a claim that a normal compile would delete files it leaves alone. `checkFiles()`
  now sweeps only when the round compiles the root itself, and mirrors the departed-module
  removal that generation does perform (through the dry-run writer, so the file is named, not
  touched). The documented cold-clone limitation for merged aggregates is unchanged: build once,
  then check. Verified by `CheckModeTest.checkMode_onAColdCloneModuleRound_agreesWithGeneration`
  (red before the fix) and `checkMode_reportsADepartedModulesRuleFileAsDrift` (the bound, kept
  green through it).
- **Check mode no longer prunes a departed module's sidecar.** `ModuleSidecar.readAll` deletes a
  sidecar whose module directory is gone, and check mode read through it. One check-mode run
  after a module left the reactor (the first thing CI does) deleted that module's sidecar, the
  only record of the rule files it wrote, so the next real build had nothing to act on and the
  departed module's rule files stayed in the repository for good. Check mode, and the
  unidentifiable-module warning that runs before generation reads the departed stems, now read
  through `ModuleSidecar.peekAll`, which leaves the file where it is. Verified by
  `CheckModeTest.checkMode_doesNotPruneADepartedModulesSidecar`, red before the fix.
- **A glob that does not compile in `.vibetags-roles` no longer stops the whole build's output.**
  `RoleConfig.load` compiled every glob eagerly and let the `PatternSyntaxException` (an unclosed
  `{` group is the easy typo) escape into the top of the generate phase, where the processor's
  outer guard downgraded it to a WARNING: no file, sidecar or mirror was written for that build,
  and nothing said why. A matcher that cannot compile now matches nothing; the unclosed brace
  still swallows the rest of its own line, and every other line routes as before. Verified by
  `RoleConfigTest.malformedGlob_isSkipped_notThrown`, an error before the fix.

### Added

- Repository alignment with the practices taught in *Vibe Architecture* (audit recorded in
  `analysis/2026-08-15-health-scorecard.md`). Library behaviour is unchanged; everything below
  is enforcement, measurement, or documentation around it:
  - Locked Files Guard CI job — the shipped `action/locked-files` now runs on this repository's
    own pull requests, with `.vibetags-locks` committed and kept current by check mode.
  - Architecture Diagram Drift CI job — the code-karta diagrams regenerate on every build and
    drift fails it (they had drifted; this release recommits them fresh).
  - Shipping-dependency allowlist — `maven-enforcer-plugin` fails the build on any
    compile/runtime dependency outside the allowlist in `vibetags-parent`.
  - Instruction evals (`evals/`) — a headless task bank measuring whether `CLAUDE.md` and the
    scoped rules actually bind an agent, wired to PRs that edit the instruction files.
  - Inquisitor CI workflow — adversarial AI review of PR diffs against the committed guardrails,
    with a structured gripe format and a deterministic verdict gate.
  - `@AIThreadSafe` on `WriteCache`, `ModuleSidecar`, `GuardrailFileWriter` and `VibeTagsLogger`,
    each note naming the async test that proves the declared strategy.
  - `DocsIndexCompletenessTest` — an orphaned reference document now fails the build (12 were
    orphaned when the test was introduced; all are now routed).
  - CI failure-log artifacts, a pull-request template (verification, provenance, prompt
    lineage), and the `consultation-loop` / `correctness-hunt` skills.
- Second alignment pass, closing the scorecard to 66/66:
  - `CLAUDE.md` context diet: 220 lines to about 120, with a 15-line Tier-1 invariant list
    where every line names its enforcing test; the moved-out detail landed verbatim in
    `docs/LOAD-BEARING.md`, `docs/LOGGING.md` (new), and `docs/ARCHITECTURE.md`.
  - Executable BDD: `src/test/resources/features/core-guardrail-flows.feature` run by
    `CoreFlowsBddTest` with a two-way scenario/binding match, dependency-free.
  - Performance contract: `ProcessorAllocationBudgetTest` asserts a measured, documented
    allocation budget on every e2e run; `nightly-perf.yml` compares the weekly allocation
    sweep against the newest committed baseline.
  - Copilot review lane (`copilot-review.yml`): every PR requests a GitHub Copilot review on
    free quota, skipping loudly when Copilot has none; `.github/MODEL-ROSTER.md` records the
    model routing and the eval-gated upgrade ceremony.
  - `@AITestDriven` on the four core classes; the two Anthropic workflows now run with
    blocked egress and endpoint allowlists; a SessionEnd hook stages prompt lineage into a
    gitignored trail; `ENGINE=copilot` lets the instruction evals run on Copilot Free.

