### PR TITLE
chore: prepare release v1.2.5

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.2.4
+version: 1.2.5
 ---
 
 # VibeTags Usage Guide
@@ -27,7 +27,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
     <dependency>
         <groupId>se.deversity.vibetags</groupId>
         <artifactId>vibetags-annotations</artifactId>
-        <version>1.2.4</version>
+        <version>1.2.5</version>
     </dependency>
 </dependencies>
 
@@ -41,7 +41,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.4</version>
+                        <version>1.2.5</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -63,8 +63,8 @@ the whole processor and its SLF4J/Logback dependencies on your compile classpath
 
 ```groovy
 dependencies {
-    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.2.4'
-    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.4'
+    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.2.5'
+    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.5'
 }
 ```
 
@@ -221,7 +221,7 @@ though the build is green.
 Every way this setup fails is silent, so check rather than assume:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.4 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.2.5 doctor
 ```
 
 Or by hand, in the order things go wrong:
@@ -1287,7 +1287,7 @@ Use on: **class, method, field**
 @AIKeepInSync(mirrors = {"pom.xml:<version>", "README.md badge", "docs/CHANGELOG.md"},
               reason = "The release version is asserted in three places and drifts silently",
               enforcedBy = "ProjectFactsConsistencyTest")
-public static final String VERSION = "1.2.4";
+public static final String VERSION = "1.2.5";
 ```
 
 The element is free to change — the failure mode is a *partial* change that desyncs a mirror no compiler checks. `@AIContract` freezes one signature so it cannot change at all; neither it nor `@AISchemaSafe` expresses "edit A ⇒ you must also edit B". Mirrors routinely point outside the compilation unit, so VibeTags can only *name* them, not verify them.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.2.4</version>
+            <version>1.2.5</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.4</version>
+                        <version>1.2.5</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -94,7 +94,7 @@ touch CLAUDE.md .cursorrules AGENTS.md   # Claude, Cursor, Codex CLI — add whi
 Or let the companion CLI do it (and `vibetags doctor` checks your setup afterwards):
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.4 init --platforms claude,cursor
+jbang se.deversity.vibetags:vibetags-cli:1.2.5 init --platforms claude,cursor
 ```
 
 **3. Annotate your first class:**
@@ -123,8 +123,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -170,8 +170,8 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.4"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.4"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.5"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.5"))
 
     compileOnly("se.deversity.vibetags:vibetags-annotations")
     kapt("se.deversity.vibetags:vibetags-processor")
@@ -518,7 +518,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.2.4</version>
+            <version>1.2.5</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -543,7 +543,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.4</version>
+                        <version>1.2.5</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -559,8 +559,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -574,15 +574,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.2.4</version>
+    <version>1.2.5</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.4'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.4'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.5'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.5'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.
@@ -906,8 +906,8 @@ presence the processor honours (the processor itself never creates them), and
 `VIBETAGS-START`/`END` marker integrity. Run it without installing anything:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.4 init --list
-jbang se.deversity.vibetags:vibetags-cli:1.2.4 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.2.5 init --list
+jbang se.deversity.vibetags:vibetags-cli:1.2.5 doctor
 ```
 
 The platform list and marker rules are read from `vibetags-processor` at runtime, so the CLI

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.5] - 2026-08-22
+
 ### Fixed
+
+- **The locked-files guard no longer blames the wrong file, or the wrong pull request.** The
+  action this repository ships to consumers carried two false-positive sources and no tests of
+  its own. Between them they produced 27 violations against code that was doing nothing wrong.
+
+  A `.vibetags-locks` records paths relative to *its own* VibeTags root, not to the repository,
+  and the guard normalised against the repository root only, then accepted either path as a
+  suffix of the other. Two projects with a module at the same relative path therefore aliased
+  each other: measured, one example's report produced nine violations against a sibling
+  example's files, with its own report removed entirely. Each recorded path is now resolved
+  against the directory of the report that declared it, and compared exactly.
+
+  Separately, a pull request that *adds* an `@AILocked` element failed on its own additions,
+  because a created file has every line in the diff. Declaring a lock is not violating one, and
+  the effect was to discourage adding guardrails to the codebase that ships them. Files the diff
+  creates are now exempt; renames stay in scope, so moving a locked file is still checked.
+
+  Twelve unit tests now cover both, run in CI, and were shown to fail against the old behaviour
+  before being trusted. `examples/gradle-multimodule` had dropped its `.vibetags-locks` opt-in to
+  work around the second defect, asserting 50 active services instead of 51; that opt-in is back.
 
 - **A full, correct build no longer claims your guardrails are stated nowhere.** A module that
   opts into a granular directory of its own, inside a reactor whose root has a `.vibetags-roles`
@@ -28,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Gradle reactors are verified to the same depth as Maven ones.** The Maven reactor had eleven
   CI verification steps to the Gradle reactor's one, while the three most recent multi-module
   defects all came from Gradle repositories: the thinner coverage sat on the tool producing the
-  bugs. `examples/gradle-multimodule` grows from two modules to four and now carries transitive
+  bugs. `examples/gradle-multimodule` grows from two modules to five and now carries transitive
   manifests, cross-module rule mirroring, role-based granular grouping, per-module nested output
   in two shapes, all 44 annotations, and every service the reactor opts into. Seven assertions ported from
   the Maven reactor gate it, including the `#365` repro that a one-subproject build must leave a
@@ -2993,7 +3015,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.2.4...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.2.5...HEAD
+[1.2.5]: https://github.com/PIsberg/vibetags/compare/v1.2.4...v1.2.5
 [1.2.4]: https://github.com/PIsberg/vibetags/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/PIsberg/vibetags/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/PIsberg/vibetags/compare/v1.2.1...v1.2.2

--- a/examples/all-tiers/pom.xml
+++ b/examples/all-tiers/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.2.4</vibetags.bom.version>
+    <vibetags.bom.version>1.2.5</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/basic/build.gradle
+++ b/examples/basic/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/examples/basic/pom.xml
+++ b/examples/basic/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.2.4</vibetags.bom.version>
+        <vibetags.bom.version>1.2.5</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/examples/gradle-composite/app/build.gradle
+++ b/examples/gradle-composite/app/build.gradle
@@ -16,8 +16,8 @@ repositories {
 
 dependencies {
     implementation 'se.deversity.vibetags.example:vibetags-example-gradle-composite-lib'
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-composite/lib/build.gradle
+++ b/examples/gradle-composite/lib/build.gradle
@@ -15,8 +15,8 @@ repositories {
 }
 
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-flat/app/build.gradle
+++ b/examples/gradle-flat/app/build.gradle
@@ -21,8 +21,8 @@ allprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-multimodule/build.gradle
+++ b/examples/gradle-multimodule/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-shared-buildfile/build.gradle
+++ b/examples/gradle-shared-buildfile/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.apache.groovy:groovy:5.1.0'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
 
     // Annotations on compile, processor on the annotation-processor path only.
     compileOnly 'se.deversity.vibetags:vibetags-annotations'

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and kapt configurations so neither needs an explicit version.
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.4"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.4"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.5"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.5"))
 
     // Annotations on compile, processor on the kapt path only — keeps the processor's
     // slf4j/logback off the consumer's compile classpath. compileOnly is enough:

--- a/examples/multimodule-indexed/pom.xml
+++ b/examples/multimodule-indexed/pom.xml
@@ -37,7 +37,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.2.4</vibetags.bom.version>
+    <vibetags.bom.version>1.2.5</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/examples/multimodule/pom.xml
+++ b/examples/multimodule/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.2.4</vibetags.bom.version>
+    <vibetags.bom.version>1.2.5</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/scala/build.gradle
+++ b/examples/scala/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.scala-lang:scala-library:2.13.18'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.2.4</vibetags.bom.version>
+        <vibetags.bom.version>1.2.5</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.2.4'
+version = '1.2.5'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.2.4'
+            version = '1.2.5'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -39,12 +39,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.2.4&lt;/version&gt;
+                &lt;version&gt;1.2.5&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.4'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.4'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.5'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.5'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -36,7 +36,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.2.4&lt;/version&gt;
+                        &lt;version&gt;1.2.5&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.2.4')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.4')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-cli/pom.xml
+++ b/vibetags-cli/pom.xml
@@ -28,7 +28,7 @@
         reports the project's VibeTags health — build-tool wiring, active platforms,
         marker integrity. Run it without installing anything:
 
-            jbang se.deversity.vibetags:vibetags-cli:1.2.4 init --list
+            jbang se.deversity.vibetags:vibetags-cli:1.2.5 init --list
 
         The platform list and marker rules are read from vibetags-processor, so this
         tool cannot drift from what the processor actually does.

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.2.4</revision>
+        <revision>1.2.5</revision>
 
         <!-- release, not source/target: on a JDK newer than 21 (CI builds 21, 25 and 26)
              source/target compiles against the *running* JDK's API and javac warns that the

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.2.4'
+version = '1.2.5'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -20,7 +20,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.2.4'
+            version = '1.2.5'
             from components.java
 
             pom {
@@ -78,7 +78,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.2.4'
+    api 'se.deversity.vibetags:vibetags-annotations:1.2.5'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation 'org.jspecify:jspecify:1.0.1'


### PR DESCRIPTION
Cuts **1.2.5** from 1.2.4. Patch bump: two defect fixes and test coverage, no API change.

## What ships

### Fixed — the locked-files guard no longer blames the wrong file, or the wrong PR

The action this repository ships to consumers carried two false-positive sources and no tests of
its own. Between them they produced **27 violations** against code that was doing nothing wrong.

A `.vibetags-locks` records paths relative to *its own* VibeTags root, not to the repository, and
the guard normalised against the repository root only, then accepted either path as a suffix of the
other. Two projects with a module at the same relative path aliased each other: measured, one
example's report produced **nine** violations against a sibling example's files with its own report
removed entirely. Paths are now resolved against the directory of the report that declared them,
and compared exactly.

Separately, a PR that *adds* an `@AILocked` element failed on its own additions, because a created
file has every line in the diff. That discouraged adding guardrails to the codebase that ships
them. Files the diff creates are now exempt; renames stay in scope.

Twelve unit tests cover both, run in CI, and were shown to fail against the old behaviour before
being trusted.

### Fixed — a correct build no longer claims your guardrails are stated nowhere

A module opting into a granular directory of its own, inside a reactor whose root has a
`.vibetags-roles`, was reported as having lost rule files it never had. Two stem namespaces met in
one sidecar field. Nothing was lost and nothing was written wrongly; the warning was the whole
defect, and it fired on every round of every build in that shape.

### Added — Gradle reactors verified to the same depth as Maven ones

The Maven reactor had eleven CI verification steps to the Gradle reactor's one, while the three
most recent multi-module defects all came from Gradle repositories. `examples/gradle-multimodule`
grows from two modules to five and carries transitive manifests, cross-module mirroring, role-based
grouping, per-module nested output, all 44 annotations, and every service it opts into.

### Changed — `examples/gradle-flat` names its modules explicitly

`app` and `lib`, matching `examples/gradle-composite`.

## Two corrections made while cutting, rather than shipping as-is

- The locked-files guard fix **had no changelog entry at all**. It changed behaviour in a shipped
  action, so it now has one.
- The Gradle entry said the fixture grew "from two modules to four". It is **five**; the showcase
  module landed after that line was written.

## Verification

| Gate | Result |
|---|---|
| `BuildVersionParityTest` | 6 tests green: no Gradle file, example pom or managed pom disagrees with `<revision>` |
| Build in order, all 7 modules | exit 0 each, checked against Maven's status and not a pipe's |
| **Guardrail-file drift in the examples** | **zero** |
| `mvn test -Pe2e` | 2002 tests, 0 failures, 0 errors, 0 skipped |
| Leftover `1.2.4` references | only historical prose and build artifacts, as expected |
| pre-commit: gitleaks, end-of-file-fixer, trailing-whitespace | passed |
| pre-commit: checkstyle | **skipped**, not passed: its hook needs a Docker daemon not running here. Checkstyle still ran, bound to the Maven `validate` phase |

The zero-drift result is the one worth reading. The processor version feeds `BuildFingerprint`, so
a release invalidates every consumer's fingerprint and reruns the whole generate phase. Nothing
moved, so rendering is unchanged and the examples regenerate byte-for-byte.

## After merge

I will not create the release. Once this is merged, tell me and I will generate the notes from the
CHANGELOG for your review before anything is published — tagging triggers the Maven Central deploy
and is not reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fnp2WQsEf2ruVAyCRZT66A