### PR TITLE
chore: bump async-test-lib to 1.9.4

### DIFF
--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -88,7 +88,7 @@
         <junit.platform.version>6.1.3</junit.platform.version>
         <mockito.version>5.23.0</mockito.version>
         <archunit.version>1.5.0</archunit.version>
-        <async-test-lib.version>1.9.3</async-test-lib.version>
+        <async-test-lib.version>1.9.4</async-test-lib.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <jmh.version>1.37</jmh.version>
 

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.5.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:6.1.3'
     // Concurrency-test harness, matching pom.xml. Resolves from Maven Central like any other dep.
-    testImplementation 'se.deversity.async-test-lib:async-test-lib:1.9.3'
+    testImplementation 'se.deversity.async-test-lib:async-test-lib:1.9.4'
     testImplementation 'org.mockito:mockito-core:5.23.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.23.0'
     // Test-only, matching pom.xml. The processor writes six YAML documents but must not gain a


### PR DESCRIPTION
## Why

Bump async-test-lib 1.9.3 -> 1.9.4 in both places that declare it (`vibetags-parent/pom.xml` property and `vibetags/build.gradle` literal, so the two tiers stay on one detector engine), the sha1-verified artifact from Maven Central (`469f4b43...`). Part of the downstream regression sweep for the 1.9.4 release. Nothing else changed.

## Evidence

Clean worktree off `origin/main`, `vibetags-annotations` installed first.
- `mvn -B test -Pe2e` in `vibetags/`: 1936 tests, 0 failures, 0 errors, 0 skipped.
- `./gradlew --no-daemon test -Pe2e` in `vibetags/`: 1936 tests, 0 skipped, 0 failures, 0 errors.
- Async classes run on both tiers: GuardrailFileWriterAsyncTest, ModuleSidecarAsyncTest, VibeTagsLoggerAsyncTest, VibeTagsLoggerConcurrencyTest, WriteCacheAsyncTest (five; the sweep's table said four, GuardrailFileWriterAsyncTest is new and now recorded).

What 1.9.4 adds that a consumer notices: a three-line PolyForm Noncommercial notice on stderr once per JVM on runs without a validated commercial licence (mock mode included); `AsyncTestRunner` for non-Jupiter frameworks. No detector constant added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EM6m2cki7kMHL4Nd4gkjz
