### PR TITLE
docs: answer the four things a first-time consumer got stuck on

### DIFF
--- a/.claude/skills/add-annotation/SKILL.md
+++ b/.claude/skills/add-annotation/SKILL.md
@@ -169,6 +169,12 @@ past the last wave — currently `V5`) unless you're extending an in-flight wave
   Combinations" if it interacts with others, a row in "Diagnosing Issues" if Step 6 added a
   warning, and — if genuinely new rather than a format addition — the annotation belongs in every
   count/list this skill maintains for the other 38.
+- **`.claude/skills/vibetags-usage/SKILL.md`, "Element cheat sheet"** — a row in the "Every
+  element, in full" table listing every element (bold the ones with no default), plus the
+  positional-form table if it declares `value()` and the "will not compile bare" list if any
+  element has no default. The word-numbers introducing those two lists are counts and move too.
+  `SkillElementTableConsistencyTest` checks all of this against the annotation source, so you do
+  not have to remember it — but you do have to make the build green before pushing.
 
 ## Verify
 

--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -10,25 +10,110 @@ VibeTags is a **compile-time Java annotation processor** that generates AI platf
 
 ## Quick Setup
 
-### 1. Add the dependency
+### 1. Add the two artifacts
 
-**Maven** (`provided` scope — compile-only):
+VibeTags ships as **two** artifacts and you need both. Depending on only one of them is the most
+common "VibeTags is broken" report, and neither failure produces a useful error:
+
+| Artifact | Belongs on | Gives you | If you omit it |
+|---|---|---|---|
+| `vibetags-annotations` | the **compile** classpath | the 44 `@AI*` annotation types you write in source | `cannot find symbol` on every `@AI*` |
+| `vibetags-processor` | the **annotation-processor** path | the processor that reads them and writes the guardrail files | compiles green, generates nothing |
+
+**Maven**. Annotations as an ordinary dependency, processor on `annotationProcessorPaths`:
+
 ```xml
-<dependency>
-    <groupId>se.deversity.vibetags</groupId>
-    <artifactId>vibetags-processor</artifactId>
-    <version>1.2.2</version>
-    <scope>provided</scope>
-</dependency>
+<dependencies>
+    <dependency>
+        <groupId>se.deversity.vibetags</groupId>
+        <artifactId>vibetags-annotations</artifactId>
+        <version>1.2.2</version>
+    </dependency>
+</dependencies>
+
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <annotationProcessorPaths>
+                    <path>
+                        <groupId>se.deversity.vibetags</groupId>
+                        <artifactId>vibetags-processor</artifactId>
+                        <version>1.2.2</version>
+                    </path>
+                </annotationProcessorPaths>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
 ```
+
+> **Do not** declare `vibetags-processor` as a plain `<scope>provided</scope>` dependency instead
+> of the block above. Since **JDK 23**, `javac` no longer discovers processors sitting on the class
+> path, so that shape compiles cleanly and writes no files: no error, no warning. If the processor
+> has to stay on the class path, add `<proc>full</proc>` to the compiler plugin's configuration.
+
+`vibetags-processor` does pull `vibetags-annotations` in transitively (kept from 0.5.x for
+backwards compatibility), so a single-artifact setup can work, but only until JDK 23, and it puts
+the whole processor and its SLF4J/Logback dependencies on your compile classpath. Declare both.
 
 **Gradle:**
+
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-processor:1.2.2'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.2'
+dependencies {
+    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.2.2'
+    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.2'
+}
 ```
 
-### 2. Opt in to AI platforms (file-presence model)
+Kotlin replaces `annotationProcessor` with `kapt` (KSP does not run JSR 269 processors, so it is
+not supported); Groovy needs the same two lines plus `groovyOptions.javaAnnotationProcessing = true`
+on the `GroovyCompile` task. Scala has no JSR 269 support at all, so annotate thin Java types beside
+the Scala code instead.
+
+### 2. Tell the processor where the project root is
+
+VibeTags writes at **the JVM's working directory** unless `-Avibetags.root` overrides it. For
+`mvn compile` run from the project root that is already correct and you can skip this step. When
+the compiler runs somewhere else, the processor happily writes a full set of guardrail files into
+a directory you never look at, and your project looks untouched:
+
+| How you build | Working directory | Set `-Avibetags.root`? |
+|---|---|---|
+| Maven, from the project root | the project root | No |
+| Maven reactor, `mvn` at the reactor root | the reactor root | No; that is the merge root already |
+| A single module on its own (`mvn -pl`, IDE "build module") | varies | Yes; point it at the reactor root |
+| Gradle, plain `JavaCompile` | usually the root project dir | Usually no |
+| Gradle worker, kapt, Groovy joint compilation | a worker scratch dir | **Yes** |
+| IDE-driven compilation (IntelliJ, Eclipse) | varies | Usually yes |
+
+```xml
+<!-- Maven: inside the same maven-compiler-plugin <configuration> as step 1 -->
+<compilerArgs><arg>-Avibetags.root=${maven.multiModuleProjectDirectory}</arg></compilerArgs>
+```
+
+```groovy
+// Gradle
+options.compilerArgs += "-Avibetags.root=${rootDir}".toString()
+```
+
+```kotlin
+// kapt. Its working directory is never the project directory.
+kapt { arguments { arg("vibetags.root", rootProject.projectDir.absolutePath) } }
+```
+
+You do not have to guess: the processor prints the path it resolved on every compile.
+
+```
+VibeTags: Root resolved: /home/me/myproject
+VibeTags: user.dir:      /home/me/myproject
+```
+
+If that first line is not your project root, that is the whole bug.
+
+### 3. Opt in to AI platforms (file-presence model)
 
 VibeTags **never creates files** — it only updates files that already exist. Create empty placeholder files for each platform you want to support:
 
@@ -78,35 +163,77 @@ touch .roomodes                            # Roo Code ("VibeTags Architect" cust
 
 To remove a platform: delete its file — VibeTags will never recreate it.
 
-> **`AGENTS.md` is special:** it is only generated when it is the **sole** AI config file in the
-> project. Since `AGENTS.md` is a near-universal agent file often kept as a pointer to another
-> tool's file (e.g. `CLAUDE.md`), VibeTags leaves it untouched whenever any other AI config file
-> is present (this also disables the `.codex/` sidecar). Opt in to *only* `AGENTS.md` to have it
-> managed.
+> **`AGENTS.md` is special, and if you see this on every single compile, this is why:**
 >
-> **Escape hatch (marker opt-in):** if you *want* a generated `AGENTS.md` alongside `CLAUDE.md`
-> — a Claude + Codex project, say — paste a marker pair into it:
->
-> ```markdown
-> <!-- VIBETAGS-START -->
-> <!-- VIBETAGS-END -->
+> ```
+> VibeTags: AGENTS.md left untouched because other AI config files are present;
+> it is treated as a pointer rather than a generated file.
 > ```
 >
-> A file carrying the markers was written by VibeTags in the first place, and only the region
-> between them is ever replaced, so refreshing it cannot clobber your prose. Marked files stay
-> managed no matter how many other AI config files are present.
+> `AGENTS.md` is a near-universal agent file that projects often keep as a thin pointer to another
+> tool's file (`CLAUDE.md`, say), so VibeTags refuses to touch it whenever any *other* AI config
+> file exists. That also disables the `.codex/` sidecar. It is a javac `NOTE`, not a warning, and
+> nothing is wrong with your build; it simply repeats until you pick one of three answers:
+>
+> - **Have VibeTags manage it**, the usual answer for a Claude + Codex project. Paste a marker
+>   pair into `AGENTS.md`:
+>
+>   ```markdown
+>   <!-- VIBETAGS-START -->
+>   <!-- VIBETAGS-END -->
+>   ```
+>
+>   A file carrying the markers was written by VibeTags in the first place, and only the region
+>   between them is ever replaced, so refreshing it cannot clobber your prose. Marked files stay
+>   managed no matter how many other AI config files are present.
+>
+> - **Keep it hand-written.** Change nothing and read the note as the confirmation it is.
+> - **Make it the sole AI config file.** Delete `CLAUDE.md`, `GEMINI.md` and the rest, and
+>   `AGENTS.md` becomes a managed file with no markers needed.
+>
+> There is no flag that silences the note while leaving `AGENTS.md` unmanaged: javac notes are not
+> suppressible per processor. Adding the marker pair is the way to stop seeing it.
 
-### 3. Annotate your Java code
+### 4. Annotate your Java code
 
 ```java
 import se.deversity.vibetags.annotations.*;
 ```
 
-### 4. Compile — guardrails are generated automatically
+Most `@AI*` annotations have **no `value()` element**, so the positional shorthand does not compile.
+`@AILocked("Legacy code")` is an error; `@AILocked(reason = "Legacy code")` is what you want. The
+[Element cheat sheet](#element-cheat-sheet--read-this-before-your-first-annotation) below lists the
+elements of all 44, including the seven that do take the positional form and the ten that will not
+compile without arguments.
+
+### 5. Compile — guardrails are generated automatically
 
 ```bash
 mvn clean compile   # or: gradle clean build
 ```
+
+`clean` matters more than it looks: VibeTags runs inside the compiler, so an incremental build with
+no changed sources never starts `javac` and a platform file you just created stays empty even
+though the build is green.
+
+### 6. Verify it actually ran
+
+Every way this setup fails is silent, so check rather than assume:
+
+```bash
+jbang se.deversity.vibetags:vibetags-cli:1.2.2 doctor
+```
+
+Or by hand, in the order things go wrong:
+
+1. **Was the processor on the path?** The compile log carries `VibeTags: Root resolved: …`. No such
+   line at all means only `vibetags-annotations` was wired up, or JDK 23+ skipped a class-path
+   processor (step 1).
+2. **Did it write where you are looking?** That same line is the output directory (step 2).
+3. **Did anything opt in?** `VibeTags: No AI config files found` means no platform file exists
+   (step 3).
+4. **Still empty?** Read `vibetags.log` at the resolved root. Every skipped write is a `write.skip`
+   event carrying a `reason=`, and `-Avibetags.log.level=DEBUG` records the full decision path.
 
 ---
 
@@ -194,6 +321,100 @@ per module. Both work; pick per platform.
 ---
 
 ## Annotations Reference
+
+### Element cheat sheet — read this before your first annotation
+
+Java's positional shorthand `@Foo(x)` only works when an annotation has an element literally named
+`value()`. **Thirty-seven of the forty-four do not**, so `@AILocked("Legacy code")` fails with a
+compiler error that does not name the element you should have used:
+
+```
+error: cannot find symbol
+@AILocked("Legacy code")
+          ^
+  symbol:   method value()
+```
+
+`@AILocked(reason = "Legacy code")` is the form that works. Nothing at the call site tells you
+which kind of annotation you are holding, hence this table.
+
+**The seven that take the positional form:**
+
+| Annotation | Positional form | Use on | `value()` type |
+|---|---|---|---|
+| `@AICallersOnly` | `@AICallersOnly({"com.acme.Api", "com.acme.Facade"})` | class, method | `String[]`, **required** |
+| `@AIExplain` | `@AIExplain(AIExplain.ComplexityLevel.HIGH)` | class, method | `ComplexityLevel`, default `HIGH` |
+| `@AIExtensible` | `@AIExtensible(AIExtensible.Strategy.VISITOR_PATTERN)` | class | `Strategy`, default `STRATEGY_PATTERN` |
+| `@AIInputSanitized` | `@AIInputSanitized(AIInputSanitized.SanitizerType.SQL_INJECTION)` | **parameter, field** | `SanitizerType[]`, **required** |
+| `@AIMemoryBudget` | `@AIMemoryBudget(AIMemoryBudget.AllocationPolicy.NO_AUTOBOXING)` | class, method | `AllocationPolicy`, default `ZERO_ALLOCATION` |
+| `@AISecureLogging` | `@AISecureLogging(AISecureLogging.MaskingPolicy.HASH)` | **field, parameter** | `MaskingPolicy`, default `OMIT` |
+| `@AIThreadAffinity` | `@AIThreadAffinity(AIThreadAffinity.Affinity.MAIN_ONLY)` | class, method | `Affinity`, **required** |
+
+Every row above was compiled to check it. `@AIInputSanitized` and `@AISecureLogging` are the two
+that do not go on a class. Putting one there fails with *annotation interface not applicable to
+this kind of declaration*, not with anything that names the target you wanted.
+
+**The ten that will not compile bare.** Each has at least one element with no default:
+
+`@AIBannedApi(forbidden)`, `@AICallersOnly(value)`, `@AIGenerated(from)`,
+`@AIInputSanitized(value)`, `@AIKeepInSync(mirrors)`, `@AILoadBearing(invariant)`,
+`@AIRegulation(standard)`, `@AISunset(jira)`, `@AITemporary(expiresOn, reason)`,
+`@AIThreadAffinity(value)`.
+
+The other thirty-four are usable bare: `@AILocked`, `@AIPrivacy`, `@AIPure` and so on all carry a
+sensible default reason. Naming a reason is still worth it, because it is what the agent reads.
+
+**Every element, in full.** Bold marks an element with no default (omit it and the build fails).
+
+| Annotation | Elements |
+|---|---|
+| `@AIArchitecture` | `belongsTo` String `""`, `cannotReference` String[] `{}` |
+| `@AIAudit` | `checkFor` String[] `{}` |
+| `@AIBannedApi` | **`forbidden`** String[], `useInstead` String `""`, `reason` String `""` |
+| `@AICallersOnly` | **`value`** String[] |
+| `@AIContext` | `focus` String `""`, `avoids` String `""` |
+| `@AIContract` | `reason` String (long default) |
+| `@AICore` | `sensitivity` String `"High"`, `note` String (default note) |
+| `@AIDeprecated` | `replacedBy` String `""`, `migrationGuide` String (default), `deadline` String `""` |
+| `@AIDomainModel` | `allow` String[] `{}` |
+| `@AIDraft` | `instructions` String (default) |
+| `@AIExplain` | `value` ComplexityLevel `HIGH`; one of `HIGH`, `MEDIUM`, `LOW` |
+| `@AIExtensible` | `value` Strategy `STRATEGY_PATTERN`; one of `STRATEGY_PATTERN`, `VISITOR_PATTERN`, `FACTORY` |
+| `@AIFeatureFlag` | `flag` String `""`, `defaultValue` boolean `false` |
+| `@AIGenerated` | **`from`** String, `regenerateWith` String `""`, `editInstead` String `""` |
+| `@AIIdempotent` | `reason` String `""` |
+| `@AIIgnore` | `reason` String (default) |
+| `@AIImmutable` | `note` String `""` |
+| `@AIInputSanitized` | **`value`** SanitizerType[]; any of `SQL_INJECTION`, `XSS`, `PATH_TRAVERSAL`, `LDAP` |
+| `@AIInternationalized` | `reason` String `""` |
+| `@AIKeepInSync` | **`mirrors`** String[], `reason` String `""`, `enforcedBy` String `""` |
+| `@AILegacyBridge` | `reason` String `""` |
+| `@AILoadBearing` | **`invariant`** String, `breaksIf` String `""`, `suppressAudit` boolean `false` |
+| `@AILocked` | `reason` String (default) |
+| `@AIMemoryBudget` | `value` AllocationPolicy `ZERO_ALLOCATION`; one of `ZERO_ALLOCATION`, `NO_AUTOBOXING`, `NO_NEW_OBJECTS` |
+| `@AIObservability` | `metrics` String[] `{}`, `traces` String[] `{}`, `logs` String[] `{}`, `note` String `""` |
+| `@AIParallelTests` | `reason` String `""` |
+| `@AIPerformance` | `constraint` String (default) |
+| `@AIPrivacy` | `reason` String (default) |
+| `@AIPrototype` | `reason` String `""` |
+| `@AIPublicAPI` | `reason` String `""` |
+| `@AIPure` | `reason` String `""` |
+| `@AIRegulation` | **`standard`** String, `clause` String `""`, `description` String (default) |
+| `@AISandboxOnly` | `reason` String `""` |
+| `@AISchemaSafe` | `reason` String `""` |
+| `@AISecure` | `aspect` String `""` |
+| `@AISecureLogging` | `value` MaskingPolicy `OMIT`; one of `OMIT`, `HASH`, `MASK_CREDIT_CARD`, `MASK_EMAIL` |
+| `@AIStrictClasspath` | `reason` String `""` |
+| `@AIStrictExceptions` | `reason` String `""` |
+| `@AIStrictTypes` | `reason` String `""` |
+| `@AISunset` | **`jira`** String |
+| `@AITemporary` | **`expiresOn`** String (`YYYY-MM-DD`), **`reason`** String |
+| `@AITestDriven` | `testLocation` String `""`, `coverageGoal` int `100`, `framework` Framework[] `{JUNIT_5}`; any of `JUNIT_5`, `JUNIT_4`, `TESTNG`, `MOCKITO`, `ASSERTJ`, `SPOCK`, `NONE`; `mockPolicy` String `""` |
+| `@AIThreadAffinity` | **`value`** Affinity; one of `MAIN_ONLY`, `NEVER_MAIN`, `BACKGROUND_ONLY`, `NAMED`; `thread` String `""`, `marshalVia` String `""`, `symptomIfViolated` String `""` |
+| `@AIThreadSafe` | `strategy` Strategy `SYNCHRONIZED`; one of `SYNCHRONIZED`, `LOCK_FREE`, `IMMUTABLE`, `THREAD_LOCAL`, `OTHER`; `note` String `""` |
+
+Enum constants are nested types, so they are written `AIExplain.ComplexityLevel.HIGH` unless you
+static-import them.
 
 ### `@AILocked` — Protect critical code from modification
 
@@ -1331,6 +1552,13 @@ tasks.withType(JavaCompile) {
 
 | Symptom | Cause | Fix |
 |---|---|---|
+| Green build, no `VibeTags:` line in the compile log at all | The processor never ran: only `vibetags-annotations` is wired up, or JDK 23+ ignored a class-path processor | Put `vibetags-processor` on `annotationProcessorPaths` / the `annotationProcessor` configuration (step 1) |
+| Green build, files generated, but not in your project | `VibeTags: Root resolved:` points somewhere else: a Gradle worker, kapt, or an IDE compile | Set `-Avibetags.root` (step 2) |
+| `cannot find symbol: class AILocked` | `vibetags-annotations` is missing from the compile classpath | Add it as an ordinary dependency (step 1) |
+| Nothing changed after creating a platform file | An incremental build with no changed sources never starts `javac` | `mvn clean compile`, or touch a source file |
+| `[NOTE] AGENTS.md left untouched because other AI config files are present` | Working as designed: `AGENTS.md` is managed only when it is the sole AI config file | Paste a `VIBETAGS-START`/`VIBETAGS-END` pair into it to have it managed; otherwise ignore (see step 3) |
+| `error: cannot find symbol` … `symbol: method value()` on an `@AI*` annotation | Positional shorthand used on an annotation that has no `value()` element | Use named elements: `@AILocked(reason = "…")`; see the [Element cheat sheet](#element-cheat-sheet--read-this-before-your-first-annotation) |
+| `[WARNING] VibeTags: unrecognized option 'vibetags.…'` | Typo in a `-A` option name | The message lists every supported option; fix the spelling |
 | No files updated after compile | Target files don't exist | `touch CLAUDE.md` (or whichever platform file) then recompile |
 | `[NOTE] No AI config files found` | No opt-in files present | Create one or more platform files (see step 2) |
 | A module's guardrails are missing from the reactor root | That module never reached the root | Give it `-Avibetags.root=<reactor>`; VibeTags warns with *"generated its guardrails as its own root"* when it can tell |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The `vibetags-usage` skill answers the four questions a first-time consumer actually got
+  stuck on.** Reported from a real setup, all four failing silently:
+  - **The two-artifact split was invisible.** The skill's install snippet declared only
+    `vibetags-processor` at `provided` scope, which is the exact shape that compiles green and
+    generates nothing on JDK 23+, where javac stopped discovering processors on the class path.
+    Step 1 is now a table of what each artifact is for and what its absence looks like, the Maven
+    snippet puts `vibetags-annotations` on the compile path and `vibetags-processor` on
+    `annotationProcessorPaths` (matching the README), and the `provided` shape is called out as a
+    thing not to do.
+  - **`-Avibetags.root` was documented only under "Advanced Configuration".** It is not advanced:
+    the processor writes at the JVM working directory, so a Gradle worker, kapt or an IDE compile
+    silently writes a full set of guardrails somewhere nobody looks. It is now step 2, with a
+    table of which builds need it and the `VibeTags: Root resolved:` line to check it against.
+  - **`@AIExplain`'s element name needed `javap` to find.** Thirty-seven of the 44 annotations
+    have no `value()`, so the positional shorthand does not compile, and the error names
+    `method value()` rather than the element you wanted. The new "Element cheat sheet" lists every
+    element of all 44, marks the ten that will not compile bare, and gives the seven that do take
+    the positional form with a compiled-and-checked example and the targets they are legal on.
+  - **The `AGENTS.md` note reads like a recurring warning.** It is a `NOTE`, it fires by design
+    whenever `AGENTS.md` is not the sole AI config file, and the marker-pair escape hatch was
+    buried. The note's own text now opens the explanation, with the three ways to resolve it.
+
+  Also new: a "Verify it actually ran" step that walks the silent failures in the order they
+  happen, and seven rows in "Diagnosing Issues" covering them.
+- **`SkillElementTableConsistencyTest` pins that cheat sheet to the annotation sources.** A
+  44-row hand-written table about compiled facts is the shape that rots silently, which is the
+  same failure the report was about. The test checks one row per annotation, every element listed
+  and bolded exactly when it has no default, every enum constant named, and both summary lists
+  (with the word-numbers introducing them). Verified by breaking the table five ways, one per
+  assertion, and confirming each goes red. The `add-annotation` skill now names the table too.
+
 ## [1.2.2] - 2026-08-16
 
 ### Changed

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -166,6 +166,7 @@ stop excluding the same one.
 | `DocumentationLinksTest` | Every relative Markdown link and anchor in the repository resolves; six dead links were live when it was written |
 | `DocsIndexCompletenessTest` | The inverse: every reference doc under `docs/` (plus `SPEC.md`) is reachable from the entry documents; 12 orphans were live when it was written |
 | `ProjectFactsConsistencyTest` | Numbers the README asserts (44 annotations, 37 platforms, 49 files, the dogfooding line counts) recomputed from the artifacts that hold them |
+| `SkillElementTableConsistencyTest` | The `vibetags-usage` skill's element cheat sheet against `vibetags-annotations`: one row per annotation, every element listed and bolded exactly when it has no default, every enum constant named, and the positional-form / will-not-compile-bare lists (and their word-number counts) holding exactly the right annotations |
 | `CoreFlowsBddTest` (`e2e`) | Executes the Gherkin scenarios in `src/test/resources/features/` against a real compile; scenario-level bindings, and the file and the bindings must match exactly in both directions, so a scenario without a binding (or a binding without a scenario) is a red build |
 | `ProcessorAllocationBudgetTest` (`e2e`) | The inner-loop performance contract: compiling 100 annotated classes must stay inside a 768 MB per-thread allocation budget (3.04x the measured 264,955,400 bytes; wall-clock is deliberately not asserted, allocation is the stable metric) |
 

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/SkillElementTableConsistencyTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/SkillElementTableConsistencyTest.java
@@ -1,0 +1,273 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Pins the {@code vibetags-usage} skill's element cheat sheet to the annotation sources.
+ *
+ * <p>The cheat sheet exists because nothing at a call site tells you whether an annotation has a
+ * {@code value()} element. A consumer reported reaching for {@code javap} to discover that
+ * {@code @AIExplain} takes {@code value()} rather than {@code complexityLevel()}, so the skill now
+ * states every element of all 44 annotations. That table is hand-written prose about compiled
+ * facts, which is exactly the shape that rots silently: adding an element, giving one a default or
+ * renaming an enum constant leaves the table confidently wrong and nothing disagrees.
+ *
+ * <p>Four claims are checked against {@code vibetags-annotations}:
+ *
+ * <ul>
+ *   <li>every annotation has a row, and every row an annotation;</li>
+ *   <li>every element is listed, bolded exactly when it has no default. Omitting one of those
+ *       fails the consumer's build, so it is the single thing the reader must not be wrong
+ *       about;</li>
+ *   <li>every enum constant is listed, so the documented constants are the ones that exist;</li>
+ *   <li>the "positional form" and "will not compile bare" lists hold exactly the right
+ *       annotations, including the English word-numbers in the prose introducing them.</li>
+ * </ul>
+ *
+ * <p>Skips gracefully if run from a working directory where the repo layout isn't reachable.
+ */
+class SkillElementTableConsistencyTest {
+
+    /** {@code vibetags/} is the surefire working directory; its parent is the repo root. */
+    private static final Path REPO_ROOT = Paths.get("").toAbsolutePath().getParent();
+
+    private static final Path SKILL = REPO_ROOT.resolve(".claude/skills/vibetags-usage/SKILL.md");
+
+    private static final Path ANNOTATIONS_DIR = REPO_ROOT.resolve(
+        "vibetags-annotations/src/main/java/se/deversity/vibetags/annotations");
+
+    /** An annotation element: four leading spaces, a type, a name, {@code ()}, an optional default. */
+    private static final Pattern ELEMENT = Pattern.compile(
+        "^ {4}([\\w<>\\[\\], .]+?)\\s+(\\w+)\\(\\)\\s*(default\\s+[^;]+)?;", Pattern.MULTILINE);
+
+    private static final Pattern ENUM_BODY = Pattern.compile(
+        "enum\\s+\\w+\\s*\\{(.*?)\\}", Pattern.DOTALL);
+
+    /** A row of the full element table: {@code | `@AIFoo` | ...elements... |}. */
+    private static final Pattern TABLE_ROW = Pattern.compile(
+        "^\\| `@(\\w+)` \\| (.+) \\|$", Pattern.MULTILINE);
+
+    /** A row of the positional-form table: its second cell opens with the annotation applied. */
+    private static final Pattern POSITIONAL_ROW = Pattern.compile(
+        "^\\| `@(\\w+)` \\| `@\\w+\\(", Pattern.MULTILINE);
+
+    /** An entry of the "will not compile bare" list: {@code `@AIFoo(element)`}. */
+    private static final Pattern BARE_ENTRY = Pattern.compile("`@(\\w+)\\(\\w+(?:, \\w+)*\\)`");
+
+    private static final String TABLE_START = "**Every element, in full.**";
+    private static final String TABLE_END = "Enum constants are nested types";
+
+    private static String skillText() throws IOException {
+        assumeTrue(Files.isRegularFile(SKILL), "vibetags-usage skill not reachable; skipping");
+        assumeTrue(Files.isDirectory(ANNOTATIONS_DIR), "annotations module not reachable; skipping");
+        return Files.readString(SKILL, StandardCharsets.UTF_8);
+    }
+
+    /** The slice of {@code text} between two literal markers, both of which must be present. */
+    private static String section(String text, String from, String to) {
+        int start = text.indexOf(from);
+        assertTrue(start >= 0, "cheat sheet marker missing from the skill: " + from);
+        int end = text.indexOf(to, start);
+        assertTrue(end > start, "cheat sheet marker missing from the skill: " + to);
+        return text.substring(start, end);
+    }
+
+    /** Source text of every {@code @AI*} annotation, keyed by simple name. */
+    private static Map<String, String> annotationSources() throws IOException {
+        Map<String, String> sources = new LinkedHashMap<>();
+        List<Path> files = new ArrayList<>();
+        try (Stream<Path> stream = Files.list(ANNOTATIONS_DIR)) {
+            stream.filter(p -> p.getFileName().toString().startsWith("AI"))
+                .filter(p -> p.toString().endsWith(".java"))
+                .sorted()
+                .forEach(files::add);
+        }
+        for (Path file : files) {
+            String name = file.getFileName().toString().replace(".java", "");
+            sources.put(name, Files.readString(file, StandardCharsets.UTF_8));
+        }
+        return sources;
+    }
+
+    /** Comment-free source, so a {@code value()} named only in Javadoc is not mistaken for one. */
+    private static String stripComments(String source) {
+        return source.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("//[^\\n]*", "");
+    }
+
+    /** The full element table, keyed by annotation name, valued by its elements cell. */
+    private static Map<String, String> tableCells(String skill) {
+        Map<String, String> cells = new LinkedHashMap<>();
+        Matcher rows = TABLE_ROW.matcher(section(skill, TABLE_START, TABLE_END));
+        while (rows.find()) {
+            cells.put(rows.group(1), rows.group(2));
+        }
+        return cells;
+    }
+
+    /** Annotations declaring an element named {@code name}, or any element with no default. */
+    private static SortedSet<String> annotationsDeclaring(Map<String, String> sources, String name) {
+        SortedSet<String> found = new TreeSet<>();
+        for (Map.Entry<String, String> entry : sources.entrySet()) {
+            Matcher elements = ELEMENT.matcher(stripComments(entry.getValue()));
+            while (elements.find()) {
+                boolean hit = name == null ? elements.group(3) == null : name.equals(elements.group(2));
+                if (hit) {
+                    found.add(entry.getKey());
+                    break;
+                }
+            }
+        }
+        return found;
+    }
+
+    @Test
+    void everyAnnotationHasARowAndEveryRowAnAnnotation() throws IOException {
+        SortedSet<String> rows = new TreeSet<>(tableCells(skillText()).keySet());
+        assertEquals(new TreeSet<>(annotationSources().keySet()), rows,
+            "the vibetags-usage element table and vibetags-annotations disagree about which "
+                + "annotations exist; update .claude/skills/vibetags-usage/SKILL.md");
+    }
+
+    @Test
+    void everyElementIsListedAndBoldedExactlyWhenItHasNoDefault() throws IOException {
+        Map<String, String> cells = tableCells(skillText());
+        List<String> problems = new ArrayList<>();
+        for (Map.Entry<String, String> entry : annotationSources().entrySet()) {
+            String cell = cells.get(entry.getKey());
+            if (cell == null) {
+                continue;   // reported by everyAnnotationHasARowAndEveryRowAnAnnotation
+            }
+            Matcher elements = ELEMENT.matcher(stripComments(entry.getValue()));
+            while (elements.find()) {
+                String element = elements.group(2);
+                boolean required = elements.group(3) == null;
+                boolean bolded = cell.contains("**`" + element + "`**");
+                if (!cell.contains("`" + element + "`")) {
+                    problems.add(entry.getKey() + "." + element + " is missing from the table");
+                } else if (required && !bolded) {
+                    problems.add(entry.getKey() + "." + element
+                        + " has no default but is not bolded as required");
+                } else if (!required && bolded) {
+                    problems.add(entry.getKey() + "." + element
+                        + " has a default but is bolded as required");
+                }
+            }
+        }
+        assertTrue(problems.isEmpty(),
+            "the vibetags-usage element table is out of date:\n  " + String.join("\n  ", problems));
+    }
+
+    @Test
+    void everyEnumConstantIsListed() throws IOException {
+        Map<String, String> cells = tableCells(skillText());
+        List<String> problems = new ArrayList<>();
+        for (Map.Entry<String, String> entry : annotationSources().entrySet()) {
+            String cell = cells.get(entry.getKey());
+            if (cell == null) {
+                continue;
+            }
+            Matcher enums = ENUM_BODY.matcher(stripComments(entry.getValue()));
+            while (enums.find()) {
+                for (String constant : enums.group(1).split(",")) {
+                    String trimmed = constant.trim();
+                    if (!trimmed.isEmpty() && !cell.contains("`" + trimmed + "`")) {
+                        problems.add(entry.getKey() + "." + trimmed + " is missing from the table");
+                    }
+                }
+            }
+        }
+        assertTrue(problems.isEmpty(),
+            "the vibetags-usage element table lists the wrong enum constants:\n  "
+                + String.join("\n  ", problems));
+    }
+
+    @Test
+    void thePositionalFormListHoldsExactlyTheAnnotationsDeclaringValue() throws IOException {
+        String skill = skillText();
+        SortedSet<String> actual = annotationsDeclaring(annotationSources(), "value");
+
+        String heading = "**The " + englishNumber(actual.size()) + " that take the positional form:**";
+        assertTrue(skill.contains(heading),
+            "the positional-form heading states the wrong count; expected: " + heading);
+
+        SortedSet<String> documented = new TreeSet<>();
+        Matcher rows = POSITIONAL_ROW.matcher(
+            section(skill, heading, "Every row above was compiled to check it."));
+        while (rows.find()) {
+            documented.add(rows.group(1));
+        }
+        assertEquals(actual, documented,
+            "the skill's positional-form table does not match the annotations declaring value()");
+    }
+
+    @Test
+    void theWillNotCompileBareListHoldsExactlyTheAnnotationsWithARequiredElement() throws IOException {
+        String skill = skillText();
+        Map<String, String> sources = annotationSources();
+        SortedSet<String> actual = annotationsDeclaring(sources, null);
+
+        String heading = "**The " + englishNumber(actual.size()) + " that will not compile bare.**";
+        assertTrue(skill.contains(heading),
+            "the \"will not compile bare\" heading states the wrong count; expected: " + heading);
+
+        SortedSet<String> documented = new TreeSet<>();
+        Matcher entries = BARE_ENTRY.matcher(section(skill, heading, "The other "));
+        while (entries.find()) {
+            documented.add(entries.group(1));
+        }
+        assertEquals(actual, documented,
+            "the skill's \"will not compile bare\" list does not match the annotations that have "
+                + "an element with no default");
+
+        int total = sources.size();
+        int positional = annotationsDeclaring(sources, "value").size();
+        String opening = "**" + capitalize(englishNumber(total - positional))
+            + " of the " + englishNumber(total) + " do not**";
+        assertTrue(skill.contains(opening),
+            "the cheat sheet's opening sentence states the wrong counts; expected: " + opening);
+
+        String tail = "The other " + englishNumber(total - actual.size()) + " are usable bare";
+        assertTrue(skill.contains(tail),
+            "the \"usable bare\" sentence states the wrong count; expected: " + tail);
+    }
+
+    private static final String[] UNITS = {
+        "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+        "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen",
+        "eighteen", "nineteen"};
+
+    private static final String[] TENS = {
+        "", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"};
+
+    /** English for 0-99, hyphenated above twenty, matching how the skill writes its counts. */
+    private static String englishNumber(int n) {
+        assertTrue(n >= 0 && n < 100, "no English spelling for " + n);
+        if (n < 20) {
+            return UNITS[n];
+        }
+        return n % 10 == 0 ? TENS[n / 10] : TENS[n / 10] + "-" + UNITS[n % 10];
+    }
+
+    private static String capitalize(String word) {
+        return Character.toUpperCase(word.charAt(0)) + word.substring(1);
+    }
+}


### PR DESCRIPTION
Consumer feedback on a first VibeTags setup named four rough edges. Every one of them fails
silently, which is what made them expensive: the build is green and nothing happens.

## What was wrong, and what it now says

**1. The two-artifact split was undiscoverable.** The skill's install snippet declared only
`vibetags-processor` at `<scope>provided</scope>`. That is the exact shape JDK 23+ ignores, because
javac no longer discovers annotation processors on the class path: it compiles green and writes no
files, with no error and no warning. Nothing in the skill said there were two artifacts, so there
was no way to tell that from a real bug.

Step 1 is now a table of what each artifact is for and what its absence looks like, and the Maven
snippet puts `vibetags-annotations` on the compile path and `vibetags-processor` on
`annotationProcessorPaths`, matching what the README has said all along. The `provided` shape is
called out explicitly as the thing not to do.

**2. `-Avibetags.root` was filed under "Advanced Configuration".** It is not advanced. The
processor writes at the JVM working directory, so a Gradle worker, kapt, or an IDE-driven compile
writes a complete set of guardrail files into a directory the user never looks at, and the project
appears untouched. It is now step 2, with a table of which builds need it and the
`VibeTags: Root resolved: <path>` line the processor already prints on every compile to check it
against.

**3. `@AIExplain`'s element name took `javap` to find.** Thirty-seven of the 44 annotations have no
`value()` element, so the positional shorthand does not compile, and javac's error points at
`method value()` rather than naming the element you should have used. This was never a one-off:
`@AILocked("...")` fails the same way.

The new **element cheat sheet** lists every element of all 44 annotations, bolding the ones with no
default, plus the ten that will not compile bare and the seven that do take the positional form
along with the targets they are legal on.

**4. The `AGENTS.md` note reads as a warning that never goes away.** It is a `NOTE`, it fires by
design whenever `AGENTS.md` is not the sole AI config file, and the marker-pair escape hatch was
buried at the end of a blockquote. The note's own text now opens the explanation, followed by the
three ways to resolve it.

Also added: a **"Verify it actually ran"** step that walks the silent failures in the order they
occur, and seven rows in "Diagnosing Issues" covering the symptoms above.

## Verified, not asserted

- Every positional-form example in the cheat sheet was compiled against
  `vibetags-annotations-1.2.2`. That is how the table gained a "Use on" column:
  `@AIInputSanitized` and `@AISecureLogging` are `PARAMETER`/`FIELD`, not class-level, and my first
  draft had them on a class.
- The `cannot find symbol` / `symbol: method value()` snippet is javac's actual output for
  `@AILocked("Legacy code")`, not a paraphrase. My first draft guessed a different error and was
  wrong.
- Every element, default and enum constant in the table was diffed against the annotation sources.

## The table can't rot

A 44-row hand-written table about compiled facts is the same failure mode the report was about, so
`SkillElementTableConsistencyTest` pins it to `vibetags-annotations`: one row per annotation, every
element listed and bolded exactly when it has no default, every enum constant named, and both
summary lists including the English word-numbers introducing them.

Proven to detect drift rather than assumed to: the table was broken five ways, one per assertion
(drop a row, unbold a required element, rename an enum constant, drop a positional row, drop a
bare-list entry), and each went red. The `add-annotation` skill now names the table so a new
annotation updates it.

## Gates

| Gate | Result |
|---|---|
| `mvn test` (fast tier) | 1313 passed, 0 failed, 0 skipped |
| `mvn test -Pe2e` (what CI runs) | 1941 passed, 0 failed, 0 skipped |
| `mvn verify` checkstyle | 0 violations |
| PMD, CPD, SpotBugs | clean, BUILD SUCCESS |
| `pre-commit run --all-files` | gitleaks, end-of-file, trailing-whitespace passed; **checkstyle hook errored** |

The pre-commit checkstyle hook fails before it reads any source: its Docker image ships
`/opt/run_checkstyle.sh` with CRLF line endings, so bash rejects the script itself. That is
pre-existing and unrelated to this branch (the 1.2.2 changelog already records `pre-commit-java`
being left at v0.2.4 for the same reason). The Maven checkstyle gate that CI actually enforces ran
and reported 0 violations.

## Not done here

The README's install snippet is already correct; only the skill was wrong. `-Avibetags.root` still
appears in the README only inside a kapt snippet, so the same "not advanced" argument could be made
for `README.md` and `USAGE.md`. Left alone, since the ask was the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ByF4XBRxUpgqAGeQHAR5fF
