### PR TITLE
fix: fold locked-element positions into the build fingerprint (#440)

### DIFF
--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/BuildFingerprint.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/BuildFingerprint.java
@@ -39,6 +39,7 @@ import se.deversity.vibetags.annotations.AITemporary;
 import se.deversity.vibetags.processor.model.ContentHash;
 import se.deversity.vibetags.processor.model.GuardrailModel;
 import se.deversity.vibetags.processor.model.TaggedElement;
+import se.deversity.vibetags.processor.model.SourceLocation;
 import se.deversity.vibetags.processor.model.TransitiveRule;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -290,6 +291,26 @@ public final class BuildFingerprint {
               .append(rule.origin()).append(':')
               .append(rule.tier().name()).append(':')
               .append(rule.memberSummary()).append(';');
+        }
+        sb.append('}')
+            // Source positions of locked elements. They are content of .vibetags-locks, which
+            // records each lock's line range, so moving a locked element with every annotation
+            // unchanged changes what should be written. Left out, this fingerprint matched, the
+            // generate phase was skipped, and the committed report kept describing the old lines
+            // — while check mode failed on the same tree and told the developer to run the
+            // regeneration that had just been short-circuited into doing nothing (issue #440).
+            //
+            // Costs nothing to a project without the report: positions are resolved only when
+            // .vibetags-locks is opted in, so this map is empty and the section is two characters.
+            .append("P{");
+        for (TaggedElement element : model.locked()) {
+            SourceLocation at = model.lockedPosition(element);
+            if (at != null) {
+                sb.append(element.qualifiedName()).append(':')
+                  .append(at.file()).append(':')
+                  .append(at.startLine()).append('-')
+                  .append(at.endLine()).append(';');
+            }
         }
         sb.append('}');
 

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/LocksReportEndToEndTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/LocksReportEndToEndTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -229,6 +230,59 @@ class LocksReportEndToEndTest {
                 + "can reject reports written in a future, incompatible schema");
         assertTrue(entries.stream().skip(1).allMatch(l -> l.contains("\"type\":\"locked\"")),
             "all records after the format record must be lock entries");
+    }
+
+    /**
+     * Moving a locked element's lines, with every annotation unchanged, must still rewrite the
+     * report.
+     *
+     * <p>The report records each locked element's line range, so a blank line above a locked class
+     * changes its content. The fingerprint short-circuit skips the whole generate phase when the
+     * annotation set and active services are unchanged, and positions were not part of it, so the
+     * second build here rewrote nothing and left the committed report describing the old lines.
+     *
+     * <p>Measured on the repository itself before the fix: inserting a constant near the top of
+     * {@code AIGuardrailProcessor} moved {@code generateFiles()} from 598-922 to 601-925,
+     * {@code mvn compile -Pself-annotate} reported BUILD SUCCESS and rewrote nothing, and CI's
+     * self-check then failed on that tree — with an error telling the developer to run the command
+     * that had just done nothing. Deleting {@code .vibetags-cache} was the only way through.
+     * Invariant 12: anything that becomes generated content reaches the fingerprint (issue #440).
+     *
+     * <p>Positions are resolved only when {@code .vibetags-locks} is opted in, so folding them in
+     * costs projects without the report nothing.
+     */
+    @Test
+    void locksReport_isRewrittenWhenALockedElementMovesWithNoAnnotationChange(@TempDir Path tmp)
+            throws Exception {
+        ProcessorTestHarness h = new ProcessorTestHarness(tmp);
+        h.addSource("com.example.lockdemo.Vault", vault(0));
+        h.compile();
+
+        String first = Files.readString(tmp.resolve(".vibetags-locks"), StandardCharsets.UTF_8);
+        assertTrue(first.contains("\"startLine\":3"),
+            "precondition: the lock is recorded at its original line. Report was:\n" + first);
+
+        // Same annotations, same services, same everything except where the class sits.
+        VibeTagsLogger.shutdown();
+        ProcessorTestHarness moved = new ProcessorTestHarness(tmp);
+        moved.addSource("com.example.lockdemo.Vault", vault(2));
+        moved.compile();
+
+        String second = Files.readString(tmp.resolve(".vibetags-locks"), StandardCharsets.UTF_8);
+        assertTrue(second.contains("\"startLine\":5"),
+            "the report must follow the element it describes. A stale line range makes the "
+                + "locked-files PR guard diff against positions that no longer exist, and the "
+                + "documented regeneration command cannot fix it because the short-circuit skips "
+                + "the write. Report was:\n" + second);
+    }
+
+    /** The same class, shifted down by {@code padding} blank lines. */
+    private static String vault(int padding) {
+        return "package com.example.lockdemo;\n"
+            + "import se.deversity.vibetags.annotations.AILocked;\n"
+            + "\n".repeat(padding)
+            + "@AILocked(reason = \"audited\")\n"
+            + "public class Vault {}\n";
     }
 
     private static ProcessorTestHarness withVaultSource(Path tmp) throws Exception {


### PR DESCRIPTION
Closes #440.

## The defect

`.vibetags-locks` records the line range of every `@AILocked` element, so moving a locked element
changes what should be written even when no annotation changes. Those positions were not part of
the build fingerprint, so the short-circuit matched, the whole generate phase was skipped, and the
committed report kept describing the old lines.

This is invariant 12: *anything that becomes generated content reaches `BuildFingerprint`*.

## Why it matters more than a stale file

It makes the documented workflow lie. Measured on this repository while landing #438:

1. A constant inserted near the top of `AIGuardrailProcessor` moved `generateFiles()` from
   598-922 to 601-925. No annotation changed.
2. `mvn compile -Pself-annotate` — the command `CLAUDE.md` documents — reported `BUILD SUCCESS` and
   rewrote **nothing**. `git status` clean.
3. CI's self-check failed on that same tree:

```
VibeTags: check failed — 1 guardrail file(s) are out of date with the annotations:
    - .vibetags-locks
  Run a normal compile (without -Avibetags.check=true) and commit the regenerated files.
```

The advice in that message is exactly what step 2 did.

4. `rm .vibetags-cache`, repeat step 2, and the report updates.

So a developer following the documented steps gets a green local build, a clean working tree, and a
red pipeline, with an error pointing at the command that just did nothing.

## The fix, and what it costs

Locked-element positions are folded into the fingerprint. This is free for projects that do not use
the report: source positions are resolved **only** when `.vibetags-locks` is opted in (the
processor gates position resolution on that file), so without it the map is empty and the new
fingerprint section is two characters. The short-circuit stays as cheap as it was.

The obvious alternative — folding positions in unconditionally — was rejected: it would make the
short-circuit miss on every edit that moves a line, which is most edits, and that short-circuit is
what keeps unchanged rebuilds cheap.

## Verification

- Written failing-first at the level a consumer sees, not against the hash: a locked class moved
  down two blank lines with every annotation unchanged left the report saying `"startLine":3`
  where it had to say `5`.
- Full suite: **1998 tests, 0 failures, 0 errors, 0 skipped**, BUILD SUCCESS, no PMD or SpotBugs
  violations.
- `TransitiveFingerprintTest` and `ProjectLifecycleEndToEndTest` both pass unchanged. Those pin the
  fingerprint's other inputs and that the short-circuit still fires on an unchanged rebuild, which
  is the regression this change could plausibly have caused.

## Left for a follow-up

Two things the issue notes that are not addressed here, because each wants its own change:

- `mvn test -Pe2e` does not run the self-check (`-Avibetags.selfcheck=true` is a separate CI step),
  so nothing local catches this class of drift. A fast test comparing `.vibetags-locks` against the
  current sources would.
- When the cause is a short-circuited regeneration, check mode's "run a normal compile" advice is
  misleading. With this fix that path should no longer occur, which is why the message is left
  alone rather than changed speculatively.
