### PR TITLE
fix: close all four open issues (#435 sibling rule files, #436 out-of-tree ids, #437 BOM, #438 duplicate regions)

### DIFF
--- a/examples/basic/reset-ai-files.sh
+++ b/examples/basic/reset-ai-files.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Reset all AI config files to empty (preserves files so processor opt-in stays active).
 # Use this before a clean compile to verify the processor regenerates all content.
 set -eu

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
@@ -970,7 +970,106 @@ public class AIGuardrailProcessor extends AbstractProcessor {
             }
         }
         warnAboutGranularOptedOutSinceAModuleLastCompiled(activeServices, allSidecars);
+        warnAboutSiblingRuleFilesThatAreMissing(activeServices, serviceFiles, allSidecars);
     }
+
+    /**
+     * Warns when the aggregate will keep naming a granular rule file that is not on disk and that
+     * this build will not write.
+     *
+     * <p>Each module writes only its own granular files: the write plan comes from the compiling
+     * module's elements, and a sibling's stems are added to the cleanup-exclusion set so they are
+     * protected from deletion rather than rewritten. That is deliberate, because writing into
+     * another module's rule files is the reach that deleted 256 committed files in issue #383,
+     * inverted. The consequence is that a file lost to {@code git clean}, a bad merge or a granular
+     * opt-out round trip stays lost until its own module recompiles, while the aggregate still
+     * points at it as the authoritative source. The guardrail is then stated nowhere: not inline,
+     * because the region is collapsed to an index, and not in a rule file, because it is gone.
+     *
+     * <p>Restoring it here would need the sidecar format to change — a {@code GranularContribution}
+     * carries globs and body but neither the description nor the display name the renderer needs —
+     * so this reports instead of repairing (issue #435).
+     *
+     * <p>The compiling module's own stems are excluded, because this build is about to write them:
+     * without that, every first build would warn about the files it is in the middle of creating.
+     */
+    private void warnAboutSiblingRuleFilesThatAreMissing(Set<String> activeServices,
+                                                         Map<String, Path> serviceFiles,
+                                                         List<ModuleSidecar> allSidecars) {
+        if (allSidecars.size() < 2) {
+            return; // Nobody else to have lost a file.
+        }
+        Set<String> granularServices = new java.util.LinkedHashSet<>();
+        for (String service : activeServices) {
+            if (service.endsWith("_granular") && serviceFiles.get(service) != null) {
+                granularServices.add(service);
+            }
+        }
+        if (granularServices.isEmpty()) {
+            return;
+        }
+        Set<String> mine = GranularRulesWriter
+            .contributionsFor(elementRules, RoleConfig.load(root)).keySet();
+
+        List<String> missing = new java.util.ArrayList<>();
+        for (String service : granularServices) {
+            Path dir = serviceFiles.get(service);
+            if (dir == null) {
+                continue; // Re-checked for the null analysis: the map lookup is @Nullable.
+            }
+            Set<String> present = filenamesIn(dir);
+            for (ModuleSidecar sidecar : allSidecars) {
+                for (String stem : sidecar.getGranularStems()) {
+                    if (mine.contains(stem) || hasFileFor(present, stem)) {
+                        continue;
+                    }
+                    String entry = sidecar.getRegionId() + "'s " + stem;
+                    if (!missing.contains(entry)) {
+                        missing.add(entry);
+                    }
+                }
+            }
+        }
+        if (missing.isEmpty()) {
+            return;
+        }
+        java.util.Collections.sort(missing);
+        getSafeMessager().printMessage(Diagnostic.Kind.WARNING,
+            "VibeTags: the generated files name " + String.join(", ", missing)
+                + " as the authoritative rule file(s) for those elements, but they are not on disk"
+                + " and this build does not write another module's files. Their guardrails are"
+                + " stated nowhere until that module recompiles. Run a full build to restore them.");
+        if (log != null) {
+            log.warn("granular.missing entries={} reason=sibling-file-absent", missing);
+        }
+    }
+
+    /** Filenames directly inside {@code dir}, or empty when it cannot be listed. */
+    private static Set<String> filenamesIn(Path dir) {
+        if (!Files.isDirectory(dir)) {
+            return Set.of();
+        }
+        try (java.util.stream.Stream<Path> entries = Files.list(dir)) {
+            return entries.map(Path::getFileName)
+                .filter(java.util.Objects::nonNull)
+                .map(Path::toString)
+                .collect(Collectors.toCollection(java.util.LinkedHashSet::new));
+        } catch (IOException | RuntimeException unreadable) {
+            return Set.of(); // A diagnostic must never be the thing that fails a build.
+        }
+    }
+
+    /** Whether any of {@code present} is a rendering of {@code stem}, whatever the extension. */
+    private static boolean hasFileFor(Set<String> present, String stem) {
+        String prefix = stem + ".";
+        for (String name : present) {
+            if (name.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 
     /**
      * The opt-out mirror of the loop above, and the reason this pair is about partial merges

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
@@ -124,6 +124,9 @@ public final class ModuleSidecar {
 
     private static final int MULTI_MODULE_THRESHOLD = 2;
 
+    /** Cap on the readable half of an out-of-tree module id; the rest is a hash. */
+    private static final int MAX_READABLE_ID = 24;
+
     /** Module sub-marker embedded inside the outer VIBETAGS-START/END block. */
     public static final String SUB_MARKER_MD_FORMAT = "<!-- VIBETAGS-MODULE: %s -->";
     public static final String SUB_MARKER_MD_END_FORMAT = "<!-- VIBETAGS-MODULE-END: %s -->";
@@ -1252,17 +1255,39 @@ public final class ModuleSidecar {
             Path rel = vibetagsRoot.relativize(compilationRoot);
             String relStr = rel.toString();
             if (relStr.isEmpty() || ".".equals(relStr)) return "_root_";
-            // If the compilation root is not *under* the VibeTags root, the relative path escapes
-            // upward (starts with ".."). Such an id is meaningless and, worse, unbounded in length:
-            // an output dir or @TempDir far from the project can produce a filename that exceeds the
-            // OS limit (seen on macOS, where save() then fails with ENAMETOOLONG and no sidecar is
-            // written). Fall back to a short stable hash, as the different-root case below does.
+            // The compilation root is not *under* the VibeTags root, so the relative path escapes
+            // upward. Two things are needed at once. The id has to be bounded, because it becomes
+            // the sidecar filename and an unbounded one fails with ENAMETOOLONG and writes no
+            // sidecar at all (seen on macOS, from an output dir or @TempDir far from the project).
+            // And it has to be a property of the *layout* rather than of where the repository is
+            // checked out, because it also appears in every VIBETAGS-MODULE marker in committed
+            // output: an id derived from the absolute path made the same repository generate
+            // different files on two machines, so check mode reported drift on a correct tree
+            // (issue #436).
+            //
+            // The relative path satisfies both. It is short, it is the same from any checkout
+            // location, and String.hashCode() is specified by the language rather than left to the
+            // implementation the way Path.hashCode() is, so it agrees across JVMs. Separators are
+            // normalised so Windows and Linux agree on the same layout. The directory name is kept
+            // in front to leave the id legible.
             if (rel.getNameCount() > 0 && "..".equals(rel.getName(0).toString())) {
-                return Integer.toHexString(compilationRoot.hashCode() & 0x7fffffff);
+                String normalised = relStr.replace(BACKSLASH, '/');
+                String hash = Integer.toHexString(normalised.hashCode() & 0x7fffffff);
+                Path name = compilationRoot.getFileName();
+                if (name == null) {
+                    return hash;
+                }
+                String readable = sanitizeId(name.toString());
+                if (readable.length() > MAX_READABLE_ID) {
+                    readable = readable.substring(0, MAX_READABLE_ID);
+                }
+                return readable.isEmpty() ? hash : readable + "_" + hash;
             }
             return sanitizeId(relStr.replace(java.io.File.separatorChar, '_'));
         } catch (IllegalArgumentException e) {
-            // Different filesystem roots (e.g., Windows different drives)
+            // Different filesystem roots (e.g. Windows drives), where there is no relative path to
+            // derive anything from. This id still moves with the checkout, but the layout offers
+            // nothing stable to replace it with.
             return Integer.toHexString(compilationRoot.hashCode() & 0x7fffffff);
         }
     }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/GranularSiblingFileLossTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/GranularSiblingFileLossTest.java
@@ -1,0 +1,130 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A granular rule file belonging to one module, lost while a different module builds.
+ *
+ * <p>Each module writes its own granular files: the write plan comes from the compiling module's
+ * own elements, and a sibling's stems are added only to the cleanup-exclusion set, so they are
+ * protected from deletion but never rewritten. That is deliberate — letting one module write into
+ * another's rule files is the reach that deleted 256 committed files in issue #383, inverted.
+ *
+ * <p>The cost is that a file lost to {@code git clean}, a bad merge or a granular opt-out round
+ * trip stays lost until its own module recompiles, while the aggregate keeps naming it as the
+ * authoritative source for the element. The guardrail is then stated nowhere: not inline, because
+ * the region is collapsed to an index, and not in a rule file, because it is gone.
+ *
+ * <p>Restoring it here is not possible without changing the sidecar format — a
+ * {@code GranularContribution} is globs plus body, carrying neither the description nor the
+ * display name the renderer needs — so the build says so instead. See issue #435.
+ */
+@Tag("e2e")
+class GranularSiblingFileLossTest {
+
+    private static final String NL = System.lineSeparator();
+    private static final String Q = String.valueOf((char) 34);
+
+    @AfterEach
+    void releaseLogHandle() {
+        VibeTagsLogger.shutdown();
+    }
+
+    @Test
+    void aSiblingsRuleFileLostToGitCleanIsReportedRatherThanSilentlyLeftMissing(@TempDir Path root)
+            throws Exception {
+        Files.createFile(root.resolve("CLAUDE.md"));
+        Files.createDirectories(root.resolve(".claude/rules"));
+        compileModule(root, "module-a", "com.example.a.Alpha", ctx("com.example.a", "Alpha", "alpha-routing"));
+        compileModule(root, "module-b", "com.example.b.Beta", ctx("com.example.b", "Beta", "beta-routing"));
+
+        Path betaRule = root.resolve(".claude/rules/com-example-b-Beta.md");
+        assertTrue(Files.exists(betaRule), "precondition: module-b wrote its rule file");
+
+        // Lost to git clean, a bad merge, or a granular opt-out round trip.
+        Files.delete(betaRule);
+        ProcessorTestHarness.awaitFilesystemTick(root);
+        VibeTagsLogger.shutdown();
+
+        List<String> warnings = compileModuleCapturingWarnings(root, "module-a",
+            "com.example.a.Alpha", ctx("com.example.a", "Alpha", "alpha-routing"));
+
+        assertTrue(warnings.stream().anyMatch(w -> w.contains("com-example-b-Beta")),
+            "the aggregate still names this file as authoritative, so a build that leaves it "
+                + "missing has to say so. Silence is the whole defect: the guardrail is stated "
+                + "nowhere and the file looks complete. Warnings were:" + NL + "  "
+                + String.join(NL + "  ", warnings));
+
+        assertFalse(Files.exists(betaRule),
+            "measured limitation: a sibling's build does not restore it, because the sidecar "
+                + "carries globs and body but neither the description nor the display name the "
+                + "renderer needs. If this now fails, restoring has been implemented and the "
+                + "warning should go with it");
+    }
+
+    /** The guard: nothing missing, nothing said. */
+    @Test
+    void staysSilentWhenEverySiblingRuleFileIsPresent(@TempDir Path root) throws Exception {
+        Files.createFile(root.resolve("CLAUDE.md"));
+        Files.createDirectories(root.resolve(".claude/rules"));
+        compileModule(root, "module-a", "com.example.a.Alpha", ctx("com.example.a", "Alpha", "alpha-routing"));
+        compileModule(root, "module-b", "com.example.b.Beta", ctx("com.example.b", "Beta", "beta-routing"));
+
+        ProcessorTestHarness.awaitFilesystemTick(root);
+        VibeTagsLogger.shutdown();
+        List<String> warnings = compileModuleCapturingWarnings(root, "module-a",
+            "com.example.a.Alpha", ctx("com.example.a", "Alpha", "alpha-routing"));
+
+        assertTrue(warnings.stream().noneMatch(w -> w.contains("com-example-b-Beta")),
+            "an intact reactor must never see this. Warnings were:" + NL + "  "
+                + String.join(NL + "  ", warnings));
+    }
+
+    private static String ctx(String pkg, String type, String focus) {
+        return "package " + pkg + ";" + NL
+            + "import se.deversity.vibetags.annotations.AIContext;" + NL
+            + "@AIContext(focus = " + Q + focus + Q + ")" + NL
+            + "public class " + type + " {}" + NL;
+    }
+
+    private static void compileModule(Path root, String module, String fqn, String source)
+            throws IOException {
+        ProcessorTestHarness harness = newHarness(root, module, fqn, source);
+        harness.compile();
+        VibeTagsLogger.shutdown();
+    }
+
+    private static List<String> compileModuleCapturingWarnings(Path root, String module, String fqn,
+                                                               String source) throws IOException {
+        ProcessorTestHarness harness = newHarness(root, module, fqn, source);
+        List<String> warnings = harness.compileReturningDiagnostics().stream()
+            .filter(d -> d.getKind() == javax.tools.Diagnostic.Kind.WARNING
+                || d.getKind() == javax.tools.Diagnostic.Kind.MANDATORY_WARNING)
+            .map(d -> d.getMessage(null))
+            .toList();
+        VibeTagsLogger.shutdown();
+        return warnings;
+    }
+
+    private static ProcessorTestHarness newHarness(Path root, String module, String fqn, String source)
+            throws IOException {
+        ProcessorTestHarness harness = new ProcessorTestHarness(root, false);
+        Files.createDirectories(root.resolve(module));
+        Files.writeString(root.resolve(module).resolve("pom.xml"),
+            "<project><artifactId>" + module + "</artifactId></project>", StandardCharsets.UTF_8);
+        harness.writeSourceFile(module + "/src/main/java/" + fqn.replace((char) 46, (char) 47) + ".java", source);
+        return harness;
+    }
+}

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/MultiModuleProcessorTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/MultiModuleProcessorTest.java
@@ -191,14 +191,21 @@ class MultiModuleProcessorTest {
         // single-module test, where the root is a @TempDir far from the project dir), relativize
         // produces a long "../../.."-laden path. Used verbatim as a filename, that can exceed the
         // OS limit — on macOS save() then failed with ENAMETOOLONG and wrote no sidecar. The id
-        // must instead be a short, stable hash with no path segments.
+        // must instead be short, with no path segments.
+        //
+        // The id was a bare hex hash of the ABSOLUTE path until issue #436, which made the same
+        // layout produce different ids on different machines and so broke reproducibility of
+        // committed output. It is now the directory name plus a hash of the path relative to the
+        // root. This test asserts the properties that made the original form necessary — bounded,
+        // no separators, no "..", stable — rather than the form itself, which is what changed.
         Path vibetagsRoot = tmp.resolve("project");
         Path compilationRoot = tmp.resolve("somewhere").resolve("else").resolve("deep");
 
         String id = ModuleSidecar.computeModuleId(compilationRoot, vibetagsRoot);
 
-        assertTrue(id.matches("[0-9a-f]+"),
-            "an out-of-tree compilation root must yield a short hex hash id, got: " + id);
+        assertTrue(id.length() <= 64, "module id must stay short enough to be a filename, got: " + id);
+        assertTrue(id.matches("[0-9a-zA-Z_-]+"),
+            "module id must contain no path separators or other filename-hostile characters, got: " + id);
         assertTrue(!id.contains(".."),
             "module id must never embed '..' path segments (filename-length risk), got: " + id);
         assertTrue(id.equals(ModuleSidecar.computeModuleId(compilationRoot, vibetagsRoot)),

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ShellScriptEncodingTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ShellScriptEncodingTest.java
@@ -1,0 +1,83 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * No tracked shell script may begin with a UTF-8 byte order mark.
+ *
+ * <p>A BOM sits in front of the shebang, so line 1 is no longer a comment. Run through
+ * {@code bash script.sh} the interpreter treats those three bytes plus {@code #!/usr/bin/env} as a
+ * command, fails to find it, and carries on with the rest of the file; run through the shebang it
+ * fails outright. The first form is the dangerous one, because the script still does its work and
+ * the step still passes, so the error sits in the log indefinitely.
+ *
+ * <p>That is exactly what happened: {@code examples/basic/reset-ai-files.sh} carried a BOM and
+ * every CI run logged {@code reset-ai-files.sh: line 1: #!/usr/bin/env: No such file or directory}
+ * while reporting success. An editor writing UTF-8-with-signature is all it takes to reintroduce
+ * it, which is why this is a test rather than a one-off fix.
+ */
+class ShellScriptEncodingTest {
+
+    private static final Path REPO_ROOT = Paths.get("").toAbsolutePath().getParent();
+    private static final byte[] UTF8_BOM = {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+
+    @Test
+    void noTrackedShellScriptStartsWithAByteOrderMark() throws Exception {
+        List<String> tracked = trackedFiles();
+        assumeTrue(!tracked.isEmpty(), "git did not list any tracked files; skipping");
+
+        List<String> scripts = tracked.stream().filter(f -> f.endsWith(".sh")).toList();
+        assumeTrue(!scripts.isEmpty(), "no tracked shell scripts; skipping");
+
+        List<String> offenders = new ArrayList<>();
+        for (String script : scripts) {
+            Path file = REPO_ROOT.resolve(script);
+            if (!Files.isRegularFile(file)) {
+                continue; // Listed but not checked out (sparse checkout, or a submodule path).
+            }
+            byte[] head = readFirstBytes(file, UTF8_BOM.length);
+            if (java.util.Arrays.equals(head, UTF8_BOM)) {
+                offenders.add(script);
+            }
+        }
+
+        assertTrue(offenders.isEmpty(),
+            "these shell scripts start with a UTF-8 BOM, which puts three bytes in front of the "
+                + "shebang and makes line 1 fail as a command instead of being read as a comment. "
+                + "Re-save them as UTF-8 without a signature: " + String.join(", ", offenders));
+    }
+
+    private static byte[] readFirstBytes(Path file, int count) throws IOException {
+        try (var in = Files.newInputStream(file)) {
+            return in.readNBytes(count);
+        }
+    }
+
+    private static List<String> trackedFiles() throws IOException, InterruptedException {
+        ProcessBuilder pb = new ProcessBuilder("git", "ls-files");
+        pb.directory(REPO_ROOT.toFile());
+        pb.redirectErrorStream(true);
+        Process p = pb.start();
+        List<String> files = new ArrayList<>();
+        try (Stream<String> lines = new BufferedReader(
+                new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8)).lines()) {
+            lines.map(String::trim).filter(s -> !s.isEmpty()).forEach(files::add);
+        }
+        p.waitFor();
+        return files;
+    }
+}

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/internal/SupersededAncestorRegionTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/internal/SupersededAncestorRegionTest.java
@@ -6,11 +6,13 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -273,4 +275,93 @@ class SupersededAncestorRegionTest {
         assertEquals(List.of("webapp"), regionIds(ModuleSidecar.readAll(root)),
             "a tie goes to the named module, matching the ancestor rule's preference");
     }
+
+    // ------------------------------------------------ out-of-tree ids must not move with the tree
+
+    /**
+     * A module outside the VibeTags root is filed under an id derived from where it sits relative
+     * to that root, not from where the checkout happens to live.
+     *
+     * <p>The id reaches committed output: it is the sidecar filename and the name in every
+     * {@code VIBETAGS-MODULE} marker. Deriving it from the absolute path meant the same repository
+     * produced different generated files on two machines, so committed output stopped reproducing
+     * and check mode reported drift on a tree where nothing was wrong. Reachable through ordinary
+     * layouts: Gradle {@code includeFlat} or a {@code projectDir} override, and Maven
+     * {@code <module>../sibling</module>}. See issue #436.
+     */
+    @Test
+    void outOfTreeModuleIdIsTheSameFromAnyCheckoutLocation() {
+        String here = ModuleSidecar.computeModuleId(
+            Paths.get("/home/alice/work/repo/lib"), Paths.get("/home/alice/work/repo/app"));
+        String there = ModuleSidecar.computeModuleId(
+            Paths.get("/ci/runner/build/repo/lib"), Paths.get("/ci/runner/build/repo/app"));
+
+        assertEquals(here, there,
+            "the same layout under a different checkout root must produce the same module id, or "
+                + "committed generated files stop reproducing across machines");
+    }
+
+    /** Two different out-of-tree modules must still be told apart, or they share a sidecar. */
+    @Test
+    void differentOutOfTreeModulesStillGetDifferentIds() {
+        String lib = ModuleSidecar.computeModuleId(
+            Paths.get("/home/alice/repo/lib"), Paths.get("/home/alice/repo/app"));
+        String tools = ModuleSidecar.computeModuleId(
+            Paths.get("/home/alice/repo/tools"), Paths.get("/home/alice/repo/app"));
+
+        assertNotEquals(lib, tools, "two modules sharing an id would share a sidecar");
+    }
+
+    /** Same directory name, different place: the id must still separate them. */
+    @Test
+    void outOfTreeModulesWithTheSameDirectoryNameAreStillDistinct() {
+        String near = ModuleSidecar.computeModuleId(
+            Paths.get("/home/alice/repo/lib"), Paths.get("/home/alice/repo/app"));
+        String far = ModuleSidecar.computeModuleId(
+            Paths.get("/home/alice/other/lib"), Paths.get("/home/alice/repo/app"));
+
+        assertNotEquals(near, far,
+            "a bare directory name would collide here and the two modules would overwrite one "
+                + "another, which is worse than an opaque id");
+    }
+
+    /** The id is a filename, so it must stay short whatever the path length. */
+    @Test
+    void outOfTreeModuleIdStaysShortEnoughToBeAFilename() {
+        StringBuilder deep = new StringBuilder("/home/alice");
+        for (int i = 0; i < 40; i++) {
+            deep.append("/averyverylongintermediatedirectoryname").append(i);
+        }
+        String id = ModuleSidecar.computeModuleId(
+            Paths.get(deep + "/lib"), Paths.get("/home/alice/repo/app"));
+
+        assertTrue(id.length() <= 64,
+            "the id becomes '.vibetags-mod-<id>'; an unbounded one fails with ENAMETOOLONG and no "
+                + "sidecar is written at all. Got " + id.length() + " chars: " + id);
+    }
+
+    /**
+     * Upgrading past issue #436 renames an out-of-tree module's sidecar, because its id is no
+     * longer derived from the absolute path. The old one is not stale by the ordinary test — its
+     * module path is empty, so the directory-existence check is skipped and never retires it — so
+     * without something else it would sit beside the new one and every generated file would carry
+     * the module twice.
+     *
+     * <p>The equal-path rule handles it: both regions report the same (empty) module path and the
+     * same elements, so the fresher wins and the leftover is deleted on the first build after the
+     * upgrade. This pins that the upgrade heals itself rather than needing a manual cleanup.
+     */
+    @Test
+    void aSidecarLeftUnderTheOldOutOfTreeIdIsRetiredByTheNewOne(@TempDir Path root) throws IOException {
+        writeSidecar(root, "3f2a9c11", "", "com.example.A", "com.example.B");   // pre-#436 id
+        writeSidecar(root, "lib_560aee97", "", "com.example.A", "com.example.B"); // post-#436 id
+        writtenAt(root, "3f2a9c11", 1_000_000L);
+        writtenAt(root, "lib_560aee97", 2_000_000L);
+
+        assertEquals(List.of("lib_560aee97"), regionIds(ModuleSidecar.readAll(root)),
+            "the upgrade must not leave the module represented twice");
+        assertFalse(Files.exists(root.resolve(".vibetags-mod-3f2a9c11")),
+            "and the leftover sidecar must be deleted, not merely skipped");
+    }
+
 }


### PR DESCRIPTION
Closes #435, #436, #437, #438.

## #437 — the BOM, and a near-miss worth knowing about

`examples/basic/reset-ai-files.sh` began with a UTF-8 byte order mark, so three bytes sat in front
of the shebang and line 1 stopped being a comment. Every CI run logged

```
reset-ai-files.sh: line 1: #!/usr/bin/env: No such file or directory
```

while reporting success, which is why it survived: the script still did its work and the step still
passed.

This fix was pushed to the #434 branch **3 minutes 27 seconds after that PR was merged**, so the
squash captured everything except it, and the BOM is still on `main`. The commit is cherry-picked
here. `ShellScriptEncodingTest` now guards all 16 tracked shell scripts, verified by re-introducing
the BOM deliberately and watching it go red before restoring.

## #436 — an out-of-tree module id that moved with the checkout

A module outside the VibeTags root was filed under a hash of its compilation root's **absolute**
path. That id is not internal: it is the sidecar filename and the name in every `VIBETAGS-MODULE`
marker, so it reaches committed output. The same repository generated different files on two
machines, and check mode reported drift on a tree where nothing was wrong.

Red first, with the real symptom:

```
expected: <70aab4c9> but was: <52f7fc5b>
```

The id now derives from the path relative to the root, with the directory name in front so it stays
legible. `String.hashCode()` is specified by the language, unlike `Path.hashCode()`, so it agrees
across JVMs; separators are normalised so Windows and Linux agree; the readable half is capped
because an unbounded id fails with `ENAMETOOLONG` and writes no sidecar at all.

Four tests pin the properties rather than the format: stable across checkout locations, distinct
for different modules, distinct for same-named directories in different places, and short enough to
be a filename.

**Upgrade path.** Changing the id renames the sidecar, and the old one is not stale by the ordinary
test, because its module path is empty so the directory-existence check is skipped. The equal-path
rule from #432 retires it: same path, same elements, fresher wins. A test pins that the upgrade
heals on the first build rather than needing manual cleanup.

**One existing test changed.** `computeModuleId_compilationRootOutsideVibetagsRoot_usesStableHash`
asserted `id.matches("[0-9a-f]+")`, which pinned the form this deliberately changes. It now asserts
the properties that made that form necessary — bounded, no separators, no `..`, stable across calls
— with the reason recorded in place. Flagging it explicitly because a changed assertion deserves a
second pair of eyes.

The different-filesystem-root case (Windows drives) keeps the absolute hash: there is no relative
path to derive anything from. Documented in place rather than left to be rediscovered.

## #435 — a rule file the aggregate names but nothing writes

I checked the issue's first option, letting a module restore a sibling's rule file from stored
contributions, and it is not possible without a format change: a `GranularContribution` is globs
plus body, and the renderer also needs the description and the display name, neither of which is
persisted. That makes restoring a compatibility decision rather than a code fix.

So this implements the cheaper half the issue itself identified: the build reports a rule file that
the aggregate names as authoritative, that is not on disk, and that this build will not write.
Without it the guardrail is stated nowhere — not inline, because the region is collapsed to an
index, and not in a rule file, because it is gone — and nothing says so.

The compiling module's own stems are excluded, or every first build would warn about files it is in
the middle of creating. Existence is checked by filename prefix rather than a service-to-extension
map, so a new granular platform needs no change here. Red first with an empty warning list, then
green, with a guard test that an intact reactor stays silent.

## #438 — superseded by the section at the end of this description

It needs the `modulePath=` line from two sidecars in a third-party repository. Equal values mean
#432 covers the reported duplication; `""` versus a real subdirectory name means something else
caused it and the investigation is not finished. I have no way to obtain that, and guessing would
turn an open question into a false conclusion.

## Verification

- `mvn clean install -Pe2e` from `vibetags/`: **1997 tests, 0 failures, 0 errors, 0 skipped**,
  BUILD SUCCESS.
- Both behaviour changes written failing-first, with the failure output quoted above.
- `pre-commit run --all-files`: secrets, end-of-file and trailing-whitespace hooks pass. The
  `checkstyle` hook is **not run** locally — it needs a Docker daemon that is not up on this
  machine — so it is left to CI rather than reported as passing.

Worth recording: SpotBugs caught a null dereference in the first draft of the #435 warning
(`Path.getFileName()` returns null for a root path), and PMD caught a `DanglingJavadoc` in an
earlier related change. Both times the build reported `BUILD FAILURE` with **zero** test failures,
so reading the test totals alone would have called it green.

---

## #438 — now fixed too, and the reported bug is finally explained

I said this needed the reporter's sidecar files. That was wrong: the layout is fully described in
the report, so it can be built and measured instead of asked for.

**What the sidecars actually record.** Running the reported layout as a real Gradle build:

| Layout | sidecar | `modulePath=` |
|---|---|---|
| subproject with its own `build.gradle` | `.vibetags-mod-svc` | `svc` |
| subproject without one | `.vibetags-mod-_root_` | *(empty)* |

So the reporter's pair is empty versus a real subdirectory — a **nesting** relation, already
handled in 1.2.3, not the equal-path hole #432 closed. Replaying their exact transition on current
code leaves one region and one mention of the element.

**Why it duplicated for them anyway.** The prune retires a region only when a fresher one covers
*all* of its elements. That is deliberate: a reactor root compiling sources of its own keeps the
elements no submodule has. A leftover `_root_` sidecar whose element set is a superset only because
it is **stale** fails that by one element, so both regions survive and everything they share is
stated twice:

```
regions=[_root_, svc]
duplicated com.example.A across regions = true
```

That also explains the intermittency the report blamed on timing or ServiceLoader double
registration. When the leftover's elements happen to match the live module's exactly, containment
holds and the prune cleans up; one stale extra and it does not. 4 clean attempts, 2 bad ones.

**Why it reports rather than repairs.** A sidecar records element ids, not whether their sources
still exist, so a stale extra element is indistinguishable from a genuinely root-owned one. And a
region carries rendered text rather than a list, so an element cannot be subtracted from it without
the sources that produced it. Retiring the region anyway would drop real guardrails. The build now
names the duplicated element and the sidecar to delete.

**Verified twice over.** The first draft of the test was red for the wrong reason — it hand-wrote
element ids as dotted FQNs when the collector records the granular stem form
(`com-example-svc-AuthUtil`). Once the fixture was corrected the test passed, so the implementation
was stashed to confirm it goes red without it.

## Verification (updated)

- `mvn clean install -Pe2e`: **1999 tests, 0 failures, 0 errors, 0 skipped**, BUILD SUCCESS.
- PMD caught a `DanglingJavadoc` in this change too (a constant inserted between a field and its
  javadoc). That is the third defect static analysis caught in this work, and all three times the
  build reported `BUILD FAILURE` with **zero** test failures.