### PR TITLE
fix: lifecycle hunt — a granular opt-out left a module indexing deleted rule files

### DIFF
--- a/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
@@ -969,6 +969,60 @@ public class AIGuardrailProcessor extends AbstractProcessor {
                     service, behind);
             }
         }
+        warnAboutGranularOptedOutSinceAModuleLastCompiled(activeServices, allSidecars);
+    }
+
+    /**
+     * The opt-out mirror of the loop above, and the reason this pair is about partial merges
+     * generally rather than only about opt-ins. The entry point above kept its narrower name
+     * because renaming it would edit {@code generateFiles()}, which is locked.
+     *
+     * <p>While a granular directory is opted in, each module renders its region as a scoped-rules
+     * index: a list of elements plus the rule file that is authoritative for each. Opting the
+     * directory back out deletes those files. The module that recompiles re-renders its region
+     * inline, but a module that does not keeps the index it rendered earlier, so the aggregate
+     * names rule files that are gone and the guardrail behind them is stated nowhere at all. That
+     * is worse than the opt-in window, where a module is merely absent: here the reader is sent
+     * somewhere empty and the aggregate still calls it authoritative.
+     *
+     * <p>The signal is structural rather than a search of rendered text: a sidecar records the
+     * granular stems it contributed, so a module still holding stems when nothing is opted in is
+     * exactly a module whose region indexes deleted files. Dropping the granular service changes
+     * the fingerprint, so each module repairs its own region on its next compile and a full pass
+     * closes the window.
+     *
+     * <p>Deliberately narrow: silent while <em>any</em> granular service is still opted in, because
+     * stems are recorded per module rather than per service, so a partial opt-out cannot be told
+     * from a live one without a sidecar format change.
+     */
+    private void warnAboutGranularOptedOutSinceAModuleLastCompiled(
+            Set<String> activeServices, List<ModuleSidecar> allSidecars) {
+        if (allSidecars.size() < 2) {
+            return; // Single module: its own round is by definition current.
+        }
+        for (String service : activeServices) {
+            if (service.endsWith("_granular")) {
+                return; // Still opted in somewhere; the collapsed shape is correct.
+            }
+        }
+        List<String> behind = allSidecars.stream()
+            .filter(sidecar -> !sidecar.getGranularStems().isEmpty())
+            .map(ModuleSidecar::getRegionId)
+            .distinct()
+            .sorted()
+            .toList();
+        if (behind.isEmpty()) {
+            return;
+        }
+        getSafeMessager().printMessage(Diagnostic.Kind.WARNING,
+            "VibeTags: the granular rules directory was opted out after "
+                + String.join(", ", behind) + " last compiled, so "
+                + (behind.size() == 1 ? "its region still points" : "their regions still point")
+                + " at rule files that no longer exist. Run a full build to complete the file.");
+        if (log != null) {
+            log.warn("merge.partial modulesBehind={} reason=granular-opted-out-after-last-compile",
+                behind);
+        }
     }
 
     /**

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ProjectLifecycleEndToEndTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ProjectLifecycleEndToEndTest.java
@@ -556,6 +556,69 @@ class ProjectLifecycleEndToEndTest {
         return found;
     }
 
+    /**
+     * The mirror of {@link #optingAPlatformInLater_carriesOnlyTheModulesThatHaveRecompiledSince},
+     * one level in: the granular directory is opted back <em>out</em> in a reactor.
+     *
+     * <p>{@code GuardrailLifecycleEndToEndTest} pins the single-module shape, where the aggregate
+     * returns to inline guardrails rather than keeping an index pointing at a path nobody
+     * generates. In a reactor only the module that recompiles gets that treatment. A module that
+     * did not recompile keeps the body it rendered while granular was active, which is a
+     * scoped-rules index naming rule files the opt-out just deleted — so its guardrail is stated
+     * nowhere at all, and the aggregate tells the agent that a file which no longer exists is the
+     * authoritative source for it. That is strictly worse than the late-opt-in case, where the
+     * module is merely absent: here the reader is actively sent somewhere empty.
+     *
+     * <p>The window is real but self-healing, exactly like the opt-in twin: dropping the granular
+     * service changes the fingerprint, so each module fixes its own region on its next compile.
+     * The build that opens the window therefore has to say so and name who is behind.
+     */
+    @Test
+    void optingTheGranularDirectoryOut_warnsAboutModulesStillPointingAtDeletedRuleFiles(
+            @TempDir Path root) throws Exception {
+        Files.createFile(root.resolve("CLAUDE.md"));
+        Files.createDirectories(root.resolve(".claude/rules"));
+        compileModule(root, "module-a", "com.example.a.Alpha", context("com.example.a", "Alpha", "alpha-routing"));
+        compileModule(root, "module-b", "com.example.b.Beta", context("com.example.b", "Beta", "beta-routing"));
+        assertTrue(Files.readString(root.resolve("CLAUDE.md")).contains("<scoped_rules>"),
+            "precondition: the aggregate is collapsed to an index while granular is opted in");
+
+        deleteRecursively(root.resolve(".claude"));
+        ProcessorTestHarness.awaitFilesystemTick(root);
+        VibeTagsLogger.shutdown();
+
+        List<String> warnings = compileModuleCapturingWarnings(root, "module-a",
+            "com.example.a.Alpha", context("com.example.a", "Alpha", "alpha-routing"));
+
+        assertTrue(warnings.stream().anyMatch(w -> w.contains("module-b")
+                && w.contains("Run a full build")),
+            "the build that opens the window has to name the module whose region still points at "
+                + "deleted rule files. Silence is the whole defect: the aggregate is well-formed "
+                + "and looks complete, and the missing guardrail is invisible. Warnings were:\n  "
+                + String.join("\n  ", warnings));
+
+        String partial = Files.readString(root.resolve("CLAUDE.md"), StandardCharsets.UTF_8);
+        assertTrue(partial.contains("alpha-routing"),
+            "the module that recompiled must state its guardrails inline again");
+        assertTrue(partial.contains(".claude/rules/com-example-b-Beta.md"),
+            "measured limitation: the module that did not recompile keeps its collapsed body, so "
+                + "the aggregate still names a rule file the opt-out deleted. If this now fails, "
+                + "the dangling-pointer window has been closed - assert the guardrail is inline "
+                + "instead");
+        assertFalse(Files.exists(root.resolve(".claude/rules/com-example-b-Beta.md")),
+            "and that named file is genuinely gone, which is what makes the pointer dangling");
+
+        ProcessorTestHarness.awaitFilesystemTick(root);
+        VibeTagsLogger.shutdown();
+        compileModule(root, "module-b", "com.example.b.Beta", context("com.example.b", "Beta", "beta-routing"));
+
+        String healed = Files.readString(root.resolve("CLAUDE.md"), StandardCharsets.UTF_8);
+        assertTrue(healed.contains("alpha-routing") && healed.contains("beta-routing"),
+            "a full reactor pass must return every module to inline guardrails");
+        assertFalse(healed.contains("<scoped_rules>"),
+            "and leave no index behind pointing at a directory nobody generates");
+    }
+
     private static void deleteRecursively(Path dir) throws IOException {
         if (!Files.exists(dir)) return;
         try (Stream<Path> files = Files.walk(dir)) {
@@ -569,6 +632,13 @@ class ProjectLifecycleEndToEndTest {
         return "package " + pkg + ";\n"
             + "import se.deversity.vibetags.annotations.AILocked;\n"
             + "@AILocked(reason = \"" + reason + "\")\n"
+            + "public class " + type + " {}\n";
+    }
+
+    private static String context(String pkg, String type, String focus) {
+        return "package " + pkg + ";\n"
+            + "import se.deversity.vibetags.annotations.AIContext;\n"
+            + "@AIContext(focus = \"" + focus + "\")\n"
             + "public class " + type + " {}\n";
     }
 


### PR DESCRIPTION
Lifecycle bug hunt under the `correctness-hunt` work order: opt-in/opt-out transitions,
withdrawal, module departure, source-set changes, repeated builds.

## Baseline

`mvn test -Pe2e` from `vibetags/` before touching anything: **1985 tests, 0 failures, 0 errors,
0 skipped**. Green, so findings are separable from pre-existing breakage.

## Bug 1: a granular opt-out leaves a module indexing deleted rule files

**Commit** `b461734`
**File** `AIGuardrailProcessor.java`

**Defect.** While a granular rules directory is opted in, each module renders its region as a
scoped-rules index: elements plus the rule file that is authoritative for each. Opting the
directory back out deletes those files. In a reactor, only the module that recompiles re-renders
its region inline. A module that does not keeps the index it rendered earlier, so its guardrail is
stated nowhere at all: not inline, because its region is collapsed, and not in a rule file, because
the opt-out removed it.

**Failure scenario.** Two modules, `.claude/rules/` opted in, both compile. Delete `.claude/`.
Recompile only `module-a`. The aggregate is well-formed and looks complete, and contains:

```
<!-- VIBETAGS-MODULE: module-b -->
  <scoped_rules>
    <element path="com.example.b.Beta" rules=".claude/rules/com-example-b-Beta.md"/>
  </scoped_rules>
<rule>... The rule files are the authoritative source for those elements.</rule>
```

with that path absent from disk. The agent is sent somewhere empty and told it is authoritative.
`GuardrailLifecycleEndToEndTest` pins the single-module shape, which passes only because that
module always recompiles; the reactor twin had no coverage.

**Fix rationale.** This is the mirror of the platform-opted-in-late window and gets the same
treatment: the window is real, self-healing on each module's next compile (dropping the granular
service changes the fingerprint), and the build that opens it now names who is behind. It is
strictly worse than the opt-in case, where a stale module is merely absent, so silence was the
whole defect.

The signal is structural rather than a search of rendered text: a sidecar records the granular
stems it contributed, so a module still holding stems while nothing is opted in is exactly a module
whose region indexes deleted files. Deliberately silent while any granular service is still opted
in, because stems are recorded per module rather than per service and telling a partial opt-out
from a live one would need a sidecar format change.

**Lock respected.** `generateFiles()` is in `<locked_files>`. The new check is called from the
existing warning method that `generateFiles()` already invokes, not from a new call site.
`generateFiles()` was verified byte-identical to HEAD (22143 chars, unchanged); the only hunk in
the file is a pure addition below it. That is also why the entry point keeps its narrower name:
renaming it would edit the locked method.

**Verified failing-first.** Red with the warning list empty, then green. `ProjectLifecycleEndToEndTest` 11/11.

## Suspicions, unresolved

**A lost granular rule file is never restored by a sibling's build.** Held back because the fix is
a design decision about write reach, not a code slip, and it is not mine to make.

Reproduced: two modules with `.claude/rules/` opted in, both compile, delete
`.claude/rules/com-example-b-Beta.md`, then build `module-a` only. Measured:

```
module-b sidecar records stems=true contributions=true
beta rule restored by module-a build = false
aggregate still indexes it = true
```

So the content needed to rewrite the file is present in `module-b`'s sidecar (which is what the
contributions added in #365 are for), the aggregate keeps pointing at the file, and no sibling
build restores it. The mechanism, read rather than guessed: `writeAll` at
`AIGuardrailProcessor:845` is handed `ModuleSidecar.mergeGranular(allSidecars)` as merged content,
but the write plan comes from `built.elementRules`, the compiling module's own elements. Line 846
adds sibling stems to the cleanup-exclusion set, so siblings' files are protected from deletion but
never rewritten.

That looks deliberate: each module owns its own granular files. Changing it means letting one
module write into another module's rule files, which is the same reach that deleted 256 committed
rule files in #383, inverted. It also widens the dangling-pointer window from bug 1 to "any lost
rule file", not just an opt-out. Worth a decision; I did not make it.

## Lifecycles probed and found sound

No change needed, each driven end to end: a departed module that returns; a module's own nested
output opted back out; a hand-deleted rule file regenerated in a single-module project; a departed
module leaving the locks report; repeated builds converging inside the opt-out window; and granular
opted in late, where a module that has not recompiled correctly stays **inline** rather than
collapsing, so no pointer dangles.

Two early probe failures were wrong expectations rather than defects, and are recorded so nobody
re-files them: emptying a module of every annotation is the documented pinned limitation
`emptyingAModuleEntirely_…`, and `@AILocked` is a safety bucket that correctly stays inline under
invariant 6.

The lean indexed root has bug 1's shape but is immune by construction: `applyRootIndexModeTo`
consults `.vibetags-root-index` at read time during the merge, so every region switches together
rather than each carrying a baked-in shape.

## Verification

- Baseline: `mvn test -Pe2e`, 1985 tests, 0 failures, 0 errors, 0 skipped.
- Final, everything staged first: `mvn clean install -Pe2e`, **1986 tests, 0 failures, 0 errors,
  0 skipped**, BUILD SUCCESS.
- `pre-commit run --all-files`: secrets, end-of-file and trailing-whitespace hooks pass. The
  `checkstyle` hook is **not run** locally, it needs a Docker daemon that is not up on this
  machine, so it is left to CI rather than reported as passing.
