### PR TITLE
fix(content): drop the label when the member behind it is unset

### DIFF
--- a/vibetags/findsecbugs-taint-config.txt
+++ b/vibetags/findsecbugs-taint-config.txt
@@ -2,3 +2,4 @@ se/deversity/vibetags/processor/internal/content/Escape.xml(Ljava/lang/String;)L
 se/deversity/vibetags/processor/internal/content/Escape.json(Ljava/lang/String;)Ljava/lang/String;:SAFE
 se/deversity/vibetags/processor/internal/content/Escape.tomlMultiline(Ljava/lang/String;)Ljava/lang/String;:SAFE
 se/deversity/vibetags/processor/internal/content/annotations/CommonFormatterHelper.claudeReason(Ljava/lang/String;)Ljava/lang/String;:SAFE
+se/deversity/vibetags/processor/internal/content/annotations/CommonFormatterHelper.element(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;:SAFE

--- a/vibetags/spotbugs-exclude.xml
+++ b/vibetags/spotbugs-exclude.xml
@@ -106,8 +106,17 @@
   <!-- ==================================================================================
        Find Security Bugs (findsecbugs-plugin). Escaped interpolation is NOT excluded here:
        Escape.xml / Escape.json / Escape.tomlMultiline and CommonFormatterHelper.claudeReason
-       are declared as sanitizers in findsecbugs-taint-config.txt, so POTENTIAL_XML_INJECTION
-       stays live and an unescaped append into the CLAUDE.md XML block still fails the build.
+       and .element are declared as sanitizers in findsecbugs-taint-config.txt, so
+       POTENTIAL_XML_INJECTION stays live and an unescaped append into the CLAUDE.md XML block
+       still fails the build.
+
+       On .element specifically: it returns "<tag>" + Escape.xml(value) + "</tag>", so its
+       value argument is sanitized on every path. Its tag argument is a string literal at
+       every call site and names the element, not its content — if that ever stops being
+       true, the sanitizer declaration stops being true with it and this note is the place
+       that says so. The detector flagged AITestDrivenFormatter the moment the escaping moved
+       from the call site into the helper, which is the gate working: it could no longer see
+       a sanitizer, so it assumed there was none.
        ================================================================================== -->
 
   <!-- CRLF_INJECTION_LOGS: mitigated centrally rather than per call site. The Logback

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIArchitectureFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIArchitectureFormatter.java
@@ -28,7 +28,8 @@ public final class AIArchitectureFormatter implements AnnotationFormatter {
                 sb.append("* `").append(className).append("` - ").append(summary).append('\n');
                 break;
             case CLAUDE:
-                sb.append("    <element path=\"").append(Escape.xml(className)).append("\">\n      <belongs_to>").append(Escape.xml(belongsTo)).append("</belongs_to>\n");
+                sb.append("    <element path=\"").append(Escape.xml(className)).append("\">\n")
+                    .append(CommonFormatterHelper.element("belongs_to", belongsTo));
                 for (String r : cannotRef) {
                     sb.append("      <cannot_reference>").append(Escape.xml(r)).append("</cannot_reference>\n");
                 }
@@ -51,14 +52,16 @@ public final class AIArchitectureFormatter implements AnnotationFormatter {
                 sb.append("- [").append(element.displayName()).append("](").append(className).append("): ").append(summary).append('\n');
                 break;
             case LLMS_FULL:
-                sb.append("### ").append(className).append("\n- **Belongs to Layer**: ").append(belongsTo).append('\n');
+                sb.append("### ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Belongs to Layer", belongsTo));
                 if (cannotRef.length > 0) {
                     sb.append("- **Prohibited References**: ").append(cannotRefStr).append('\n');
                 }
                 sb.append('\n');
                 break;
             case AIDER_CONVENTIONS:
-                sb.append("#### ARCHITECTURE LAYER: ").append(className).append("\n- **Layer**: ").append(belongsTo).append('\n')
+                sb.append("#### ARCHITECTURE LAYER: ").append(className).append('\n')
+                  .append(CommonFormatterHelper.bullet("Layer", belongsTo))
                   .append(cannotRef.length > 0 ? "- **Cannot Reference**: " + cannotRefStr + "\n" : "").append('\n');
                 break;
             case ZED:

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIBannedApiFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIBannedApiFormatter.java
@@ -34,7 +34,7 @@ public final class AIBannedApiFormatter implements AnnotationFormatter {
                 break;
             case CLAUDE:
                 sb.append("    <element path=\"").append(Escape.xml(className)).append("\">\n")
-                    .append("      <forbidden>").append(Escape.xml(forbidden)).append("</forbidden>\n");
+                    .append(CommonFormatterHelper.element("forbidden", forbidden));
                 if (!useInstead.isEmpty()) {
                     sb.append("      <use-instead>").append(Escape.xml(useInstead)).append("</use-instead>\n");
                 }
@@ -60,7 +60,8 @@ public final class AIBannedApiFormatter implements AnnotationFormatter {
                 sb.append("- [").append(element.displayName()).append("](").append(className).append("): ").append(summary).append('\n');
                 break;
             case LLMS_FULL:
-                sb.append("### ").append(className).append("\n- **Banned here**: ").append(forbidden).append('\n');
+                sb.append("### ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Banned here", forbidden));
                 if (!useInstead.isEmpty()) {
                     sb.append("- **Sanctioned route**: ").append(useInstead).append('\n');
                 }
@@ -71,7 +72,7 @@ public final class AIBannedApiFormatter implements AnnotationFormatter {
                 break;
             case AIDER_CONVENTIONS:
                 sb.append("#### BANNED APIs: ").append(className).append('\n')
-                  .append("- **Forbidden**: ").append(forbidden).append('\n')
+                  .append(CommonFormatterHelper.bullet("Forbidden", forbidden))
                   .append(useInstead.isEmpty() ? "" : "- **Use instead**: " + useInstead + "\n")
                   .append(reason.isEmpty() ? "" : "- **Reason**: " + reason + "\n")
                   .append("- **Rule**: These compile but are prohibited at this element.\n\n");

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AICallersOnlyFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AICallersOnlyFormatter.java
@@ -25,13 +25,17 @@ public final class AICallersOnlyFormatter implements AnnotationFormatter {
 
         switch (platform) {
             case CLAUDE:
-                sb.append("    <file path=\"").append(Escape.xml(className)).append("\">\n      <allowed_callers>").append(Escape.xml(callers)).append("</allowed_callers>\n    </file>\n");
+                sb.append("    <file path=\"").append(Escape.xml(className)).append("\">\n")
+                    .append(CommonFormatterHelper.element("allowed_callers", callers))
+                    .append("    </file>\n");
                 break;
             case LLMS_FULL:
-                sb.append("### ").append(className).append("\n- **Allowed Callers**: ").append(callers).append("\n\n");
+                sb.append("### ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Allowed Callers", callers)).append('\n');
                 break;
             case AIDER_CONVENTIONS:
-                sb.append("#### CALLERS LIMIT: ").append(className).append("\n- **Allowed Callers**: ").append(callers).append("\n\n");
+                sb.append("#### CALLERS LIMIT: ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Allowed Callers", callers)).append('\n');
                 break;
             case INTERPRETER:
                 sb.append("- `").append(className).append("` (callers limited): ").append(summary).append('\n');

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIContextFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIContextFormatter.java
@@ -26,7 +26,10 @@ public final class AIContextFormatter implements AnnotationFormatter {
                 sb.append("* `").append(className).append("`\n  * Focus: ").append(focus).append("\n  * Avoid: ").append(avoids).append('\n');
                 break;
             case CLAUDE:
-                sb.append("    <file path=\"").append(Escape.xml(className)).append("\">\n      <focus>").append(Escape.xml(focus)).append("</focus>\n      <avoids>").append(Escape.xml(avoids)).append("</avoids>\n    </file>\n");
+                sb.append("    <file path=\"").append(Escape.xml(className)).append("\">\n")
+                    .append(CommonFormatterHelper.element("focus", focus))
+                    .append(CommonFormatterHelper.element("avoids", avoids))
+                    .append("    </file>\n");
                 break;
             case CODEX:
                 sb.append("- `").append(className).append("`: Focus on ").append(focus).append(". Avoid ").append(avoids).append(".\n");
@@ -45,10 +48,14 @@ public final class AIContextFormatter implements AnnotationFormatter {
                 sb.append("- [").append(element.displayName()).append("](").append(className).append("): Focus - ").append(focus).append(". Avoid - ").append(avoids).append('\n');
                 break;
             case LLMS_FULL:
-                sb.append("### ").append(className).append("\n- **Focus**: ").append(focus).append("\n- **Avoid**: ").append(avoids).append("\n\n");
+                sb.append("### ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Focus", focus))
+                    .append(CommonFormatterHelper.bullet("Avoid", avoids)).append('\n');
                 break;
             case AIDER_CONVENTIONS:
-                sb.append("#### CONTEXT: ").append(className).append("\n- **Focus**: ").append(focus).append("\n- **Avoid**: ").append(avoids).append("\n\n");
+                sb.append("#### CONTEXT: ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Focus", focus))
+                    .append(CommonFormatterHelper.bullet("Avoid", avoids)).append('\n');
                 break;
             case ZED:
                 sb.append("- `").append(className).append("`: Focus - ").append(focus).append(". Avoid - ").append(avoids).append('\n');

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIContractFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIContractFormatter.java
@@ -25,10 +25,12 @@ public final class AIContractFormatter implements AnnotationFormatter {
                 sb.append("* `").append(className).append("` - ").append(reason).append('\n');
                 break;
             case CLAUDE:
-                sb.append("    <element path=\"").append(Escape.xml(className)).append("\">\n      <reason>").append(Escape.xml(reason)).append("</reason>\n    </element>\n");
+                sb.append("    <element path=\"").append(Escape.xml(className)).append("\">\n")
+                    .append(CommonFormatterHelper.element("reason", reason))
+                    .append("    </element>\n");
                 break;
             case CODEX:
-                sb.append("- **").append(className).append("**: ").append(reason).append('\n');
+                sb.append(CommonFormatterHelper.codexBullet(className, reason));
                 break;
             case COPILOT:
                 sb.append("- `").append(className).append("` - ").append(reason).append('\n');
@@ -44,10 +46,12 @@ public final class AIContractFormatter implements AnnotationFormatter {
                 sb.append("- [").append(element.displayName()).append("](").append(className).append("): ").append(reason).append('\n');
                 break;
             case LLMS_FULL:
-                sb.append("### ").append(className).append("\n- **Reason**: ").append(reason).append("\n\n");
+                sb.append("### ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Reason", reason)).append('\n');
                 break;
             case AIDER_CONVENTIONS:
-                sb.append("#### CONTRACT: ").append(className).append("\n- **Constraint**: Signature is frozen. Do not change method names, parameter types, return types, or checked exceptions.\n- **Reason**: ").append(reason).append("\n\n");
+                sb.append("#### CONTRACT: ").append(className).append("\n- **Constraint**: Signature is frozen. Do not change method names, parameter types, return types, or checked exceptions.\n")
+                    .append(CommonFormatterHelper.bullet("Reason", reason)).append('\n');
                 break;
             case ZED:
                 sb.append("- `").append(className).append("`: ").append(reason).append('\n');

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AICoreFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AICoreFormatter.java
@@ -26,7 +26,10 @@ public final class AICoreFormatter implements AnnotationFormatter {
                 sb.append("* `").append(className).append("` - Sensitivity: ").append(sensitivity).append(". Note: ").append(note).append('\n');
                 break;
             case CLAUDE:
-                sb.append("    <element path=\"").append(Escape.xml(className)).append("\">\n      <sensitivity>").append(Escape.xml(sensitivity)).append("</sensitivity>\n      <note>").append(Escape.xml(note)).append("</note>\n    </element>\n");
+                sb.append("    <element path=\"").append(Escape.xml(className)).append("\">\n")
+                    .append(CommonFormatterHelper.element("sensitivity", sensitivity))
+                    .append(CommonFormatterHelper.element("note", note))
+                    .append("    </element>\n");
                 break;
             case CODEX:
                 sb.append("- **").append(className).append("** (sensitivity: ").append(sensitivity).append("): ").append(note).append('\n');
@@ -45,10 +48,14 @@ public final class AICoreFormatter implements AnnotationFormatter {
                 sb.append("- [").append(element.displayName()).append("](").append(className).append("): Sensitivity: ").append(sensitivity).append(". Note: ").append(note).append('\n');
                 break;
             case LLMS_FULL:
-                sb.append("### ").append(className).append("\n- **Sensitivity**: ").append(sensitivity).append("\n- **Note**: ").append(note).append("\n\n");
+                sb.append("### ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Sensitivity", sensitivity))
+                    .append(CommonFormatterHelper.bullet("Note", note)).append('\n');
                 break;
             case AIDER_CONVENTIONS:
-                sb.append("#### CORE FUNCTIONALITY: ").append(className).append("\n- **Sensitivity**: ").append(sensitivity).append("\n- **Note**: ").append(note).append("\n\n");
+                sb.append("#### CORE FUNCTIONALITY: ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Sensitivity", sensitivity))
+                    .append(CommonFormatterHelper.bullet("Note", note)).append('\n');
                 break;
             case ZED:
                 sb.append("- `").append(className).append("`: Sensitivity: ").append(sensitivity).append(". Note: ").append(note).append('\n');

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIDeprecatedFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIDeprecatedFormatter.java
@@ -39,14 +39,14 @@ public final class AIDeprecatedFormatter implements AnnotationFormatter {
                 if (!replacedBy.isEmpty()) {
                     sb.append("      <replaced_by>").append(Escape.xml(replacedBy)).append("</replaced_by>\n");
                 }
-                sb.append("      <migration_guide>").append(Escape.xml(migrationGuide)).append("</migration_guide>\n");
+                sb.append(CommonFormatterHelper.element("migration_guide", migrationGuide));
                 if (!deadline.isEmpty()) {
                     sb.append("      <deadline>").append(Escape.xml(deadline)).append("</deadline>\n");
                 }
                 sb.append("    </element>\n");
                 break;
             case CODEX:
-                sb.append("- **").append(className).append("**: ").append(summary).append('\n');
+                sb.append(CommonFormatterHelper.codexBullet(className, summary.toString()));
                 break;
             case COPILOT:
                 sb.append("- `").append(className).append("` - ").append(summary).append('\n');
@@ -66,7 +66,7 @@ public final class AIDeprecatedFormatter implements AnnotationFormatter {
                 if (!replacedBy.isEmpty()) {
                     sb.append("- **Replaced by**: ").append(replacedBy).append('\n');
                 }
-                sb.append("- **Migration**: ").append(migrationGuide).append('\n');
+                sb.append(CommonFormatterHelper.bullet("Migration", migrationGuide));
                 if (!deadline.isEmpty()) {
                     sb.append("- **Deadline**: ").append(deadline).append('\n');
                 }
@@ -75,7 +75,7 @@ public final class AIDeprecatedFormatter implements AnnotationFormatter {
             case AIDER_CONVENTIONS:
                 sb.append("#### DEPRECATED: ").append(className).append("\n- **Status**: Scheduled for removal. Do not extend.\n")
                   .append(replacedBy.isEmpty() ? "" : "- **Replaced by**: " + replacedBy + "\n")
-                  .append("- **Migration**: ").append(migrationGuide).append('\n')
+                  .append(CommonFormatterHelper.bullet("Migration", migrationGuide))
                   .append(deadline.isEmpty() ? "" : "- **Deadline**: " + deadline + "\n").append('\n');
                 break;
             case WINDSURF:

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIDraftFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIDraftFormatter.java
@@ -25,10 +25,12 @@ public final class AIDraftFormatter implements AnnotationFormatter {
                 sb.append("* `").append(className).append("` - Task: ").append(instructions).append('\n');
                 break;
             case CLAUDE:
-                sb.append("    <task path=\"").append(Escape.xml(className)).append("\">\n      <instructions>").append(Escape.xml(instructions)).append("</instructions>\n    </task>\n");
+                sb.append("    <task path=\"").append(Escape.xml(className)).append("\">\n")
+                    .append(CommonFormatterHelper.element("instructions", instructions))
+                    .append("    </task>\n");
                 break;
             case CODEX:
-                sb.append("- **").append(className).append("**: ").append(instructions).append('\n');
+                sb.append(CommonFormatterHelper.codexBullet(className, instructions));
                 break;
             case COPILOT:
                 sb.append("- `").append(className).append("`: ").append(instructions).append('\n');
@@ -44,10 +46,12 @@ public final class AIDraftFormatter implements AnnotationFormatter {
                 sb.append("- [").append(element.displayName()).append("](").append(className).append("): ").append(instructions).append('\n');
                 break;
             case LLMS_FULL:
-                sb.append("### ").append(className).append("\n- **Instructions**: ").append(instructions).append("\n\n");
+                sb.append("### ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Instructions", instructions)).append('\n');
                 break;
             case AIDER_CONVENTIONS:
-                sb.append("#### DRAFT/TODO: ").append(className).append("\n- **Instruction**: ").append(instructions).append("\n\n");
+                sb.append("#### DRAFT/TODO: ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Instruction", instructions)).append('\n');
                 break;
             case ZED:
                 sb.append("- `").append(className).append("`: ").append(instructions).append('\n');

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIGeneratedFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIGeneratedFormatter.java
@@ -36,7 +36,7 @@ public final class AIGeneratedFormatter implements AnnotationFormatter {
                 break;
             case CLAUDE:
                 sb.append("    <element path=\"").append(Escape.xml(className)).append("\">\n")
-                    .append("      <from>").append(Escape.xml(from)).append("</from>\n");
+                    .append(CommonFormatterHelper.element("from", from));
                 if (!editInstead.isEmpty()) {
                     sb.append("      <edit-instead>").append(Escape.xml(editInstead)).append("</edit-instead>\n");
                 }
@@ -72,8 +72,8 @@ public final class AIGeneratedFormatter implements AnnotationFormatter {
                 break;
             case AIDER_CONVENTIONS:
                 sb.append("#### GENERATED: ").append(className).append('\n')
-                  .append("- **Source**: ").append(from).append('\n')
-                  .append("- **Edit instead**: ").append(target).append('\n')
+                  .append(CommonFormatterHelper.bullet("Source", from))
+                  .append(CommonFormatterHelper.bullet("Edit instead", target))
                   .append(regenerateWith.isEmpty() ? "" : "- **Regenerate with**: " + regenerateWith + "\n")
                   .append("- **Rule**: Never hand-edit. Change the source and regenerate.\n\n");
                 break;

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIInputSanitizedFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIInputSanitizedFormatter.java
@@ -29,13 +29,17 @@ public final class AIInputSanitizedFormatter implements AnnotationFormatter {
 
         switch (platform) {
             case CLAUDE:
-                sb.append("    <file path=\"").append(Escape.xml(className)).append("\">\n      <sanitization_types>").append(Escape.xml(typeList)).append("</sanitization_types>\n    </file>\n");
+                sb.append("    <file path=\"").append(Escape.xml(className)).append("\">\n")
+                    .append(CommonFormatterHelper.element("sanitization_types", typeList))
+                    .append("    </file>\n");
                 break;
             case LLMS_FULL:
-                sb.append("### ").append(className).append("\n- **Sanitization Requirement**: ").append(typeList).append("\n\n");
+                sb.append("### ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Sanitization Requirement", typeList)).append('\n');
                 break;
             case AIDER_CONVENTIONS:
-                sb.append("#### INPUT SANITIZATION: ").append(className).append("\n- **Required Filters**: ").append(typeList).append("\n\n");
+                sb.append("#### INPUT SANITIZATION: ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Required Filters", typeList)).append('\n');
                 break;
             case INTERPRETER:
                 sb.append("- `").append(className).append("` (sanitized): ").append(summary).append('\n');

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIKeepInSyncFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIKeepInSyncFormatter.java
@@ -65,9 +65,12 @@ public final class AIKeepInSyncFormatter implements AnnotationFormatter {
                 sb.append("- [").append(element.displayName()).append("](").append(className).append("): ").append(summary).append('\n');
                 break;
             case LLMS_FULL:
-                sb.append("### ").append(className).append("\n- **Must stay in sync with**:\n");
-                for (String mirror : keepInSync.mirrors()) {
-                    sb.append("  - ").append(mirror).append('\n');
+                sb.append("### ").append(className).append('\n');
+                if (keepInSync.mirrors().length > 0) {
+                    sb.append("- **Must stay in sync with**:\n");
+                    for (String mirror : keepInSync.mirrors()) {
+                        sb.append("  - ").append(mirror).append('\n');
+                    }
                 }
                 if (!reason.isEmpty()) {
                     sb.append("- **Reason**: ").append(reason).append('\n');
@@ -79,7 +82,7 @@ public final class AIKeepInSyncFormatter implements AnnotationFormatter {
                 break;
             case AIDER_CONVENTIONS:
                 sb.append("#### KEEP IN SYNC: ").append(className).append('\n')
-                  .append("- **Mirrors**: ").append(mirrors).append('\n')
+                  .append(CommonFormatterHelper.bullet("Mirrors", mirrors))
                   .append(reason.isEmpty() ? "" : "- **Reason**: " + reason + "\n")
                   .append("- **Enforced by**: ")
                   .append(enforcedBy.isEmpty() ? "nothing — verify by hand" : enforcedBy).append('\n')

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AILoadBearingFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AILoadBearingFormatter.java
@@ -34,7 +34,7 @@ public final class AILoadBearingFormatter implements AnnotationFormatter {
                 break;
             case CLAUDE:
                 sb.append("    <element path=\"").append(Escape.xml(className)).append("\">\n")
-                    .append("      <invariant>").append(Escape.xml(invariant)).append("</invariant>\n");
+                    .append(CommonFormatterHelper.element("invariant", invariant));
                 if (!breaksIf.isEmpty()) {
                     sb.append("      <breaks-if>").append(Escape.xml(breaksIf)).append("</breaks-if>\n");
                 }
@@ -61,7 +61,7 @@ public final class AILoadBearingFormatter implements AnnotationFormatter {
                 break;
             case LLMS_FULL:
                 sb.append("### ").append(className).append("\n- This code is deliberate, not accidental.\n")
-                    .append("- **Invariant**: ").append(invariant).append('\n');
+                    .append(CommonFormatterHelper.bullet("Invariant", invariant));
                 if (!breaksIf.isEmpty()) {
                     sb.append("- **Breaks if changed**: ").append(breaksIf).append('\n');
                 }
@@ -72,7 +72,7 @@ public final class AILoadBearingFormatter implements AnnotationFormatter {
                 break;
             case AIDER_CONVENTIONS:
                 sb.append("#### LOAD-BEARING: ").append(className).append('\n')
-                  .append("- **Invariant**: ").append(invariant).append('\n')
+                  .append(CommonFormatterHelper.bullet("Invariant", invariant))
                   .append(breaksIf.isEmpty() ? "" : "- **Breaks if changed**: " + breaksIf + "\n")
                   .append(suppressAudit ? "- **Audit**: Not a defect. Do not flag.\n" : "")
                   .append("- **Rule**: Refactor freely, but preserve the invariant.\n\n");

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AILockedFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AILockedFormatter.java
@@ -25,13 +25,15 @@ public final class AILockedFormatter implements AnnotationFormatter {
                 sb.append("* `").append(className).append("` - Reason: ").append(reason).append('\n');
                 break;
             case CLAUDE:
-                sb.append("    <file path=\"").append(Escape.xml(className)).append("\">\n      <reason>").append(Escape.xml(reason)).append("</reason>\n    </file>\n");
+                sb.append("    <file path=\"").append(Escape.xml(className)).append("\">\n")
+                    .append(CommonFormatterHelper.element("reason", reason))
+                    .append("    </file>\n");
                 break;
             case AI_EXCLUDE:
                 sb.append("**/").append(element.simpleName()).append(".java\n");
                 break;
             case CODEX:
-                sb.append("- **").append(className).append("**: ").append(reason).append('\n');
+                sb.append(CommonFormatterHelper.codexBullet(className, reason));
                 break;
             case COPILOT:
                 sb.append("- `").append(className).append("` - ").append(reason).append('\n');
@@ -47,10 +49,12 @@ public final class AILockedFormatter implements AnnotationFormatter {
                 sb.append("- [").append(element.displayName()).append("](").append(className).append("): ").append(reason).append('\n');
                 break;
             case LLMS_FULL:
-                sb.append("### ").append(className).append("\n- **Reason**: ").append(reason).append("\n\n");
+                sb.append("### ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Reason", reason)).append('\n');
                 break;
             case AIDER_CONVENTIONS:
-                sb.append("#### LOCKED: ").append(className).append("\n- **Status**: Locked (Do Not Edit)\n- **Reason**: ").append(reason).append("\n\n");
+                sb.append("#### LOCKED: ").append(className).append("\n- **Status**: Locked (Do Not Edit)\n")
+                    .append(CommonFormatterHelper.bullet("Reason", reason)).append('\n');
                 break;
             case ZED:
                 sb.append("- `").append(className).append("`: ").append(reason).append('\n');

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIObservabilityFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIObservabilityFormatter.java
@@ -41,7 +41,7 @@ public final class AIObservabilityFormatter implements AnnotationFormatter {
                 sb.append("    </element>\n");
                 break;
             case CODEX:
-                sb.append("- **").append(className).append("**: ").append(summary).append('\n');
+                sb.append(CommonFormatterHelper.codexBullet(className, summary.toString()));
                 break;
             case COPILOT:
                 sb.append("- `").append(className).append("` - ").append(summary).append('\n');
@@ -65,7 +65,8 @@ public final class AIObservabilityFormatter implements AnnotationFormatter {
                 sb.append('\n');
                 break;
             case AIDER_CONVENTIONS:
-                sb.append("#### OBSERVABILITY: ").append(className).append("\n- **Rule**: Do not remove or rename instrumentation without flagging the affected dashboard/alert.\n- **Details**: ").append(summary).append("\n\n");
+                sb.append("#### OBSERVABILITY: ").append(className).append("\n- **Rule**: Do not remove or rename instrumentation without flagging the affected dashboard/alert.\n")
+                    .append(CommonFormatterHelper.bullet("Details", summary.toString())).append('\n');
                 break;
             case WINDSURF:
                 sb.append("* `").append(className).append("` (observability) - ").append(summary).append('\n');

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIPerformanceFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIPerformanceFormatter.java
@@ -25,10 +25,12 @@ public final class AIPerformanceFormatter implements AnnotationFormatter {
                 sb.append("* `").append(className).append("` - ").append(constraint).append('\n');
                 break;
             case CLAUDE:
-                sb.append("    <element path=\"").append(Escape.xml(className)).append("\">\n      <constraint>").append(Escape.xml(constraint)).append("</constraint>\n    </element>\n");
+                sb.append("    <element path=\"").append(Escape.xml(className)).append("\">\n")
+                    .append(CommonFormatterHelper.element("constraint", constraint))
+                    .append("    </element>\n");
                 break;
             case CODEX:
-                sb.append("- **").append(className).append("**: ").append(constraint).append('\n');
+                sb.append(CommonFormatterHelper.codexBullet(className, constraint));
                 break;
             case COPILOT:
                 sb.append("- `").append(className).append("`: ").append(constraint).append('\n');
@@ -44,10 +46,12 @@ public final class AIPerformanceFormatter implements AnnotationFormatter {
                 sb.append("- [").append(element.displayName()).append("](").append(className).append("): ").append(constraint).append('\n');
                 break;
             case LLMS_FULL:
-                sb.append("### ").append(className).append("\n- **Constraint**: ").append(constraint).append("\n\n");
+                sb.append("### ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Constraint", constraint)).append('\n');
                 break;
             case AIDER_CONVENTIONS:
-                sb.append("#### PERFORMANCE CONSTRAINTS: ").append(className).append("\n- **Rule**: Optimal complexity required. O(n^2) is forbidden on hot paths.\n- **Constraint**: ").append(constraint).append("\n\n");
+                sb.append("#### PERFORMANCE CONSTRAINTS: ").append(className).append("\n- **Rule**: Optimal complexity required. O(n^2) is forbidden on hot paths.\n")
+                    .append(CommonFormatterHelper.bullet("Constraint", constraint)).append('\n');
                 break;
             case ZED:
                 sb.append("- `").append(className).append("`: ").append(constraint).append('\n');

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIPrivacyFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIPrivacyFormatter.java
@@ -25,7 +25,9 @@ public final class AIPrivacyFormatter implements AnnotationFormatter {
                 sb.append("* `").append(className).append("` - ").append(reason).append('\n');
                 break;
             case CLAUDE:
-                sb.append("    <element path=\"").append(Escape.xml(className)).append("\">\n      <reason>").append(Escape.xml(reason)).append("</reason>\n    </element>\n");
+                sb.append("    <element path=\"").append(Escape.xml(className)).append("\">\n")
+                    .append(CommonFormatterHelper.element("reason", reason))
+                    .append("    </element>\n");
                 break;
             case CODEX:
                 sb.append("- `").append(className).append("`: ").append(reason).append('\n');
@@ -44,10 +46,12 @@ public final class AIPrivacyFormatter implements AnnotationFormatter {
                 sb.append("- [").append(element.displayName()).append("](").append(className).append("): ").append(reason).append('\n');
                 break;
             case LLMS_FULL:
-                sb.append("### ").append(className).append("\n- **Reason**: ").append(reason).append("\n\n");
+                sb.append("### ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Reason", reason)).append('\n');
                 break;
             case AIDER_CONVENTIONS:
-                sb.append("#### PRIVACY/PII: ").append(className).append("\n- **Safety Rule**: Never log or expose runtime values of this element.\n- **Reason**: ").append(reason).append("\n\n");
+                sb.append("#### PRIVACY/PII: ").append(className).append("\n- **Safety Rule**: Never log or expose runtime values of this element.\n")
+                    .append(CommonFormatterHelper.bullet("Reason", reason)).append('\n');
                 break;
             case ZED:
                 sb.append("- `").append(className).append("`: ").append(reason).append('\n');

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIRegulationFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AIRegulationFormatter.java
@@ -27,11 +27,12 @@ public final class AIRegulationFormatter implements AnnotationFormatter {
                 sb.append("* `").append(className).append("` - ").append(summary).append('\n');
                 break;
             case CLAUDE:
-                sb.append("    <element path=\"").append(Escape.xml(className)).append("\">\n      <standard>").append(Escape.xml(standard)).append("</standard>\n");
+                sb.append("    <element path=\"").append(Escape.xml(className)).append("\">\n")
+                    .append(CommonFormatterHelper.element("standard", standard));
                 if (!clause.isEmpty()) {
                     sb.append("      <clause>").append(Escape.xml(clause)).append("</clause>\n");
                 }
-                sb.append("      <description>").append(Escape.xml(description)).append("</description>\n    </element>\n");
+                sb.append(CommonFormatterHelper.element("description", description)).append("    </element>\n");
                 break;
             case CODEX:
                 sb.append("- **").append(className).append("**: ").append(summary).append('\n');
@@ -50,16 +51,18 @@ public final class AIRegulationFormatter implements AnnotationFormatter {
                 sb.append("- [").append(element.displayName()).append("](").append(className).append("): ").append(summary).append('\n');
                 break;
             case LLMS_FULL:
-                sb.append("### ").append(className).append("\n- **Standard**: ").append(standard).append('\n');
+                sb.append("### ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Standard", standard));
                 if (!clause.isEmpty()) {
                     sb.append("- **Clause**: ").append(clause).append('\n');
                 }
-                sb.append("- **Description**: ").append(description).append("\n\n");
+                sb.append(CommonFormatterHelper.bullet("Description", description)).append('\n');
                 break;
             case AIDER_CONVENTIONS:
-                sb.append("#### REGULATORY: ").append(className).append("\n- **Standard**: ").append(standard).append('\n')
+                sb.append("#### REGULATORY: ").append(className).append('\n')
+                  .append(CommonFormatterHelper.bullet("Standard", standard))
                   .append(clause.isEmpty() ? "" : "- **Clause**: " + clause + "\n")
-                  .append("- **Description**: ").append(description).append("\n\n");
+                  .append(CommonFormatterHelper.bullet("Description", description)).append('\n');
                 break;
             case WINDSURF:
                 sb.append("* `").append(className).append("` (regulation) - ").append(summary).append('\n');

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AISunsetFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AISunsetFormatter.java
@@ -29,13 +29,20 @@ public final class AISunsetFormatter implements AnnotationFormatter {
 
         switch (platform) {
             case CLAUDE:
-                sb.append("    <file path=\"").append(Escape.xml(className)).append("\">\n      <sunset_ticket>").append(Escape.xml(jira)).append("</sunset_ticket>\n      <replacement_target>").append(Escape.xml(replacementName)).append("</replacement_target>\n    </file>\n");
+                sb.append("    <file path=\"").append(Escape.xml(className)).append("\">\n")
+                    .append(CommonFormatterHelper.element("sunset_ticket", jira))
+                    .append(CommonFormatterHelper.element("replacement_target", replacementName))
+                    .append("    </file>\n");
                 break;
             case LLMS_FULL:
-                sb.append("### ").append(className).append("\n- **Sunset Status**: Active (Forbid new calls)\n- **JIRA Ticket**: ").append(jira).append("\n- **Replacement**: ").append(replacementName).append("\n\n");
+                sb.append("### ").append(className).append("\n- **Sunset Status**: Active (Forbid new calls)\n")
+                    .append(CommonFormatterHelper.bullet("JIRA Ticket", jira))
+                    .append(CommonFormatterHelper.bullet("Replacement", replacementName)).append('\n');
                 break;
             case AIDER_CONVENTIONS:
-                sb.append("#### SUNSET API: ").append(className).append("\n- **Ticket**: ").append(jira).append("\n- **Replacement**: ").append(replacementName).append("\n\n");
+                sb.append("#### SUNSET API: ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Ticket", jira))
+                    .append(CommonFormatterHelper.bullet("Replacement", replacementName)).append('\n');
                 break;
             case INTERPRETER:
                 sb.append("- `").append(className).append("` (sunset): ").append(summary).append('\n');

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AITemporaryFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AITemporaryFormatter.java
@@ -25,13 +25,20 @@ public final class AITemporaryFormatter implements AnnotationFormatter {
 
         switch (platform) {
             case CLAUDE:
-                sb.append("    <file path=\"").append(Escape.xml(className)).append("\">\n      <temporary_expiration>").append(Escape.xml(expiresOn)).append("</temporary_expiration>\n      <temporary_reason>").append(Escape.xml(reason)).append("</temporary_reason>\n    </file>\n");
+                sb.append("    <file path=\"").append(Escape.xml(className)).append("\">\n")
+                    .append(CommonFormatterHelper.element("temporary_expiration", expiresOn))
+                    .append(CommonFormatterHelper.element("temporary_reason", reason))
+                    .append("    </file>\n");
                 break;
             case LLMS_FULL:
-                sb.append("### ").append(className).append("\n- **Temporal Expiration**: ").append(expiresOn).append("\n- **Reason**: ").append(reason).append("\n\n");
+                sb.append("### ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Temporal Expiration", expiresOn))
+                    .append(CommonFormatterHelper.bullet("Reason", reason)).append('\n');
                 break;
             case AIDER_CONVENTIONS:
-                sb.append("#### TEMPORARY WORKAROUND: ").append(className).append("\n- **Expires On**: ").append(expiresOn).append("\n- **Reason**: ").append(reason).append("\n\n");
+                sb.append("#### TEMPORARY WORKAROUND: ").append(className).append('\n')
+                    .append(CommonFormatterHelper.bullet("Expires On", expiresOn))
+                    .append(CommonFormatterHelper.bullet("Reason", reason)).append('\n');
                 break;
             case INTERPRETER:
                 sb.append("- `").append(className).append("` (temporary): ").append(summary).append('\n');

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AITestDrivenFormatter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/AITestDrivenFormatter.java
@@ -40,7 +40,7 @@ public final class AITestDrivenFormatter implements AnnotationFormatter {
             case CLAUDE:
                 sb.append("    <element path=\"").append(Escape.xml(className)).append("\">\n")
                     .append("      <coverage_goal>").append(coverageGoal).append("</coverage_goal>\n")
-                    .append("      <frameworks>").append(Escape.xml(frameworksStr)).append("</frameworks>\n");
+                    .append(CommonFormatterHelper.element("frameworks", frameworksStr));
                 if (!testLocation.isEmpty()) {
                     sb.append("      <test_location>").append(Escape.xml(testLocation)).append("</test_location>\n");
                 }
@@ -66,7 +66,8 @@ public final class AITestDrivenFormatter implements AnnotationFormatter {
                 sb.append("- [").append(element.displayName()).append("](").append(className).append("): ").append(summary).append('\n');
                 break;
             case LLMS_FULL:
-                sb.append("### ").append(className).append("\n- **Coverage Goal**: ").append(coverageGoal).append("%\n- **Frameworks**: ").append(frameworksStr).append('\n');
+                sb.append("### ").append(className).append("\n- **Coverage Goal**: ").append(coverageGoal).append("%\n")
+                    .append(CommonFormatterHelper.bullet("Frameworks", frameworksStr));
                 if (!testLocation.isEmpty()) {
                     sb.append("- **Test Location**: ").append(testLocation).append('\n');
                 }
@@ -76,7 +77,8 @@ public final class AITestDrivenFormatter implements AnnotationFormatter {
                 sb.append('\n');
                 break;
             case AIDER_CONVENTIONS:
-                sb.append("#### TEST-DRIVEN: ").append(className).append("\n- **Rule**: Changes MUST be accompanied by test updates.\n- **Coverage Goal**: ").append(coverageGoal).append("%\n- **Frameworks**: ").append(frameworksStr).append('\n');
+                sb.append("#### TEST-DRIVEN: ").append(className).append("\n- **Rule**: Changes MUST be accompanied by test updates.\n- **Coverage Goal**: ").append(coverageGoal).append("%\n")
+                    .append(CommonFormatterHelper.bullet("Frameworks", frameworksStr));
                 break;
             case ZED:
                 sb.append("- `").append(className).append("`: ").append(summary).append('\n');

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/CommonFormatterHelper.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/annotations/CommonFormatterHelper.java
@@ -30,6 +30,45 @@ final class CommonFormatterHelper {
     }
 
     /**
+     * Renders a markdown bullet with a bold label, or nothing at all when {@code value} is unset.
+     *
+     * <p>An annotation written bare — {@code @AILocked} with no {@code reason}, the form people
+     * actually write — must not leave {@code - **Reason**:} with nothing after it in the generated
+     * file. The label costs an agent's context window and carries no guardrail in return, so the
+     * whole bullet is dropped rather than emitted empty. Pinned by {@code UnsetMemberRenderingTest}.
+     */
+    static String bullet(String label, String value) {
+        return (value == null || value.isBlank()) ? "" : "- **" + label + "**: " + value + "\n";
+    }
+
+    /**
+     * Renders an XML element indented six spaces for the Claude formats, or nothing at all when
+     * {@code value} is unset, so a bare annotation does not produce {@code <reason></reason>}.
+     *
+     * <p>Emits the same bytes as the inline form it replaces whenever the member is populated.
+     */
+    static String element(String tag, String value) {
+        return (value == null || value.isBlank())
+            ? ""
+            : "      <" + tag + ">" + Escape.xml(value) + "</" + tag + ">\n";
+    }
+
+    /**
+     * Renders the Codex bullet — the element's path in bold, then its summary — dropping the colon
+     * along with the summary when there is none, so a bare annotation does not leave
+     * {@code - **com.example.Foo**:} with nothing after it.
+     *
+     * <p>The element keeps its line either way. Its presence under the section heading is itself
+     * the guardrail, and dropping the line would hide an annotation that is visibly there in the
+     * source — the worse of the two failures.
+     */
+    static String codexBullet(String path, String summary) {
+        return (summary == null || summary.isBlank())
+            ? "- **" + path + "**\n"
+            : "- **" + path + "**: " + summary + "\n";
+    }
+
+    /**
      * Attempts to format standard markdown/plain-text platforms.
      * Returns true if the platform was formatted and handled, false otherwise.
      */
@@ -41,7 +80,7 @@ final class CommonFormatterHelper {
                 sb.append("* `").append(className).append("` - ").append(summary).append('\n');
                 return true;
             case CODEX:
-                sb.append("- **").append(className).append("**: ").append(summary).append('\n');
+                sb.append(codexBullet(className, summary));
                 return true;
             case COPILOT:
                 sb.append("- `").append(className).append("` - ").append(summary).append('\n');

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/platforms/ClaudeRenderer.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/platforms/ClaudeRenderer.java
@@ -422,11 +422,18 @@ public final class ClaudeRenderer implements PlatformRenderer {
         if (model.audit().isEmpty()) {
             return;
         }
-        StringBuilder sec = new StringBuilder("  <audit_requirements>\n");
+        StringBuilder body = new StringBuilder();
         for (TaggedElement e : model.audit()) {
-            FormatterRegistry.audit().format(e, sec, Platform.CLAUDE);
+            FormatterRegistry.audit().format(e, body, Platform.CLAUDE);
         }
-        sec.append("  </audit_requirements>\n");
+        // A bare @AIAudit carries no checkFor() list, so the formatter contributes nothing. Emitting
+        // the wrapper anyway leaves an empty <audit_requirements> and a <rule> pointing at it — the
+        // agent is told to consult a list that is not there.
+        if (body.isEmpty()) {
+            return;
+        }
+        StringBuilder sec = new StringBuilder("  <audit_requirements>\n");
+        sec.append(body).append("  </audit_requirements>\n");
         sb.append('\n').append(sec)
             .append("\n<rule>\n  If you are asked to modify any file listed in <audit_requirements>, you must first silently analyze your proposed code for the listed <vulnerability_check> items. If your code introduces these vulnerabilities, you must rewrite it before displaying it to the user.\n</rule>\n");
     }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/internal/content/platforms/UnsetMemberRenderingTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/internal/content/platforms/UnsetMemberRenderingTest.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -62,8 +64,40 @@ class UnsetMemberRenderingTest {
     private static final Set<Class<? extends Annotation>> RENDERS_NOTHING_WHEN_BARE =
         Set.of(se.deversity.vibetags.annotations.AIAudit.class);
 
+    /**
+     * A markdown bullet whose bold label is followed by nothing: {@code - **Reason**:} and the line
+     * ends. The label is the whole cost — an agent reading the file pays for it and learns nothing.
+     */
+    private static final Pattern EMPTY_LABELLED_BULLET =
+        Pattern.compile("(?m)^\\s*-\\s+\\*\\*[^*\\n]+\\*\\*:[ \\t]*$");
+
+    /** An XML element with nothing but whitespace between its tags: {@code <reason></reason>}. */
+    private static final Pattern EMPTY_XML_ELEMENT =
+        Pattern.compile("<([a-zA-Z_][\\w-]*)>\\s*</\\1>");
+
     static Stream<Platform> aggregatePlatforms() {
         return Stream.of(Platform.values()).filter(p -> !p.name().endsWith("_GRANULAR"));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("aggregatePlatforms")
+    @DisplayName("an unset optional member emits no label at all, rather than a label with nothing after it")
+    void unsetMembersLeaveNoEmptyLabels(Platform platform) {
+        String bare = PlatformRendererRegistry.getRenderer(platform)
+            .render(GuardrailModels.everyAnnotationWithMembersUnset(), platform, CONTEXT);
+
+        List<String> empty = new ArrayList<>();
+        for (Matcher m = EMPTY_LABELLED_BULLET.matcher(bare); m.find(); ) {
+            empty.add(m.group().trim());
+        }
+        for (Matcher m = EMPTY_XML_ELEMENT.matcher(bare); m.find(); ) {
+            empty.add(m.group().replace("\n", "\\n"));
+        }
+
+        assertEquals(List.of(), empty,
+            platform + " emits a label with nothing after it when the member behind it is unset. "
+                + "Guard the member the way the same formatter already guards it on other "
+                + "platforms — CommonFormatterHelper.bullet and .element do it in one place");
     }
 
     @ParameterizedTest(name = "{0}")


### PR DESCRIPTION
Closes #474.

## What was wrong

A bare annotation — `@AILocked` with no `reason`, the form people actually write — left **99 labels with nothing after them**, across five platform files:

| Platform | empty labels | shape |
|---|---|---|
| `CLAUDE` | 23 | `<reason></reason>`, `<focus></focus>`, `<belongs_to></belongs_to>`, … |
| `CLAUDE_LOCAL` | 23 | the same set |
| `AIDER_CONVENTIONS` | 25 | `- **Reason**:`, `- **Layer**:`, `- **Mirrors**:`, … |
| `LLMS_FULL` | 22 | `- **Reason**:`, `- **Banned here**:`, … |
| `CODEX` | 6 | `- **com.example.Foo**:` — the element name, a colon, nothing |

Plus one the issue did not name: `ClaudeRenderer` emitted an empty `<audit_requirements>` wrapper *and* a `<rule>` instructing the agent to consult the list inside it, whenever every `@AIAudit` in the build was written bare. The agent is pointed at a list that is not there.

No guardrail is lost by any of this. The cost is tokens — in files whose entire purpose is to stay lean enough to fit an agent's context.

## The fix

The guard already existed. `AISecureFormatter` guards its `aspect` on every arm; the pattern just was not applied uniformly. Rather than write that ternary out another 60 times, three helpers in `CommonFormatterHelper` hold it in one place:

- `bullet(label, value)` — a markdown bullet, or nothing
- `element(tag, value)` — an indented XML element, or nothing
- `codexBullet(path, summary)` — drops the colon along with the summary, keeping the element's line, because the line's presence under the section heading *is* the guardrail

Each emits **the same bytes as the inline form it replaces** whenever the member is populated. That is why the existing 2344-test suite passes without a single golden-file update.

`appendAuditSection` now builds its body first and returns when there is nothing in it.

## How it was verified

- **Failing-first, and shown failing.** The assertion #474 asked for was restored to `UnsetMemberRenderingTest`, then run against the *unfixed* formatters with the production change stashed. It failed on 5 platforms and named all 99 empty labels. With the fix: green.
- `mvn test` — 1672 pass, 0 fail.
- `mvn test -Pe2e` (what CI runs) — 2344 pass, 0 fail.
- `mvn verify -DskipTests` — checkstyle, PMD and CPD all pass.
- **`mvn compile -Pself-annotate` from a deleted `.vibetags-cache`** moved nothing. The issue expected this repository's own files to move; they do not, because VibeTags populates every member it annotates itself with, so the defect never reached its own output. Verified against a cold cache, not against "no diff".

The regression guard derives its cases from `GuardrailAnnotations.ALL` and `Platform.values()`, so a new annotation or platform is covered the day it lands — nobody maintains a list.

### Gates not run here

- **SpotBugs** did not run locally: the plugin requires Maven 3.8.9 and this machine has 3.8.6. Not a result — it is untested until CI runs it.
- **The `checkstyle` pre-commit hook** was skipped (it needs Docker, which was not running). The Maven `checkstyle:check` binding covers the same rules and passed. `gitleaks`, `end-of-file-fixer` and `trailing-whitespace` passed.

## Left out, deliberately

The same defect has shapes this assertion does not match. On `CURSOR` a bare `@AILocked` still renders:

```
* `com.example.fixture.AILockedTarget` - Reason:
```

a dangling separator rather than a bold label. There are roughly a dozen such shapes across `CURSOR`, `COPILOT`, `QWEN`, `ZED`, `MENTAT` and `SWEEP`. Fixing them is not mechanical: it needs a per-annotation decision about fallback text, and about members whose "unset" value is a real default rather than an absence (`coverageGoal` 0, `strategy` OTHER, `replacedBy` `java.lang.Object`). Filed as a follow-up issue rather than left in this PR body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUjemLTYEwQHhjmztrrapT
