### PR TITLE
chore: prepare release v1.2.4

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.2.3
+version: 1.2.4
 ---
 
 # VibeTags Usage Guide
@@ -27,7 +27,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
     <dependency>
         <groupId>se.deversity.vibetags</groupId>
         <artifactId>vibetags-annotations</artifactId>
-        <version>1.2.3</version>
+        <version>1.2.4</version>
     </dependency>
 </dependencies>
 
@@ -41,7 +41,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.3</version>
+                        <version>1.2.4</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -63,8 +63,8 @@ the whole processor and its SLF4J/Logback dependencies on your compile classpath
 
 ```groovy
 dependencies {
-    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.2.3'
-    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.3'
+    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.2.4'
+    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.4'
 }
 ```
 
@@ -221,7 +221,7 @@ though the build is green.
 Every way this setup fails is silent, so check rather than assume:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.3 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.2.4 doctor
 ```
 
 Or by hand, in the order things go wrong:
@@ -1287,7 +1287,7 @@ Use on: **class, method, field**
 @AIKeepInSync(mirrors = {"pom.xml:<version>", "README.md badge", "docs/CHANGELOG.md"},
               reason = "The release version is asserted in three places and drifts silently",
               enforcedBy = "ProjectFactsConsistencyTest")
-public static final String VERSION = "1.2.3";
+public static final String VERSION = "1.2.4";
 ```
 
 The element is free to change — the failure mode is a *partial* change that desyncs a mirror no compiler checks. `@AIContract` freezes one signature so it cannot change at all; neither it nor `@AISchemaSafe` expresses "edit A ⇒ you must also edit B". Mirrors routinely point outside the compilation unit, so VibeTags can only *name* them, not verify them.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.4</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.3</version>
+                        <version>1.2.4</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -94,7 +94,7 @@ touch CLAUDE.md .cursorrules AGENTS.md   # Claude, Cursor, Codex CLI — add whi
 Or let the companion CLI do it (and `vibetags doctor` checks your setup afterwards):
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.3 init --platforms claude,cursor
+jbang se.deversity.vibetags:vibetags-cli:1.2.4 init --platforms claude,cursor
 ```
 
 **3. Annotate your first class:**
@@ -123,8 +123,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.3')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.3')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -170,8 +170,8 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.3"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.3"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.4"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.4"))
 
     compileOnly("se.deversity.vibetags:vibetags-annotations")
     kapt("se.deversity.vibetags:vibetags-processor")
@@ -513,7 +513,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.4</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -538,7 +538,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.3</version>
+                        <version>1.2.4</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -554,8 +554,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.3')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.3')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -569,15 +569,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.3'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.3'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.4'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.4'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.
@@ -898,8 +898,8 @@ presence the processor honours (the processor itself never creates them), and
 `VIBETAGS-START`/`END` marker integrity. Run it without installing anything:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.3 init --list
-jbang se.deversity.vibetags:vibetags-cli:1.2.3 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.2.4 init --list
+jbang se.deversity.vibetags:vibetags-cli:1.2.4 doctor
 ```
 
 The platform list and marker rules are read from `vibetags-processor` at runtime, so the CLI

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.4] - 2026-08-20
+
 ### Added
 
 - **Every build layout VibeTags supports now has a worked example, and Gradle reactors are
@@ -16,6 +18,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in: an ordinary reactor, subprojects configured from the root build file, a flat layout with a
   module beside the root, and a composite build. Each asserts the regression that would matter
   for it, not merely that the build exits zero.
+
+### Changed
+
+- **The example projects moved under `examples/`.** Seven directories at the repository root were
+  most of what a newcomer saw first; they are now `examples/basic`, `all-tiers`, `groovy`,
+  `kotlin`, `multimodule`, `multimodule-indexed` and `scala`. Older CHANGELOG entries keep the
+  paths they were written with, because they record what was true then.
+
+- **An out-of-tree module is no longer identified by where the repository is checked out.** A
+  module that is not under the VibeTags root was filed under a hash of its compilation root's
+  absolute path. That id is not internal: it is the sidecar filename and the name in every
+  `VIBETAGS-MODULE` marker, so it reaches committed output. The same repository generated
+  different files on two machines, and check mode reported drift on a tree where nothing was
+  wrong. Reachable through ordinary layouts: Gradle `includeFlat` or a `projectDir` override, and
+  Maven `<module>../sibling</module>`.
+
+  The id now comes from the path relative to the root, which is a property of the layout rather
+  than of the checkout, with the directory name kept in front so it stays legible.
+  `String.hashCode()` is specified by the language, unlike `Path.hashCode()`, so it agrees across
+  JVMs; separators are normalised so Windows and Linux agree; and the readable half is capped,
+  because an unbounded id fails with `ENAMETOOLONG` and writes no sidecar at all.
+
+  Upgrading renames such a module's sidecar. The old one is retired automatically on the first
+  build by the equal-path rule above, so no manual cleanup is needed. The
+  different-filesystem-root case keeps its absolute hash: there is no relative path to derive
+  anything from.
 
 ### Fixed
 
@@ -36,15 +64,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   warning names the subprojects and the option. It is narrow: it fires only when the compiling
   module resolved to the VibeTags root itself, only for included directories that exist, carry
   sources and have no build file of their own, and never once `-Avibetags.module` has been passed.
-
-### Changed
-
-- **The example projects moved under `examples/`.** Seven directories at the repository root were
-  most of what a newcomer saw first; they are now `examples/basic`, `all-tiers`, `groovy`,
-  `kotlin`, `multimodule`, `multimodule-indexed` and `scala`. Older CHANGELOG entries keep the
-  paths they were written with, because they record what was true then.
-
-### Fixed
 
 - **Two module regions naming the same directory no longer both survive.** Reported against 1.2.3
   from a Gradle repository whose `settings.gradle` carries `rootProject.name='x'` beside
@@ -70,6 +89,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Per-module output and the `VIBETAGS-MODULE` markers date to 0.9.0, not 1.2.3, and the merge is
   service-agnostic, so nothing about this was specific to `CLAUDE.md`.
+
+- **Opting a granular rules directory back out no longer leaves a module pointing at deleted
+  files.** In a reactor only the module that recompiles re-renders its region inline. A module
+  that does not keeps the scoped-rules index it rendered while the directory existed, so the
+  aggregate names rule files the opt-out just deleted and that guardrail is stated nowhere: not
+  inline, because the region is collapsed, and not in a rule file, because it is gone. Worse than
+  the platform-opted-in-late window, where a module is merely absent. The build now names the
+  modules that are behind, and each repairs its own region on its next compile.
+
+- **A granular rule file the aggregate still names is reported when nothing will write it.** Each
+  module writes only its own granular files; a sibling's stems are protected from deletion but
+  never rewritten, deliberately, because writing into another module's rule files is the reach
+  that deleted 256 committed files in #383. So a file lost to `git clean`, a bad merge or an
+  opt-out round trip stays lost until its own module recompiles, while the aggregate keeps calling
+  it authoritative. Restoring it would need the sidecar format to change, since a contribution
+  carries globs and body but neither the description nor the display name the renderer needs, so
+  the build reports it instead.
+
+- **An element claimed by two regions is reported, with the sidecar to delete.** The region prune
+  retires a region only when a fresher one covers *all* of its elements, so that a reactor root
+  compiling sources of its own keeps what no submodule has. A leftover `_root_` sidecar whose
+  element set is a superset only because it is stale fails that by one element, so both regions
+  survive and everything they share is stated twice. This is what made the originally reported
+  duplication intermittent: when the leftover's elements happened to match the live module's
+  exactly the prune cleaned up, and one stale extra was enough to stop it.
+
+- **Moving a locked element now regenerates the locks report.** `.vibetags-locks` records each
+  lock's line range, so moving a locked element changes what should be written even when no
+  annotation does. Positions were not part of the build fingerprint, so the short-circuit matched
+  and the whole generate phase was skipped: `-Pself-annotate` reported success and rewrote
+  nothing, while check mode failed on the same tree and advised running the command that had just
+  done nothing. Costs projects without the report nothing, because positions are resolved only
+  when `.vibetags-locks` is opted in.
+
+- **`examples/basic/reset-ai-files.sh` no longer fails its own shebang.** A UTF-8 byte order mark
+  sat in front of `#!`, so every CI run logged `line 1: #!/usr/bin/env: No such file or directory`
+  while still reporting success. `ShellScriptEncodingTest` now guards every tracked shell script.
 
 ## [1.2.3] - 2026-08-20
 
@@ -2897,7 +2953,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.2.3...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.2.4...HEAD
+[1.2.4]: https://github.com/PIsberg/vibetags/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/PIsberg/vibetags/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/PIsberg/vibetags/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/PIsberg/vibetags/compare/v1.2.0...v1.2.1

--- a/examples/all-tiers/pom.xml
+++ b/examples/all-tiers/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.2.3</vibetags.bom.version>
+    <vibetags.bom.version>1.2.4</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/basic/build.gradle
+++ b/examples/basic/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.3')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.3')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/examples/basic/pom.xml
+++ b/examples/basic/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.2.3</vibetags.bom.version>
+        <vibetags.bom.version>1.2.4</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/examples/gradle-composite/app/build.gradle
+++ b/examples/gradle-composite/app/build.gradle
@@ -16,8 +16,8 @@ repositories {
 
 dependencies {
     implementation 'se.deversity.vibetags.example:vibetags-example-gradle-composite-lib'
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.3')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.3')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-composite/lib/build.gradle
+++ b/examples/gradle-composite/lib/build.gradle
@@ -15,8 +15,8 @@ repositories {
 }
 
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.3')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.3')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-flat/app/build.gradle
+++ b/examples/gradle-flat/app/build.gradle
@@ -21,8 +21,8 @@ allprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.3')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.3')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-multimodule/build.gradle
+++ b/examples/gradle-multimodule/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.3')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.3')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-shared-buildfile/build.gradle
+++ b/examples/gradle-shared-buildfile/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.3')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.3')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.apache.groovy:groovy:5.1.0'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.3')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.3')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
 
     // Annotations on compile, processor on the annotation-processor path only.
     compileOnly 'se.deversity.vibetags:vibetags-annotations'

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and kapt configurations so neither needs an explicit version.
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.3"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.3"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.4"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.4"))
 
     // Annotations on compile, processor on the kapt path only — keeps the processor's
     // slf4j/logback off the consumer's compile classpath. compileOnly is enough:

--- a/examples/multimodule-indexed/pom.xml
+++ b/examples/multimodule-indexed/pom.xml
@@ -37,7 +37,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.2.3</vibetags.bom.version>
+    <vibetags.bom.version>1.2.4</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/examples/multimodule/pom.xml
+++ b/examples/multimodule/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.2.3</vibetags.bom.version>
+    <vibetags.bom.version>1.2.4</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/scala/build.gradle
+++ b/examples/scala/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.scala-lang:scala-library:2.13.18'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.3')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.3')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.2.3</vibetags.bom.version>
+        <vibetags.bom.version>1.2.4</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.2.3'
+version = '1.2.4'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.2.3'
+            version = '1.2.4'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -39,12 +39,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.2.3&lt;/version&gt;
+                &lt;version&gt;1.2.4&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.3'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.3'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.4'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.4'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -36,7 +36,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.2.3&lt;/version&gt;
+                        &lt;version&gt;1.2.4&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.2.3')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.3')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-cli/pom.xml
+++ b/vibetags-cli/pom.xml
@@ -28,7 +28,7 @@
         reports the project's VibeTags health — build-tool wiring, active platforms,
         marker integrity. Run it without installing anything:
 
-            jbang se.deversity.vibetags:vibetags-cli:1.2.3 init --list
+            jbang se.deversity.vibetags:vibetags-cli:1.2.4 init --list
 
         The platform list and marker rules are read from vibetags-processor, so this
         tool cannot drift from what the processor actually does.

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.2.3</revision>
+        <revision>1.2.4</revision>
 
         <!-- release, not source/target: on a JDK newer than 21 (CI builds 21, 25 and 26)
              source/target compiles against the *running* JDK's API and javac warns that the

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.2.3'
+version = '1.2.4'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.2.3'
+            version = '1.2.4'
             from components.java
 
             pom {
@@ -78,7 +78,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.2.3'
+    api 'se.deversity.vibetags:vibetags-annotations:1.2.4'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.1'

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
@@ -66,6 +66,11 @@ class ReleaseScriptCoverageTest {
         "docs/proposed-annotations.md",
         "docs/RELEASING.md",
         "docs/CONCEPT_PLUGIN.md",
+        // The build-layout matrix names the release a behaviour arrived in ("Since
+        // 1.2.4 the build says so ..."), which is what tells a reader hitting that Gradle
+        // layout whether their version warns them. Rewriting it each release would claim
+        // the warning has always existed.
+        "docs/MULTI-MODULE.md",
         // The multi-module examples' own lineage. Each child pom names its example root
         // (groupId se.deversity.vibetags.example) at version 1.0.0, which is the sample
         // project's own version, not a VibeTags coordinate. The roots do carry one (the BOM


### PR DESCRIPTION
Prepares 1.2.4. Six PRs merged since 1.2.3, four of which fix ways a module's guardrails could go
missing or be stated twice with nothing saying so.

## What is in it

**Fixed**

- **Two module regions naming the same directory no longer both survive** (#432). `isNestedUnder`
  is false in *both* directions for equal paths, so two regions on one directory fell through the
  prune untouched and every guardrail was stated twice.
- **A Gradle layout that silently lost a module's guardrails now says so** (#434). Subprojects
  configured from the root build file share one identity and overwrite each other; the surviving
  aggregate carried one module's guardrails with the other's simply absent.
- **Opting a granular directory back out no longer leaves a module pointing at deleted files**
  (#433).
- **A rule file the aggregate still names is reported when nothing will write it** (#435).
- **An element claimed by two regions is reported, with the sidecar to delete** (#438). This is
  what made the originally reported duplication intermittent.
- **Moving a locked element now regenerates the locks report** (#440). Positions were not in the
  fingerprint, so `-Pself-annotate` reported success and rewrote nothing while check mode failed on
  the same tree.
- **`reset-ai-files.sh` no longer fails its own shebang** (#437), a UTF-8 BOM in front of `#!`.

**Changed**

- **Out-of-tree module ids no longer move with the checkout** (#436). The id reaches committed
  output, so the same repository generated different files on two machines. Sidecars are renamed by
  this and the old one is retired automatically on the first build.
- **The example projects moved under `examples/`** (#434), and every build layout now has a worked
  example, including four Gradle layouts that had no CI coverage at all before.

## The CHANGELOG needed writing, not just renaming

Only four bullets existed for six merged PRs. #433, #435, #436, #437, #438 and #440 had described
themselves in their PR bodies and nowhere a consumer would read. All six are written up here, and
the two stray `### Fixed` headings are merged.

## Verification

- **Full build in release order**, annotations through `vibetags-cli` and all three Maven examples:
  every step exit 0.
- **No guardrail drift.** All 24 changed files are version bumps, the CHANGELOG, or the test noted
  below. The examples regenerate byte-for-byte under the new version, which matters because a
  release invalidates every fingerprint and reruns the whole generate phase.
- **`BuildVersionParityTest` passes**, so no Gradle file, example pom or managed pom disagrees with
  `<revision>`. `set-version.sh` rewrote 22 files including all four new Gradle examples.
- **Consumer sweep against this candidate**: codekarta, common-license-lib and skill3 **pass**.
  blindbean **fails only** because the isolated clone lacks its uncommitted native FHE library
  (`FheException: could not load the native FHE library`), and async-test-lib was **not swept** at
  all because its clone will not check out on Windows. Three of five genuinely pass; the other two
  are limits of isolating those repositories, not evidence about this release. Every consumer repo
  was left untouched, verified after each step.
- **pre-commit**: gitleaks and both whitespace hooks pass. `checkstyle` did **not** run locally,
  needing a Docker daemon that is not up here; it is bound to Maven's `validate` phase, which the
  build above ran, and CI runs it too.

## One test changed

`docs/MULTI-MODULE.md` joins `HISTORICAL` in `ReleaseScriptCoverageTest`. Its layout matrix says
"Since 1.2.4 the build says so", which is what tells a reader hitting that Gradle layout whether
their version warns them. Rewriting it each release would claim the warning had always existed,
which is the same corruption that list already protects changelogs and benchmark provenance from.
The test caught this during the release rather than letting 1.2.5 rewrite the sentence silently.

## On the version number

`#436` changes sidecar filenames, so correct persisted data exists under the old behaviour, which
`docs/RELEASING.md` flags as potentially major-worthy. Shipping it as a patch because the migration
is automatic and tested: the stale sidecar is retired on the first build by the equal-path rule from
#432, pinned by `aSidecarLeftUnderTheOldOutOfTreeIdIsRetiredByTheNewOne`. No consumer action needed.

## Known gap, tracked

Gradle reactors are verified one way where Maven reactors are verified eleven (#443). The three most
recent multi-module defects all came from Gradle repositories, so that is worth closing before the
next multi-module change lands.
