### PR TITLE
fix(action): stop the locked-files guard blaming the wrong file, and the wrong PR (#451, #452)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -977,6 +977,14 @@ jobs:
           cd ../vibetags
           mvn install -B -q -DskipTests
 
+      # The guard shipped for two releases with no tests of its own, and carried two
+      # false-positive sources that one fixture would have caught: locks from one reactor
+      # matching another reactor's identically-named paths, and a PR that adds an @AILocked
+      # element failing on its own additions. Both are pinned now. Stdlib unittest, so this
+      # adds no dependency.
+      - name: Test the locked-files guard
+        run: python3 -m unittest discover -s action/locked-files -v
+
       - name: Guard @AILocked elements against this PR's diff
         uses: ./action/locked-files
         with:

--- a/action/locked-files/README.md
+++ b/action/locked-files/README.md
@@ -63,6 +63,25 @@ recognise and may reject reports with a `version` they do not support:
 
 - Line ranges come from the javac Compiler Tree API. Under non-javac compilers (e.g. ECJ)
   the report has no line info and the guard falls back to file-level matching.
+
+## How a lock's file is matched
+
+A `.vibetags-locks` records paths relative to **its own VibeTags root**, not to the repository.
+The guard resolves each recorded path against the directory of the report that declared it, then
+compares repo-relative paths exactly.
+
+That matters in a repository with more than one project in it. The guard used to accept either
+path as a suffix of the other, so two reactors with a module at the same relative path aliased
+each other: one example's locks flagged another example's diff, measured at nine false violations.
+
+## Files the diff creates are exempt
+
+A file that did not exist at the base cannot have had its locked code touched, and the author of
+the diff is the one declaring the lock. Flagging it meant a PR could never introduce an
+`@AILocked` element, which discouraged adding guardrails to the codebase that ships them.
+
+Renames stay in scope (git reports them as `R`, not `A`), so moving a locked file is still
+checked, as is any later PR that edits it.
 - Maven multi-module builds aggregate every module's locks into one report automatically
   (the report rides VibeTags' module-sidecar merge).
 - The script is plain Python 3 + git and can run locally:

--- a/action/locked-files/check_locked_diff.py
+++ b/action/locked-files/check_locked_diff.py
@@ -60,10 +60,33 @@ def find_reports(root):
     return reports
 
 
+def resolve_lock_path(recorded, report_dir, repo_root):
+    """A lock's repo-relative path, resolved against the report that declared it.
+
+    A ``.vibetags-locks`` records paths relative to its own VibeTags root, not to the
+    repository. Normalizing against the repository root alone therefore leaves two reactors
+    that both have a module at, say, ``showcase/src/main/java/...`` recording the identical
+    string, and nothing downstream can tell them apart. Measured before this was fixed: a
+    Gradle example's new files drew nine violations from the *Maven* example's report.
+
+    Absolute paths are made repo-relative directly; anything outside the repository is left
+    as it is, so it simply matches nothing.
+    """
+    path = recorded.replace("\\", "/")
+    if os.path.isabs(path):
+        rel = os.path.relpath(path, repo_root).replace("\\", "/")
+        return path if rel.startswith("..") else rel
+    report_rel = os.path.relpath(report_dir, repo_root).replace("\\", "/")
+    if report_rel in ("", "."):
+        return os.path.normpath(path).replace("\\", "/")
+    return os.path.normpath(report_rel + "/" + path).replace("\\", "/")
+
+
 def load_locks(report_paths, repo_root):
-    """Returns a list of lock dicts with a normalized, repo-relative-ish 'file' path."""
+    """Returns a list of lock dicts with a repo-relative 'file' path."""
     locks = []
     for report in report_paths:
+        report_dir = os.path.dirname(os.path.abspath(report))
         with open(report, encoding="utf-8") as fh:
             for line in fh:
                 line = line.strip()
@@ -77,30 +100,36 @@ def load_locks(report_paths, repo_root):
                     continue
                 path = entry.get("file")
                 if path:
-                    path = path.replace("\\", "/")
-                    rel = os.path.relpath(path, repo_root).replace("\\", "/")
-                    if not rel.startswith(".."):
-                        path = rel
-                    entry["file"] = path
+                    entry["file"] = resolve_lock_path(path, report_dir, repo_root)
                 locks.append(entry)
     return locks
 
 
+def added_paths(name_status_text):
+    """Paths the diff CREATES, from ``git diff --name-status``.
+
+    A file that did not exist at the base cannot have had its locked code touched: the author
+    of the diff is the one declaring the lock. Renames are status R and stay in scope, so
+    moving a locked file is still checked.
+    """
+    added = set()
+    for line in name_status_text.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[0].strip() == "A":
+            added.add(parts[1].strip().replace("\\", "/"))
+    return added
+
+
 def locks_for(locks, diff_path):
-    """Locks whose file matches a diff path; tolerates absolute vs relative prefixes."""
+    """Locks whose file is this diff path.
+
+    Compared exactly. This used to fall back to matching either path as a suffix of the other,
+    to paper over absolute-vs-relative prefixes; ``resolve_lock_path`` now makes both sides
+    repo-relative, and the suffix fallback actively did harm: any two modules sharing a
+    relative path aliased each other's locks.
+    """
     diff_path = diff_path.replace("\\", "/")
-    matched = []
-    for lock in locks:
-        lock_path = lock.get("file")
-        if not lock_path:
-            continue
-        if (
-            lock_path == diff_path
-            or lock_path.endswith("/" + diff_path)
-            or diff_path.endswith("/" + lock_path)
-        ):
-            matched.append(lock)
-    return matched
+    return [lock for lock in locks if lock.get("file") == diff_path]
 
 
 def parse_diff(diff_text):
@@ -159,6 +188,9 @@ def main():
 
     # Trailing "--" terminates options/refs so no value can be reinterpreted as a pathspec/flag.
     diff_text = run_git("diff", "--unified=0", "--no-color", merge_base, "HEAD", "--")
+    created = added_paths(
+        run_git("diff", "--name-status", "--no-color", merge_base, "HEAD", "--")
+    )
     kind = "warning" if warn_only else "error"
     violations = 0
 
@@ -187,7 +219,13 @@ def main():
             print(f"::{kind} file={display}::A line containing @AILocked was removed -- "
                   "removing a lock requires explicit human review")
 
-        # 1. Changed lines intersect a locked range at HEAD.
+        # 1. Changed lines intersect a locked range at HEAD. Files this diff CREATES are
+        # exempt: the lock did not exist at the base, so nobody can have violated it, and
+        # flagging it means a PR may never introduce an @AILocked element. That blocked adding
+        # guardrails to the very codebase that ships them. A later PR editing the now-locked
+        # file is a rename or a modification, not an addition, and is still checked.
+        if display in created:
+            continue
         for lock in locks_for(locks, display):
             start, end = lock.get("startLine"), lock.get("endLine")
             element = lock.get("element", "?")

--- a/action/locked-files/test_check_locked_diff.py
+++ b/action/locked-files/test_check_locked_diff.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Unit tests for the locked-files guard.
+
+The guard had no tests, and shipped two false-positive sources that a single fixture would
+have caught. Both are pinned here, with the measurement that found them in the docstring so a
+future reader knows what the assertion is defending rather than guessing from the name.
+
+Run: python3 -m unittest discover -s action/locked-files
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from check_locked_diff import (  # noqa: E402
+    added_paths,
+    load_locks,
+    locks_for,
+    resolve_lock_path,
+)
+
+REPO = "/repo"
+
+
+class ResolveLockPathTest(unittest.TestCase):
+    """A lock's path is relative to its own report, not to the repository."""
+
+    def test_relative_path_is_resolved_against_the_reports_directory(self):
+        self.assertEqual(
+            "examples/multimodule/showcase/src/Main.java",
+            resolve_lock_path("showcase/src/Main.java", "/repo/examples/multimodule", REPO),
+        )
+
+    def test_report_at_the_repo_root_keeps_the_recorded_path(self):
+        self.assertEqual(
+            "vibetags/src/Main.java",
+            resolve_lock_path("vibetags/src/Main.java", REPO, REPO),
+        )
+
+    def test_absolute_path_is_made_repo_relative(self):
+        self.assertEqual(
+            "vibetags/src/Main.java",
+            resolve_lock_path("/repo/vibetags/src/Main.java", REPO, REPO),
+        )
+
+    def test_two_reactors_sharing_a_relative_path_resolve_differently(self):
+        """The measured defect: nine false violations from a sibling example's report.
+
+        Both reactors had a module at showcase/, so both recorded the identical string. The
+        Maven example's locks were blaming the Gradle example's diff and vice versa.
+        """
+        maven = resolve_lock_path(
+            "showcase/src/App.java", "/repo/examples/multimodule", REPO)
+        gradle = resolve_lock_path(
+            "showcase/src/App.java", "/repo/examples/gradle-multimodule", REPO)
+        self.assertNotEqual(maven, gradle)
+
+
+class LocksForTest(unittest.TestCase):
+    def test_matches_only_the_exact_path(self):
+        locks = [
+            {"file": "examples/multimodule/showcase/src/App.java", "element": "maven"},
+            {"file": "examples/gradle-multimodule/showcase/src/App.java", "element": "gradle"},
+        ]
+        matched = locks_for(locks, "examples/gradle-multimodule/showcase/src/App.java")
+        self.assertEqual(["gradle"], [lock["element"] for lock in matched])
+
+    def test_a_shorter_path_is_not_a_match_by_suffix(self):
+        """The old fallback matched either path as a suffix of the other. That is what let
+        one reactor's locks claim another's files."""
+        locks = [{"file": "showcase/src/App.java", "element": "somewhere-else"}]
+        self.assertEqual(
+            [], locks_for(locks, "examples/gradle-multimodule/showcase/src/App.java"))
+
+    def test_backslashes_are_normalized(self):
+        locks = [{"file": "a/b/C.java", "element": "x"}]
+        self.assertEqual(1, len(locks_for(locks, "a\\b\\C.java")))
+
+
+class AddedPathsTest(unittest.TestCase):
+    def test_collects_only_added_files(self):
+        text = "A\tnew/File.java\nM\told/File.java\nD\tgone/File.java\n"
+        self.assertEqual({"new/File.java"}, added_paths(text))
+
+    def test_renames_are_not_treated_as_additions(self):
+        """A rename must stay in scope: moving a locked file is still touching it."""
+        text = "R096\told/File.java\tnew/File.java\n"
+        self.assertEqual(set(), added_paths(text))
+
+    def test_tolerates_blank_and_malformed_lines(self):
+        self.assertEqual({"x/Y.java"}, added_paths("\nA\tx/Y.java\ngarbage\n\n"))
+
+
+class LoadLocksTest(unittest.TestCase):
+    def test_entries_from_two_reports_do_not_collide(self):
+        with tempfile.TemporaryDirectory() as root:
+            first = os.path.join(root, "one")
+            second = os.path.join(root, "two")
+            os.makedirs(first)
+            os.makedirs(second)
+            line = ('{"type":"locked","element":"E",'
+                    '"file":"showcase/src/App.java","startLine":1,"endLine":9}\n')
+            for directory in (first, second):
+                with open(os.path.join(directory, ".vibetags-locks"), "w", encoding="utf-8") as fh:
+                    fh.write("# VIBETAGS-START\n")
+                    fh.write(line)
+                    fh.write("# VIBETAGS-END\n")
+
+            locks = load_locks(
+                [os.path.join(first, ".vibetags-locks"),
+                 os.path.join(second, ".vibetags-locks")],
+                root,
+            )
+            self.assertEqual(
+                ["one/showcase/src/App.java", "two/showcase/src/App.java"],
+                sorted(lock["file"] for lock in locks),
+            )
+            self.assertEqual(
+                1, len(locks_for(locks, "two/showcase/src/App.java")),
+                "a lock declared by one report must not match the other reactor's file")
+
+    def test_non_locked_entries_are_ignored(self):
+        with tempfile.TemporaryDirectory() as root:
+            report = os.path.join(root, ".vibetags-locks")
+            with open(report, "w", encoding="utf-8") as fh:
+                fh.write('{"type":"other","file":"a/B.java"}\n')
+                fh.write('not json at all\n')
+                fh.write('{"type":"locked","element":"E","file":"a/B.java"}\n')
+            locks = load_locks([report], root)
+            self.assertEqual(1, len(locks))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #451. Closes #452.

Branched off `main`, not stacked on #453. Stacking is what stranded #450.

The guard shipped for two releases with no tests of its own and carried two false-positive
sources. Both surfaced while adding a second annotation showcase in #453; between them they
produced **27 violations** against code that was doing nothing wrong.

## #451 — locks from one project blamed another project's files

A `.vibetags-locks` records paths relative to **its own VibeTags root**, not to the repository.
`load_locks` normalised against the repo root only, so two reactors with a module at
`showcase/src/main/java/...` both recorded the identical string:

```
"file":"showcase/src/main/java/com/example/service/OrderService.java"   # examples/multimodule
"file":"showcase/src/main/java/com/example/service/OrderService.java"   # examples/gradle-multimodule
```

`locks_for` then accepted either path as a suffix of the other, so nothing downstream could tell
them apart. **Measured:** with the Gradle reactor's report removed entirely, the Maven reactor's
still produced **9 violations** against Gradle files.

Each recorded path is now resolved against the directory of the report that declared it, then
compared exactly. The suffix fallback existed to paper over absolute-vs-relative prefixes;
`resolve_lock_path` handles those directly, so the fallback is gone.

## #452 — a PR that adds an `@AILocked` element failed on its own additions

The guard intersects locked ranges at HEAD with the diff, and a created file has every line in
that diff. Declaring a lock is not violating one: nobody can have touched a guardrail that did
not exist at the base.

This is not only about examples. Any PR adding an `@AILocked` element to `vibetags/src/main/java`
hits it, so the guard quietly discouraged adding guardrails to the codebase that ships them.

Files with status `A` are now exempt. Renames are `R`, so moving a locked file is still checked,
and so is any later PR that edits it.

## Verification

The interesting part is proving these tests detect the defects rather than describe them.

- **12 unit tests**, stdlib `unittest` only, no new dependency, run in CI via a new step in the
  `locked-files` job.
- **Proven red then green**: restoring only the old suffix matching turns
  `test_a_shorter_path_is_not_a_match_by_suffix` red; the fix turns it green.
- **End to end in a scratch git repo**: a second example gaining a class at a colliding relative
  path, with its own report, reports `no locked code touched` and exits 0.
- **Control, so this is a fix and not a hole**: in the same scratch repo, modifying the *first*
  example's locked class still fails with
  `::error::Change touches @AILocked element p.X (lines 2-3)` and exit 1.
- Guard run against this branch with base `origin/main`: no locked code touched.
- `mvn test -Pe2e`: 2000 tests, 0 failures, 0 errors, 0 skipped.
- pre-commit gitleaks, end-of-file-fixer, trailing-whitespace pass. Its checkstyle hook was
  **skipped**, no Docker daemon locally; checkstyle runs in the Maven build regardless.

## Follow-up

#453's Gradle reactor dropped `.vibetags-locks` to work around #452, which is why it asserts 50
active services rather than 51. Once both land, that opt-in can come back and the count returns to
51. Filed separately rather than left in this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fnp2WQsEf2ruVAyCRZT66A