### PR TITLE
chore: prepare release v1.2.3

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.2.2
+version: 1.2.3
 ---
 
 # VibeTags Usage Guide
@@ -27,7 +27,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
     <dependency>
         <groupId>se.deversity.vibetags</groupId>
         <artifactId>vibetags-annotations</artifactId>
-        <version>1.2.2</version>
+        <version>1.2.3</version>
     </dependency>
 </dependencies>
 
@@ -41,7 +41,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.2</version>
+                        <version>1.2.3</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -63,8 +63,8 @@ the whole processor and its SLF4J/Logback dependencies on your compile classpath
 
 ```groovy
 dependencies {
-    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.2.2'
-    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.2'
+    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.2.3'
+    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.3'
 }
 ```
 
@@ -221,7 +221,7 @@ though the build is green.
 Every way this setup fails is silent, so check rather than assume:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.2 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.2.3 doctor
 ```
 
 Or by hand, in the order things go wrong:
@@ -1287,7 +1287,7 @@ Use on: **class, method, field**
 @AIKeepInSync(mirrors = {"pom.xml:<version>", "README.md badge", "docs/CHANGELOG.md"},
               reason = "The release version is asserted in three places and drifts silently",
               enforcedBy = "ProjectFactsConsistencyTest")
-public static final String VERSION = "1.2.2";
+public static final String VERSION = "1.2.3";
 ```
 
 The element is free to change — the failure mode is a *partial* change that desyncs a mirror no compiler checks. `@AIContract` freezes one signature so it cannot change at all; neither it nor `@AISchemaSafe` expresses "edit A ⇒ you must also edit B". Mirrors routinely point outside the compilation unit, so VibeTags can only *name* them, not verify them.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.2.2</version>
+            <version>1.2.3</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.2</version>
+                        <version>1.2.3</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -94,7 +94,7 @@ touch CLAUDE.md .cursorrules AGENTS.md   # Claude, Cursor, Codex CLI — add whi
 Or let the companion CLI do it (and `vibetags doctor` checks your setup afterwards):
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.2 init --platforms claude,cursor
+jbang se.deversity.vibetags:vibetags-cli:1.2.3 init --platforms claude,cursor
 ```
 
 **3. Annotate your first class:**
@@ -123,8 +123,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.3')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -170,8 +170,8 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.2"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.2"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.3"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.3"))
 
     compileOnly("se.deversity.vibetags:vibetags-annotations")
     kapt("se.deversity.vibetags:vibetags-processor")
@@ -513,7 +513,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.2.2</version>
+            <version>1.2.3</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -538,7 +538,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.2</version>
+                        <version>1.2.3</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -554,8 +554,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.3')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -569,15 +569,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.2'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.2'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.3'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.3'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.
@@ -898,8 +898,8 @@ presence the processor honours (the processor itself never creates them), and
 `VIBETAGS-START`/`END` marker integrity. Run it without installing anything:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.2 init --list
-jbang se.deversity.vibetags:vibetags-cli:1.2.2 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.2.3 init --list
+jbang se.deversity.vibetags:vibetags-cli:1.2.3 doctor
 ```
 
 The platform list and marker rules are read from `vibetags-processor` at runtime, so the CLI

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.3] - 2026-08-19
+
+### Fixed
+
+- **One module no longer appears twice when a Gradle subproject sits below the VibeTags root.**
+  Reported from a repository whose `settings.gradle` declares `include 'app'` at the git root,
+  keeps every Java source under `app/`, and passes `-Avibetags.root` pointing at the git root.
+  Two sidecars existed for what is one module: `.vibetags-mod-_root_` with an empty `modulePath`
+  and `.vibetags-mod-app` with `modulePath=app`, carrying byte-identical bodies for every
+  annotated element. The stale check that retires a sidecar when its module directory is gone
+  cannot retire the first one, because its module path is the root directory and that always
+  exists, so every build emitted both regions into every generated file — 24 rule files, 212
+  duplicated lines, each guardrail stated twice under two `VIBETAGS-MODULE` markers.
+
+  `ModuleSidecar.readAll` now also retires a region whose annotated elements are all claimed by
+  regions of modules nested inside it. An annotated element belongs to exactly one module, so two
+  regions claiming it are the same sources read twice under a less specific identity, and the more
+  specific module wins. Coverage runs downward only and demands full containment: a subproject is
+  never retired by its ancestor, a reactor root that compiles sources of its own keeps at least one
+  element no submodule has and so keeps its region, siblings are never nested under one another,
+  and a sidecar that records no element ids is left alone. Check mode excludes the superseded
+  region without deleting anything. Existing builds heal on the first compile after the upgrade:
+  the processor version is part of the fingerprint, so the short-circuit cannot skip the merge that
+  does the pruning.
+
 ### Changed
 
 - **The `vibetags-usage` skill answers the four questions a first-time consumer actually got
@@ -63,27 +88,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bump, and what to hand over.
 
 ### Fixed
-
-- **One module no longer appears twice when a Gradle subproject sits below the VibeTags root.**
-  Reported from a repository whose `settings.gradle` declares `include 'app'` at the git root,
-  keeps every Java source under `app/`, and passes `-Avibetags.root` pointing at the git root.
-  Two sidecars existed for what is one module: `.vibetags-mod-_root_` with an empty `modulePath`
-  and `.vibetags-mod-app` with `modulePath=app`, carrying byte-identical bodies for every
-  annotated element. The stale check that retires a sidecar when its module directory is gone
-  cannot retire the first one, because its module path is the root directory and that always
-  exists, so every build emitted both regions into every generated file — 24 rule files, 212
-  duplicated lines, each guardrail stated twice under two `VIBETAGS-MODULE` markers.
-
-  `ModuleSidecar.readAll` now also retires a region whose annotated elements are all claimed by
-  regions of modules nested inside it. An annotated element belongs to exactly one module, so two
-  regions claiming it are the same sources read twice under a less specific identity, and the more
-  specific module wins. Coverage runs downward only and demands full containment: a subproject is
-  never retired by its ancestor, a reactor root that compiles sources of its own keeps at least one
-  element no submodule has and so keeps its region, siblings are never nested under one another,
-  and a sidecar that records no element ids is left alone. Check mode excludes the superseded
-  region without deleting anything. Existing builds heal on the first compile after the upgrade:
-  the processor version is part of the fingerprint, so the short-circuit cannot skip the merge that
-  does the pruning.
 
 - **A granular rule file's front matter now follows its inputs.** The `globs:` / `paths:` /
   `applyTo:` list at the top of a rule file is rendered from `.vibetags-roles` (and, for
@@ -2775,7 +2779,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.2.2...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.2.3...HEAD
+[1.2.3]: https://github.com/PIsberg/vibetags/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/PIsberg/vibetags/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/PIsberg/vibetags/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/PIsberg/vibetags/compare/v1.1.1...v1.2.0

--- a/example-all-tiers/pom.xml
+++ b/example-all-tiers/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.2.2</vibetags.bom.version>
+    <vibetags.bom.version>1.2.3</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/example-groovy/build.gradle
+++ b/example-groovy/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.apache.groovy:groovy:5.1.0'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.3')
 
     // Annotations on compile, processor on the annotation-processor path only.
     compileOnly 'se.deversity.vibetags:vibetags-annotations'

--- a/example-kotlin/build.gradle.kts
+++ b/example-kotlin/build.gradle.kts
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and kapt configurations so neither needs an explicit version.
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.2"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.2"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.3"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.3"))
 
     // Annotations on compile, processor on the kapt path only — keeps the processor's
     // slf4j/logback off the consumer's compile classpath. compileOnly is enough:

--- a/example-multimodule-indexed/pom.xml
+++ b/example-multimodule-indexed/pom.xml
@@ -37,7 +37,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.2.2</vibetags.bom.version>
+    <vibetags.bom.version>1.2.3</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/example-multimodule/pom.xml
+++ b/example-multimodule/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.2.2</vibetags.bom.version>
+    <vibetags.bom.version>1.2.3</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/example-scala/build.gradle
+++ b/example-scala/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.scala-lang:scala-library:2.13.18'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.3')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.3')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.2.2</vibetags.bom.version>
+        <vibetags.bom.version>1.2.3</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.2.2</vibetags.bom.version>
+        <vibetags.bom.version>1.2.3</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.2.2'
+version = '1.2.3'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.2.2'
+            version = '1.2.3'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -39,12 +39,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.2.2&lt;/version&gt;
+                &lt;version&gt;1.2.3&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.2'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.2'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.3'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.3'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -36,7 +36,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.2.2&lt;/version&gt;
+                        &lt;version&gt;1.2.3&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.2.2')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.2')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.2.3')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.3')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-cli/pom.xml
+++ b/vibetags-cli/pom.xml
@@ -28,7 +28,7 @@
         reports the project's VibeTags health — build-tool wiring, active platforms,
         marker integrity. Run it without installing anything:
 
-            jbang se.deversity.vibetags:vibetags-cli:1.2.2 init --list
+            jbang se.deversity.vibetags:vibetags-cli:1.2.3 init --list
 
         The platform list and marker rules are read from vibetags-processor, so this
         tool cannot drift from what the processor actually does.

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.2.2</revision>
+        <revision>1.2.3</revision>
 
         <!-- release, not source/target: on a JDK newer than 21 (CI builds 21, 25 and 26)
              source/target compiles against the *running* JDK's API and javac warns that the

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.2.2'
+version = '1.2.3'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.2.2'
+            version = '1.2.3'
             from components.java
 
             pom {
@@ -78,7 +78,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.2.2'
+    api 'se.deversity.vibetags:vibetags-annotations:1.2.3'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.1'

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
@@ -98,6 +98,12 @@ class ReleaseScriptCoverageTest {
         "vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV6DefinitionTest.java",
         "vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV6EndToEndTest.java",
         "vibetags/src/test/java/se/deversity/vibetags/processor/NewAnnotationsV6ValidationTest.java",
+        // Malformed-JSON fixtures. Json's javadoc and JsonTest both use "1.2.3" as an example of
+        // a string a lenient number parser would wrongly accept, and the test asserts it is
+        // rejected. It is a JSON literal, not a coordinate; rewriting it on the release that
+        // happens to be numbered 1.2.3 would break the assertion it exists to make.
+        "vibetags/src/main/java/se/deversity/vibetags/processor/internal/Json.java",
+        "vibetags/src/test/java/se/deversity/vibetags/processor/internal/JsonTest.java",
         // The benchmark plotters. Two default --version to the last release that actually has
         // measurements under load-tests/results/; bumping that on release would aim them at a
         // directory nobody has generated yet. The other two name versions inside a comment


### PR DESCRIPTION
Prepares the 1.2.3 release: version bump, changelog, and two corrections found on the way.

## What 1.2.3 ships

### Fixed

**One module no longer appears twice when a Gradle subproject sits below the VibeTags root**
(#426). A repository whose `settings.gradle` declares `include 'app'` at the git root, keeps every
Java source under `app/`, and passes `-Avibetags.root` pointing at the git root ended up with two
sidecars for one module — `.vibetags-mod-_root_` with an empty `modulePath` and `.vibetags-mod-app`
— carrying byte-identical bodies for every annotated element. The stale check that retires a
sidecar when its module directory is gone cannot retire the first one, because its module path is
the root directory and that always exists. Every build therefore emitted both regions into every
generated file: 24 rule files, 212 duplicated lines, each guardrail stated twice under two
`VIBETAGS-MODULE` markers.

`ModuleSidecar.readAll` now also retires a region whose annotated elements are all claimed by
regions of modules nested inside it. Consumers heal on the first compile after upgrading — the
processor version is part of the build fingerprint, so the short-circuit cannot skip the merge that
does the pruning.

### Changed

The `vibetags-usage` skill now answers the four things a first-time consumer got stuck on, and
`SkillElementTableConsistencyTest` pins its 44-row element cheat sheet to the annotation sources
(#423).

## Two corrections made in this PR

**The #426 changelog entry was in the wrong section.** It was written under the first `### Fixed`
heading in the file, which turned out to belong to the already-released `[1.2.2]` block rather than
`[Unreleased]`, and it merged that way. Moved into `[1.2.3]` where it belongs. No released section
should gain entries after the fact.

**`ReleaseScriptCoverageTest` failed the release build, correctly.** `Json.java` and `JsonTest.java`
use the literal `1.2.3` as an example of a malformed JSON number that a lenient parser would wrongly
accept, and the test asserts it is rejected. That collides with the version being cut, the same
shape as the `pitest-junit5-plugin 1.2.2` pin. Rewriting it would break the assertion it exists to
make, so both files are recorded in the test's `HISTORICAL` list with that reason — the remedy the
failure message itself names.

## Verification

| Gate | Result |
|---|---|
| `BuildVersionParityTest` | 6 tests, pass — no Gradle file, example pom or managed pom disagrees with `<revision>` |
| `mvn test -Pe2e` (vibetags) | **1958 tests, 0 failures, 0 errors** |
| `ReleaseScriptCoverageTest` | pass, after the two JSON fixtures were exempted with a reason |
| Build in order | `vibetags-annotations` → `vibetags` → `vibetags-bom` → `vibetags-cli`, all clean |
| Consumers | `example`, `example-multimodule`, `example-multimodule-indexed` all compile against the freshly installed BOM |
| Guardrail drift | **none** — `git status` after the example builds shows only version bumps, the changelog and the one test file |
| Leftover `1.2.2` references | all expected: the pitest-junit5-plugin pin, the changelog's own history, and gitignored `.flattened-pom.xml` artifacts |
| pre-commit | gitleaks, end-of-file-fixer, trailing-whitespace passed. **`checkstyle` skipped** — its hook needs a Docker daemon that was not running locally. Checkstyle itself did run, bound to Maven's `validate` phase, with 0 violations |

The zero-drift result is worth its own line: the version bump invalidates every consumer's
`BuildFingerprint` and reruns the whole generate phase, so any rendering change would have moved the
examples' committed output here. Nothing moved.

`load-tests/pom.xml` is untouched by design — its `<processor.version>` is pinned independently so
benchmarks can compare across versions.

Merge when CI is green; the GitHub release is cut separately, from `main`, after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcR6MkRWdEJR123DkYq52N
