### PR TITLE
fix: settle two module regions that name the same directory

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Two module regions naming the same directory no longer both survive.** Reported against 1.2.3
+  from a Gradle repository whose `settings.gradle` carries `rootProject.name='x'` beside
+  `include 'x'`: `CLAUDE.md` stated every guardrail twice, under two byte-identical
+  `<!-- VIBETAGS-MODULE -->` blocks.
+
+  The region prune added in 1.2.3 settles an overlap by asking which region is nested under the
+  other, and `isNestedUnder` is false in *both* directions when the two paths are equal. Two
+  regions on one directory therefore fell through it untouched, however completely one covered
+  the other. Equal paths are not a corner case: `computeModulePath` returns `""` for the root
+  project and also for every compilation root it cannot relativize under the VibeTags root, so an
+  out-of-tree root, a `..`-escaping relative path or an `IllegalArgumentException` all land two
+  regions on `""`. That is also why the duplication was intermittent rather than a function of the
+  name collision alone, since it depends on how each round resolved its compilation root.
+
+  Such a pair is now settled the same way as a nested one, by sidecar freshness, with a tie going
+  to the named module over the root identity. The relation is asymmetric for any two distinct
+  regions, so exactly one is retired and every build retires the same one. Retirement still
+  requires full containment, which is what keeps the rule from eating a real module: two genuinely
+  different modules that both land on `""` claim different elements and both keep their region. An
+  unreadable sidecar mtime reads as maximally fresh, so it is now explicitly barred from being the
+  reason a region is retired; duplication is recoverable and a dropped live region is not.
+
+  Per-module output and the `VIBETAGS-MODULE` markers date to 0.9.0, not 1.2.3, and the merge is
+  service-agnostic, so nothing about this was specific to `CLAUDE.md`.
+
 ## [1.2.3] - 2026-08-20
 
 ### Fixed

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
@@ -701,8 +701,16 @@ public final class ModuleSidecar {
      *       that is then dropped and the file would freeze on the departed module's last text.</li>
      * </ul>
      *
+     * <p>A third shape has no nesting at all: two regions naming the <em>same</em> directory,
+     * which is what a Gradle {@code settings.gradle} carrying {@code rootProject.name='x'} beside
+     * {@code include 'x'} produces, and what any two compilations produce when both resolve a
+     * root-like module path. {@code isNestedUnder} is false in both directions for equal paths,
+     * so before this was handled both regions survived and every generated file stated the same
+     * guardrails twice. {@link #yieldsOnSamePath} settles that pair, again by freshness.
+     *
      * <p>Ties go to the more specific module, which is the first case's shape and the historical
-     * default: on equal timestamps a descendant still retires its ancestor, never the reverse.
+     * default: on equal timestamps a descendant still retires its ancestor, never the reverse,
+     * and on one path the named module outlives the root identity.
      *
      * <p>Conservative in every other respect. A region is dropped only when the fresher regions
      * cover <em>all</em> of its elements, so a reactor root that compiles sources of its own keeps
@@ -742,6 +750,9 @@ public final class ModuleSidecar {
                     if (otherWrittenAt >= writtenAt) covered.addAll(otherElements);
                 } else if (isNestedUnder(path, otherPath) && otherWrittenAt > writtenAt) {
                     covered.addAll(otherElements);
+                } else if (path.equals(otherPath)
+                        && yieldsOnSamePath(region, other, writtenAt, otherWrittenAt)) {
+                    covered.addAll(otherElements);
                 }
             });
             if (!covered.isEmpty() && covered.containsAll(elements)) {
@@ -777,6 +788,37 @@ public final class ModuleSidecar {
             p = p.substring(0, p.length() - 1);
         }
         return "_root_".equals(p) ? "" : p;
+    }
+
+    /**
+     * Whether {@code region} gives way to {@code other} when both name the <em>same</em>
+     * directory. Neither is nested under the other, so the ancestor rule cannot separate them,
+     * and without this they both survive and every generated file states the same guardrails
+     * twice under two {@code VIBETAGS-MODULE} markers.
+     *
+     * <p>Freshness decides first, as everywhere else here. A tie goes to the named module over
+     * the root identity, matching the ancestor rule's preference for the more specific of two
+     * identities, and otherwise to the lower region id. The relation is asymmetric for any two
+     * distinct regions, so exactly one of the pair is retired and every build retires the same
+     * one. Containment is still required by the caller, which is what keeps this from eating a
+     * real module: {@code ""} is also the catch-all path for a compilation root that cannot be
+     * relativized, and two genuinely different modules that land on it claim different elements.
+     */
+    private static boolean yieldsOnSamePath(String region, String other,
+                                            long writtenAt, long otherWrittenAt) {
+        // An unreadable mtime reads as Long.MAX_VALUE, i.e. maximally fresh. It must never be
+        // the reason a region is retired: duplication is recoverable, a dropped live region is
+        // not. The caller already refuses to retire a region whose own mtime is unreadable.
+        if (otherWrittenAt == Long.MAX_VALUE) return false;
+        if (otherWrittenAt != writtenAt) return otherWrittenAt > writtenAt;
+        boolean regionIsRoot = isRootRegionId(region);
+        if (regionIsRoot != isRootRegionId(other)) return regionIsRoot;
+        return region.compareTo(other) > 0;
+    }
+
+    /** True for the identity a compilation gets when it resolves to the VibeTags root itself. */
+    private static boolean isRootRegionId(String regionId) {
+        return regionId.isEmpty() || "_root_".equals(regionId);
     }
 
     /** True when {@code candidate} names a directory strictly below {@code ancestor}. */

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/AncestorModuleDuplicateRegionTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/AncestorModuleDuplicateRegionTest.java
@@ -18,19 +18,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Regression tests for a Gradle repository with exactly one included subproject whose directory is
  * a strict subdirectory of the VibeTags root.
  *
- * <p>Reported layout: {@code settings.gradle} at the git root declares {@code include 'mcp-b2bapi'},
- * all Java sources live under {@code mcp-b2bapi/}, and the subproject's {@code compileJava} passes
+ * <p>Reported layout: {@code settings.gradle} at the git root declares {@code include 'webapp'},
+ * all Java sources live under {@code webapp/}, and the subproject's {@code compileJava} passes
  * {@code -Avibetags.root} pointing at the git root, one level above the sources. Two sidecars were
  * on disk for what is really one module:
  *
  * <pre>
  *   .vibetags-mod-_root_       moduleId=_root_      modulePath=
- *   .vibetags-mod-mcp-b2bapi   moduleId=mcp-b2bapi  modulePath=mcp-b2bapi
+ *   .vibetags-mod-webapp   moduleId=webapp  modulePath=webapp
  * </pre>
  *
  * <p>Both carried byte-identical bodies for every annotated element, because both were rendered
  * from the same source tree: the {@code _root_} one from a build whose module identity resolved to
- * the ancestor directory, the {@code mcp-b2bapi} one from a build that resolved the subproject.
+ * the ancestor directory, the {@code webapp} one from a build that resolved the subproject.
  * The stale check in {@code ModuleSidecar.readAll} exempts an empty {@code modulePath} - the root
  * directory always exists - so the ancestor sidecar was immortal, and every subsequent build
  * emitted its region beside the real module's. The result was two {@code VIBETAGS-MODULE} regions
@@ -88,7 +88,7 @@ class AncestorModuleDuplicateRegionTest {
     /** The git root: settings.gradle declaring one subproject, plus a root build file. */
     private void setUpRepo() throws IOException {
         Files.writeString(repoRoot.resolve("settings.gradle"),
-            "rootProject.name = 'mcp-b2bapi'\ninclude 'mcp-b2bapi'\n", StandardCharsets.UTF_8);
+            "rootProject.name = 'webapp'\ninclude 'webapp'\n", StandardCharsets.UTF_8);
         Files.writeString(repoRoot.resolve("build.gradle"),
             "plugins { id 'java' }\n", StandardCharsets.UTF_8);
         Files.createDirectories(repoRoot.resolve(".gemini/rules"));
@@ -96,17 +96,17 @@ class AncestorModuleDuplicateRegionTest {
 
     /** Gives the subproject its own build file, so the module-root walk stops there. */
     private void giveSubprojectItsOwnBuildFile() throws IOException {
-        Files.createDirectories(repoRoot.resolve("mcp-b2bapi"));
-        Files.writeString(repoRoot.resolve("mcp-b2bapi/build.gradle"),
+        Files.createDirectories(repoRoot.resolve("webapp"));
+        Files.writeString(repoRoot.resolve("webapp/build.gradle"),
             "plugins { id 'java' }\n", StandardCharsets.UTF_8);
     }
 
-    /** One {@code :mcp-b2bapi:compileJava} pass, with {@code vibetags.root} at the git root. */
+    /** One {@code :webapp:compileJava} pass, with {@code vibetags.root} at the git root. */
     private void compileSubproject() throws IOException {
         ProcessorTestHarness harness = new ProcessorTestHarness(repoRoot, false);
-        harness.writeSourceFile("mcp-b2bapi/src/main/java/com/example/auth/AuthUtil.java",
+        harness.writeSourceFile("webapp/src/main/java/com/example/auth/AuthUtil.java",
             AUTH_UTIL_SOURCE);
-        harness.writeSourceFile("mcp-b2bapi/src/main/java/com/example/report/ReportBuilder.java",
+        harness.writeSourceFile("webapp/src/main/java/com/example/report/ReportBuilder.java",
             SIBLING_SOURCE);
         harness.compile();
     }
@@ -130,7 +130,7 @@ class AncestorModuleDuplicateRegionTest {
         setUpRepo();
         compileSubproject();                 // resolves to the git root  -> _root_
         giveSubprojectItsOwnBuildFile();
-        compileSubproject();                 // resolves to the subproject -> mcp-b2bapi
+        compileSubproject();                 // resolves to the subproject -> webapp
 
         String authUtil = ruleFile("com-example-auth-AuthUtil");
         assertEquals(1, countOf(authUtil, "## Security-Critical Code"),
@@ -153,7 +153,7 @@ class AncestorModuleDuplicateRegionTest {
         giveSubprojectItsOwnBuildFile();
         compileSubproject();
 
-        assertTrue(Files.exists(repoRoot.resolve(".vibetags-mod-mcp-b2bapi")),
+        assertTrue(Files.exists(repoRoot.resolve(".vibetags-mod-webapp")),
             "the real module's sidecar must stay");
         assertFalse(Files.exists(repoRoot.resolve(".vibetags-mod-_root_")),
             "the ancestor sidecar covers no element the subproject does not, so it must be pruned");

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/internal/SupersededAncestorRegionTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/internal/SupersededAncestorRegionTest.java
@@ -200,4 +200,77 @@ class SupersededAncestorRegionTest {
         assertTrue(regionIds(ModuleSidecar.readAll(root)).contains("app"),
             "the subproject is the fresher identity for the element it claims");
     }
+    // ------------------------------------------- one directory claimed under two identities
+
+    @Test
+    void twoRootLikeRegionsForOneDirectoryResolveToOne(@TempDir Path root) throws IOException {
+        // Reported from a Gradle repo whose settings.gradle carries rootProject.name='x' and
+        // include 'x'. Both compilations resolved a root-like module path: computeModulePath
+        // returns "" for the root project, and also for any compilation root it cannot
+        // relativize under the VibeTags root (an out-of-tree root, a ".."-escaping relative,
+        // or an IllegalArgumentException). Two regions then describe one directory, and
+        // neither is nested under the other, so both were written out verbatim and every
+        // generated file stated the same guardrails twice under two VIBETAGS-MODULE markers.
+        writeSidecar(root, "_root_", "", "com.example.A", "com.example.B");
+        writeSidecar(root, "webapp", "", "com.example.A", "com.example.B");
+        writtenAt(root, "_root_", 1_000_000L);
+        writtenAt(root, "webapp", 2_000_000L);
+
+        assertEquals(List.of("webapp"), regionIds(ModuleSidecar.readAll(root)),
+            "one directory cannot hold two regions; the fresher identity describes it");
+        assertFalse(Files.exists(root.resolve(".vibetags-mod-_root_")));
+    }
+
+    @Test
+    void theStalerOfTwoIdenticallyPathedRegionsIsRetiredEitherWay(@TempDir Path root) throws IOException {
+        // The mirror direction, so the rule cannot be satisfied by always preferring "_root_".
+        writeSidecar(root, "_root_", "", "com.example.A");
+        writeSidecar(root, "webapp", "", "com.example.A");
+        writtenAt(root, "_root_", 2_000_000L);
+        writtenAt(root, "webapp", 1_000_000L);
+
+        assertEquals(List.of("_root_"), regionIds(ModuleSidecar.readAll(root)));
+        assertFalse(Files.exists(root.resolve(".vibetags-mod-webapp")));
+    }
+
+    @Test
+    void twoRegionsOnOneNonRootPathAlsoResolveToOne(@TempDir Path root) throws IOException {
+        // Same shape one level down: a module compiled once under its derived id and once under
+        // an -Avibetags.module override leaves two regions on one directory.
+        Files.createDirectories(root.resolve("app"));
+        writeSidecar(root, "app", "app", "com.example.A");
+        writeSidecar(root, "custom-name", "app", "com.example.A");
+        writtenAt(root, "app", 1_000_000L);
+        writtenAt(root, "custom-name", 2_000_000L);
+
+        assertEquals(List.of("custom-name"), regionIds(ModuleSidecar.readAll(root)));
+    }
+
+    @Test
+    void identicallyPathedRegionsWithDifferentElementsBothSurvive(@TempDir Path root) throws IOException {
+        // The safety net that keeps the new rule from eating a real module. "" is also the
+        // catch-all for a compilation root that cannot be relativized, so two genuinely
+        // different modules can land on it. They claim different elements, so neither covers
+        // the other and both keep their region: containment is what makes retirement safe.
+        writeSidecar(root, "_root_", "", "com.example.A");
+        writeSidecar(root, "other", "", "com.example.B");
+        writtenAt(root, "_root_", 1_000_000L);
+        writtenAt(root, "other", 2_000_000L);
+
+        assertEquals(List.of("_root_", "other"), regionIds(ModuleSidecar.readAll(root)));
+        assertTrue(Files.exists(root.resolve(".vibetags-mod-_root_")));
+    }
+
+    @Test
+    void identicallyPathedRegionsOnEqualTimestampsStillResolveToOne(@TempDir Path root) throws IOException {
+        // Two sidecars written inside one filesystem tick. A tie must not mean "keep both",
+        // which is the duplication, and must land the same way on every build.
+        writeSidecar(root, "_root_", "", "com.example.A");
+        writeSidecar(root, "webapp", "", "com.example.A");
+        writtenAt(root, "_root_", 1_500_000L);
+        writtenAt(root, "webapp", 1_500_000L);
+
+        assertEquals(List.of("webapp"), regionIds(ModuleSidecar.readAll(root)),
+            "a tie goes to the named module, matching the ancestor rule's preference");
+    }
 }


### PR DESCRIPTION
## The defect

Reported against 1.2.3 from a Gradle repository whose `settings.gradle` carries
`rootProject.name='x'` beside `include 'x'`: `CLAUDE.md` stated every guardrail twice, under two
byte-identical `<!-- VIBETAGS-MODULE -->` blocks.

The region prune added in 1.2.3 settles an overlap by asking which region is nested under the
other. `isNestedUnder` returns false in **both** directions when the two paths are equal, so two
regions naming one directory fell through it untouched, however completely one covered the other.

Equal paths are not a corner case. `computeModulePath` returns `""` for the root project and for
every compilation root it cannot relativize under the VibeTags root, so an out-of-tree root, a
`..`-escaping relative path, and an `IllegalArgumentException` all land two regions on `""`.

## Why it was intermittent

The reporter could trigger it twice and then not at all across four further attempts, and read that
as timing or classpath-level double registration of the processor. It is neither. Which regions
collide depends on how each round resolved its compilation root, not on the `settings.gradle` name
collision alone. Double execution would duplicate elements *within* a region; it cannot produce two
separately labelled regions.

## The rule

A same-path pair is now settled the way a nested pair is, by sidecar freshness, with a tie going to
the named module over the root identity. The relation is asymmetric for any two distinct regions,
so exactly one is retired and every build retires the same one.

Retirement still demands full containment, and that is what stops the rule eating a real module:
`""` is also the catch-all for an unrelativizable compilation root, and two genuinely different
modules landing on it claim different elements, so both keep their region. That case is pinned by
`identicallyPathedRegionsWithDifferentElementsBothSurvive`, which passed before this change and
must keep passing.

This also bars an unreadable sidecar mtime from being the reason a region is retired. It reads as
`Long.MAX_VALUE`, i.e. maximally fresh, and the caller already refuses to retire a region whose own
mtime is unreadable. Duplication is recoverable; a dropped live region is not, because the
aggregate is assembled from sidecars and the file would freeze on the departed module's last text.

## Verification

Failing-first. Four of the five new tests were red on the unfixed code with exactly the reported
symptom:

```
expected: <[webapp]> but was: <[_root_, webapp]>
expected: <[_root_]>     but was: <[_root_, webapp]>
expected: <[custom-name]> but was: <[app, custom-name]>
```

After the fix: `SupersededAncestorRegionTest` 17/17, and the full suite from `vibetags/`
(`mvn clean install -Pe2e`) 1985 tests, 0 failures, 0 errors, 0 skipped, including the
pre-existing `AncestorModuleDuplicateRegionTest`, `ModuleFlattenedIntoRootTest` and
`MultiModuleGranularRoleMergeTest` coverage.

`pre-commit`: secrets, end-of-file and trailing-whitespace hooks pass. The `checkstyle` hook is
**not run** locally, it needs a Docker daemon that is not up on this machine, so it is left to CI
rather than reported as passing.

## Two claims from the report that do not hold

Both would misdirect anyone reading the issue later.

- *"1.2.2 didn't have per-module output at all, so this is new in 1.2.3."* The `VIBETAGS-MODULE`
  markers first shipped in **v0.9.0**. What 1.2.3 added was the prune that removes duplicate
  regions; it fixed the nested case and left the equal-path case open.
- *"The bug appears isolated to whichever writer path renders CLAUDE.md's module wrapping."*
  `GeminiRenderer` and the Claude renderer are both plain `PlatformRenderer`s with no
  `mergeShape`/`wholeFileMerge` override, so they share one merge path. GEMINI.md was most likely
  not opted in.

## Still unconfirmed

Whether this is the trigger in the reporter's repository. That turns on the `modulePath=` header in
their two sidecars: equal values (typically both empty) means this covers it, `""` versus
`webapp` means something else produced their duplication.

No version bump here. Shipping this needs a 1.2.4.

## Naming

The fixtures use a neutral module name. The reporting project's own name was carried into
`AncestorModuleDuplicateRegionTest` by the earlier fix and is replaced here. A test reads better
named after the shape it pins than after whoever hit it.
