### PR TITLE
ci(evals): pin the claude CLI with a lockfile and npm ci

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,8 +19,12 @@ updates:
         patterns:
           - "github/codeql-action*"
 
+  # evals/ holds the only npm manifest in the repo: the pinned claude CLI the instruction
+  # evals run on. This entry pointed at `/`, where no package.json has ever existed, so it
+  # produced nothing at all. Keeping it pointed at a real manifest is what stops the pin
+  # below from freezing the CLI at whatever version it was pinned to.
   - package-ecosystem: npm
-    directory: /
+    directory: /evals
     schedule:
       interval: daily
 

--- a/.github/workflows/instruction-evals.yml
+++ b/.github/workflows/instruction-evals.yml
@@ -7,9 +7,10 @@
 # triggers on the instruction-file paths and manual dispatch, never on every commit.
 #
 # Requires the ANTHROPIC_API_KEY secret; without it the run reports SKIPPED, which is not
-# a pass. The claude CLI is installed at whatever version npm currently serves - a known,
-# accepted deviation from this repo's pin-everything rule, because the CLI's flag surface
-# must track the live API; the harness fails loudly (exit 2) if the flags drift.
+# a pass. The claude CLI is pinned by evals/package-lock.json and installed with `npm ci`,
+# so a run resolves the same integrity-checked tarballs every time instead of whatever npm
+# serves that day. The CLI's flag surface still has to track the live API, so Dependabot
+# raises the pin on its own schedule and the harness fails loudly (exit 2) if flags drift.
 
 name: Instruction Evals
 
@@ -70,9 +71,19 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: env.HAVE_KEY == 'true'
 
-      - name: Install the claude CLI
+      # `npm ci` against the committed lockfile, not `npm install -g`: the lockfile carries
+      # an integrity hash per tarball, so a compromised or moved republish fails the install
+      # instead of silently running. The version check is not decoration - npm can defer a
+      # package's postinstall, and this package's postinstall is what swaps the 500-byte
+      # placeholder for the native binary. Without the check that stub surfaces as a dozen
+      # identical trial failures later; with it, the job stops here.
+      - name: Install the claude CLI (pinned by evals/package-lock.json)
         if: env.HAVE_KEY == 'true'
-        run: npm install -g @anthropic-ai/claude-code
+        working-directory: evals
+        run: |
+          npm ci
+          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+          "$PWD/node_modules/.bin/claude" --version
 
       - name: Run the task bank
         if: env.HAVE_KEY == 'true'

--- a/evals/README.md
+++ b/evals/README.md
@@ -31,6 +31,7 @@ The current bank measures four rules that CI cannot otherwise see an agent break
 
 ```bash
 export ANTHROPIC_API_KEY=...   # hermetic runs cannot use stored logins
+(cd evals && npm ci) && export PATH="$PWD/evals/node_modules/.bin:$PATH"   # pinned CLI
 bash evals/run-instruction-evals.sh                 # all tasks, 3 trials each
 TRIALS=10 bash evals/run-instruction-evals.sh       # decision-grade run
 TASKS="locked-element" bash evals/run-instruction-evals.sh
@@ -81,6 +82,13 @@ variable under measurement is the committed instruction stack of this repository
 `AGENTS.md`, `GEMINI.md`, or `.claude/**` - the merge gate for instruction edits - and on
 manual dispatch. It requires the `ANTHROPIC_API_KEY` secret; without it the workflow
 reports SKIPPED, which is not a pass. Results upload as an artifact.
+
+The CLI itself is pinned: `evals/package.json` names the version and
+`evals/package-lock.json` carries an integrity hash per tarball, so CI installs it with
+`npm ci` and a moved or republished tarball fails the install rather than running. Any
+`claude` on `PATH` still works for a local run - the pin binds CI. Dependabot raises the
+version daily, which is what keeps the pin from freezing the CLI's flag surface away from
+the live API.
 
 ## Adding a task
 

--- a/evals/package-lock.json
+++ b/evals/package-lock.json
@@ -1,0 +1,155 @@
+{
+  "name": "vibetags-evals",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vibetags-evals",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@anthropic-ai/claude-code": "2.1.245"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code": {
+      "version": "2.1.245",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.245.tgz",
+      "integrity": "sha512-+7baJddJXZukgd6AgC7xStHGsMTVHDPlRcAoqTSPx2NQ+QwKGtvCZQLgbnKuhjkwq9v9vKvYwIhLOwGiE77mVQ==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN README.md",
+      "bin": {
+        "claude": "bin/claude.exe"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-code-darwin-arm64": "2.1.245",
+        "@anthropic-ai/claude-code-darwin-x64": "2.1.245",
+        "@anthropic-ai/claude-code-linux-arm64": "2.1.245",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.245",
+        "@anthropic-ai/claude-code-linux-x64": "2.1.245",
+        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.245",
+        "@anthropic-ai/claude-code-win32-arm64": "2.1.245",
+        "@anthropic-ai/claude-code-win32-x64": "2.1.245"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
+      "version": "2.1.245",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.245.tgz",
+      "integrity": "sha512-jjXl0zI4v3UXpkOlvDdPzJzz0rQ1QwvzDlKMSUIw5rGMReiOErq8o8DJyQJNgERejGG5Et9DiUFm+Bg6Tq9IBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-x64": {
+      "version": "2.1.245",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.245.tgz",
+      "integrity": "sha512-4WJJ+nHOuhV00/55I3LoVhfWDBU4KGgYdBe/lZjuufOSFhoREeG8T/HT2bYS/qTbFZUbkBau80M1TBMiBDbnbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64": {
+      "version": "2.1.245",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.245.tgz",
+      "integrity": "sha512-Qbn5HnZbYeW4GdifVkDGfcVKqj3/f3U9sfVd3LEaUZh08CcS8D/ptJ76zuBfQUGHJHfToAdNVfak86uJ84b1Dg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
+      "version": "2.1.245",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.245.tgz",
+      "integrity": "sha512-Fb6aeNv5NZf8XhFbBqb0HG5gT3Y+3FtrJetPoYbN36i74Jqt5Xsw85o/JyCPBULWBoNHDBm/ljYfn+/KwRerFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64": {
+      "version": "2.1.245",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.245.tgz",
+      "integrity": "sha512-SRO5w2f9iHKZmREp389kPKxWAr6qEODxggdhhS7zF16OMwaUHjV5Yu7Oq8jSMD57gQiBjOfvFp/SJg3CdfHCtA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
+      "version": "2.1.245",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.245.tgz",
+      "integrity": "sha512-loThtx/opxdpmwk07VmjQL7ALhOKJJozdJs2T5SXVY7iAEZwX+nPK+Zz0CyvT3XRtxtimbEeNaQPmk43PUkFag==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-arm64": {
+      "version": "2.1.245",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.245.tgz",
+      "integrity": "sha512-gG/B3EU+nQZA9tjp43JE94p2VoCh0VotfaxyKYOf1eW0JmJRYzcpvV2Iih8/5i/FkL9TWghPAtRV8YcxwzTtow==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-x64": {
+      "version": "2.1.245",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.245.tgz",
+      "integrity": "sha512-/SVV2dUpKIyuNylzsHo0pFqKAn6HGcqNB/fEpluahvUIaYsgluJsBs8m3uIgYLfU4nFnPbemrYj0ekoG626SgA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    }
+  }
+}

--- a/evals/package.json
+++ b/evals/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "vibetags-evals",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Pins the claude CLI used by evals/run-instruction-evals.sh so CI installs it with 'npm ci' against a committed lockfile of integrity hashes.",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@anthropic-ai/claude-code": "2.1.245"
+  }
+}


### PR DESCRIPTION
Closes code-scanning alert [27](https://github.com/PIsberg/vibetags/security/code-scanning/27)
(Scorecard `Pinned-Dependencies`, medium, `score is 9: npmCommand not pinned by hash`).

## The failure this prevents

`instruction-evals.yml` installed the eval CLI with `npm install -g @anthropic-ai/claude-code`.
That resolves whatever npm serves at that moment, and the resulting binary then runs in a job
holding `ANTHROPIC_API_KEY`. A compromised or moved republish of the package would have run
with nothing in the pipeline able to detect the swap.

## Why a version suffix would not have fixed it

Worth stating because it is the obvious first move and it does not work. Scorecard's
[`isNpmUnpinnedDownload`](https://github.com/ossf/scorecard/blob/v5.5.0/checks/raw/shell_download_validate.go)
counts *every* `npm install` as unpinned regardless of the package spec â€” only `npm ci`, or a
git URL ending in a commit hash, returns pinned. `npm install -g pkg@2.1.245` would have left
the alert open. The reason is sound: only a committed lockfile carries a per-tarball integrity
hash, which is what "pinned by hash" means here.

So this adds `evals/package.json` + `evals/package-lock.json` and switches the step to `npm ci`.

## Two things that would have bitten silently

- **A Windows-generated lockfile can omit other platforms' binaries.** The CLI fans out to 8
  platform-specific optional deps. Verified the committed lockfile records all 8 with `sha512`
  integrity, including `linux-x64` â€” without it `npm ci` breaks on `ubuntu-latest`.
- **npm can defer the postinstall.** The package ships a 500-byte placeholder that its
  postinstall swaps for the native binary, and npm 11.17+ has an allow-scripts gate. Confirmed
  locally that `npm ci --ignore-scripts` leaves the stub and the CLI exits 1. The install step
  therefore ends with `claude --version`, so that failure lands once, here, instead of as a
  dozen identical trial failures in the next step.

## Keeping the pin from rotting

The old header comment argued the install was left unpinned deliberately, because the CLI's
flag surface must track the live API. That reason is real, so the PR keeps it working rather
than overriding it: Dependabot's npm entry pointed at `/`, where no `package.json` has ever
existed, so it had never produced a single update. Repointed at `/evals`, the daily bump now
raises the pin. The comment and `evals/README.md` were updated to say what the job actually
does now.

## Verification

| Check | Result |
| --- | --- |
| Lockfile records all 8 platform variants with sha512, incl. `linux-x64` | pass |
| `npm ci` then `claude --version` | pass, prints `2.1.245` |
| `npm ci --ignore-scripts` leaves a stub (the case the version check catches) | reproduced, exits 1 |
| Both YAML files parse; install step is exactly the 3 intended lines | pass |
| `CodeQlActionVersionParityTest` (the only test reading `.github/`) | pass, 1 test 0 failures |
| `pre-commit` on changed files | pass (checkstyle **skipped** â€” no Java changed) |

### What CI did *not* verify

The `Instruction Evals` check on this PR is green in 27s, and that green is a **skip, not a
pass**: `ANTHROPIC_API_KEY` is not configured on this repo, so `Install the claude CLI` and
`Run the task bank` both report `skipped`. The step this PR changes did not execute on a
runner. (Neither did the command it replaces — that lane has never had a key.)

Rather than leave the linux path unverified, it was run for real on linux-x64 (WSL Ubuntu
22.04, glibc 2.35, a self-contained Node 22.20 + npm 10.9.3, no system packages touched),
using the committed `package.json` and `package-lock.json`:

- `npm ci` exited 0 and resolved `@anthropic-ai/claude-code-linux-x64` — the correct variant.
- The postinstall replaced the 500-byte placeholder with a 391 MB `ELF 64-bit LSB executable,
  x86-64` binary.
- `claude --version` from `node_modules/.bin` printed `2.1.245`, exit 0 — the same `PATH` the
  workflow exports.

The Java suite was not run in full: this change touches only `.github/` and `evals/`, no main
or test sources. The alert itself is recomputed by `scorecards.yml` on push to `main`, so it
closes after merge, not from this PR.

## Follow-up

#472 â€” the runner's ambient Node/npm is still unpinned; deliberately out of scope here, since
Scorecard does not flag the runner toolchain and pinning it is a separate decision.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MhjHghKqe4pWRmD8P5woTP

