### PR TITLE
ci: verify the non-javac degradation the docs promise, under a real ECJ

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1227,6 +1227,42 @@ jobs:
   # is fresh, then intersects the PR diff with the locked line ranges; a diff that touches
   # an @AILocked element fails here and names the element and its reason. PR-only: the
   # guard is about proposed changes, and it needs a base to diff against.
+  # The one leg that does not run javac. docs/PROCESSOR.md and USAGE.md both promise that
+  # VibeTags degrades - loses @AILocked positions, keeps every guardrail - under a compiler
+  # with no Tree API, and nothing verified either sentence. The paths behind them are
+  # unreachable from a JUnit test running under javac, and reaching them from one would mean
+  # adding a seam to production code purely so a test could fail it (issue #475). Compiling
+  # a real fixture under a real ECJ needs no seam and checks the documented behaviour.
+  ecj-degradation:
+    name: Non-javac Compiler Degradation (ECJ)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Install VibeTags Annotations and Processor (Maven)
+        run: |
+          cd vibetags-annotations
+          mvn install -B -q -DskipTests
+          cd ../vibetags
+          mvn install -B -q -DskipTests
+
+      # Runs both compilers over the same fixture and compares. The javac half is the
+      # control: without it every ECJ assertion passes equally well on an empty report.
+      - name: Verify the processor degrades under ECJ rather than failing
+        run: scripts/ecj-degradation-check.sh
+
   locked-files:
     name: Locked Files Guard
     if: github.event_name == 'pull_request'

--- a/USAGE.md
+++ b/USAGE.md
@@ -258,7 +258,7 @@ The compile writes `.vibetags-locks` — JSON Lines between `# VIBETAGS` hash ma
 # VIBETAGS-END
 ```
 
-Line positions come from the javac Compiler Tree API; under other compilers (ECJ) entries omit positions and tools fall back to file-level matching. In Maven multi-module builds the report aggregates every module's locks via module sub-markers.
+Line positions come from the javac Compiler Tree API; under other compilers (ECJ) entries omit positions and tools fall back to file-level matching. CI compiles a fixture under a real ECJ on every run and checks exactly that — the guardrails survive, the positions do not. In Maven multi-module builds the report aggregates every module's locks via module sub-markers.
 
 **2. Add the action to your PR workflow:**
 

--- a/docs/PROCESSOR.md
+++ b/docs/PROCESSOR.md
@@ -241,7 +241,10 @@ to skip it). The format is JSON Lines wrapped in `# VIBETAGS` hash markers — d
 last-writer-wins. Positions come from `SourcePositionResolver` (javac Compiler Tree API, resolved in
 `process()` while rounds are live) as `model.SourceLocation`. Gradle's incremental-processing
 wrapper is reflectively unwrapped so positions survive Gradle-run javac (`treesFor`); under
-genuinely non-javac compilers (ECJ) entries omit position fields.
+genuinely non-javac compilers (ECJ) entries omit position fields. That last sentence is
+measured rather than asserted: the `ecj-degradation` CI leg
+(`scripts/ecj-degradation-check.sh`) compiles `examples/basic` under both compilers and
+compares — same locked elements, positions under javac only.
 
 The `kind` field is `ElementTag.name()`, which mirrors `javax.lang.model.element.ElementKind`
 name-for-name (`CLASS`, `METHOD`, `FIELD`, …), plus `UNKNOWN` when the compiler reports no kind.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -137,6 +137,35 @@ The same `.github/actions/verify-generated-files` composite action runs after th
 
 Mutation testing used to be a job here. It now lives in its own manually triggered workflow — see section 7.
 
+### Job: `ecj-degradation`
+
+The one leg that does not run javac. `scripts/ecj-degradation-check.sh` compiles
+`examples/basic` twice over — once with javac, once with the Eclipse Compiler for Java pinned by
+`<ecj.version>` in `vibetags-parent/pom.xml` — and compares the results.
+
+It exists because [docs/PROCESSOR.md](PROCESSOR.md) and [USAGE.md](../USAGE.md) both promise
+that VibeTags *degrades* under a compiler with no Tree API, losing `@AILocked` line positions and
+nothing else, and nothing verified either sentence. The code behind that promise —
+`SourcePositionResolver`'s whole no-Tree-API branch and the `Trees.instance` guards around it — is
+unreachable from a JUnit test running under javac, and reaching it from one would mean adding a
+seam to production code purely so a test could fail it (issue #475). A real compiler needs no
+seam.
+
+Four assertions, in order of what they protect:
+
+1. **ECJ compiles the fixture and exits 0.** The promise the whole design rests on is that
+   VibeTags never fails somebody's build. A compiler it cannot fully serve must still compile.
+2. **Both compilers report the same `@AILocked` elements** (9 at the time of writing). Degrading
+   costs positions, not guardrails — a lock that vanishes under ECJ is a lock nobody enforces.
+3. **Every javac entry carries a position and no ECJ entry does.** The javac half is the control:
+   without it, assertion 3 passes just as well on a report that contains nothing at all.
+4. **Every guardrail's prose and every type-level element path is identical** between the two.
+
+Assertion 4 is deliberately not a byte-for-byte diff of the marker region, and the script says
+why at the assertion: member element paths *do* differ between the compilers, because
+`ElementNaming` leans on `Element.toString()`, whose format `javax.lang.model` leaves to the
+implementation. This job is what found that.
+
 ### Job: `locked-files`
 
 Pull requests only. Dogfood of the shipped `action/locked-files`: installs the annotations and

--- a/scripts/ecj-degradation-check.sh
+++ b/scripts/ecj-degradation-check.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# Checks the documented claim that VibeTags degrades, rather than fails, under a compiler
+# that does not expose javac's Tree API.
+#
+#   docs/PROCESSOR.md : "under genuinely non-javac compilers (ECJ) entries omit position fields"
+#   USAGE.md          : "under other compilers (ECJ) entries omit positions and tools fall
+#                        back to file-level matching"
+#
+# Nothing verified either sentence. The paths behind them - SourcePositionResolver's whole
+# no-Tree-API branch and the Trees.instance guards around it - are unreachable from a JUnit
+# test running under javac, and reaching them from one would mean adding a seam to
+# production code purely so a test could fail it (issue #475, option 2). Compiling a real
+# fixture under a real ECJ needs no seam and checks the behaviour honestly.
+#
+# What it asserts, and why each one matters:
+#
+#   1. ECJ compiles the fixture with the processor on its processor path and exits 0.
+#      The promise the whole design rests on is that VibeTags never fails a consumer's
+#      build. A compiler it cannot fully serve must still compile.
+#   2. Both compilers report the same @AILocked elements. Degrading must cost positions,
+#      not guardrails - a lock that silently vanishes under ECJ is a lock nobody enforces.
+#   3. Every javac entry carries a position and no ECJ entry does. The javac half is the
+#      control: without it the ECJ assertion passes just as well on a broken report that
+#      contains nothing at all.
+#   4. Every guardrail's prose, and every type-level element path, is identical between the
+#      two. This is the sentence "degrades" is standing on: what an agent is told does not
+#      depend on which compiler ran. It is not a byte-for-byte diff of the whole region,
+#      and the comment above that assertion says exactly why - member paths currently do
+#      differ, which this check is what discovered.
+#
+# Usage: scripts/ecj-degradation-check.sh
+# Requires: a JDK, mvn on PATH, and vibetags-annotations + vibetags installed
+#           (see CLAUDE.md "Build and test" for the order).
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+FIXTURE="$ROOT/examples/basic"
+
+# Windows shells hand java POSIX paths it cannot read, and want ';' between classpath entries.
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) SEP=";" ; winpath() { cygpath -w "$1"; } ;;
+  *)                    SEP=":" ; winpath() { printf "%s" "$1"; } ;;
+esac
+
+read_pom_property() {
+  sed -n "s|.*<$1>\(.*\)</$1>.*|\1|p" "$ROOT/vibetags-parent/pom.xml"
+}
+
+# One home for the version: the parent POM, like every other third-party pin (invariant 14).
+ECJ_VERSION=$(read_pom_property "ecj.version")
+if [ -z "$ECJ_VERSION" ]; then
+  echo "FAIL: no <ecj.version> in vibetags-parent/pom.xml - the pin this script reads is gone" >&2
+  exit 1
+fi
+VERSION=$(read_pom_property "revision")
+echo "ECJ $ECJ_VERSION against VibeTags $VERSION"
+
+PROC_JAR="$ROOT/vibetags/target/vibetags-processor-$VERSION.jar"
+if [ ! -f "$PROC_JAR" ]; then
+  echo "FAIL: $PROC_JAR not found - run 'mvn clean install' in vibetags/ first" >&2
+  exit 1
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+mvn -q -f "$ROOT/vibetags/pom.xml" dependency:get "-Dartifact=org.eclipse.jdt:ecj:$ECJ_VERSION"
+mvn -q -f "$ROOT/vibetags/pom.xml" dependency:build-classpath \
+    -Dmdep.includeScope=runtime "-Dmdep.outputFile=$WORK/cp.txt"
+
+REPO=$(mvn -q -f "$ROOT/vibetags/pom.xml" help:evaluate \
+       -Dexpression=settings.localRepository -DforceStdout)
+ECJ_JAR="$REPO/org/eclipse/jdt/ecj/$ECJ_VERSION/ecj-$ECJ_VERSION.jar"
+if [ ! -f "$ECJ_JAR" ]; then
+  echo "FAIL: ECJ jar not at $ECJ_JAR after dependency:get" >&2
+  exit 1
+fi
+
+CP="$(winpath "$PROC_JAR")$SEP$(cat "$WORK/cp.txt")"
+
+# Seeds a compile directory. The fixture's committed generated files are the opt-in: file
+# presence is the only way a platform turns on (tier-1 invariant 1), so a bare source tree
+# would produce nothing at all and this would compare two empty reports. .vibetags-locks is
+# not committed in the fixture, so it is created empty here to opt that report in.
+seed() {
+  local target="$WORK/$1"
+  mkdir -p "$target"
+  cp -r "$FIXTURE/." "$target/"
+  rm -rf "$target/target" "$target/build" "$target/.gradle" \
+         "$target/.vibetags-cache" "$target/.vibetags-mod-_root_" "$target/vibetags.log"
+  : > "$target/.vibetags-locks"
+  mkdir -p "$target/classes" "$target/gen"
+  ( cd "$target" && find src -name "*.java" > sources.txt )
+}
+
+seed javac-run
+seed ecj-run
+
+echo "== compiling the fixture with javac (the control) =="
+( cd "$WORK/javac-run" && javac -proc:full -nowarn \
+    -classpath "$CP" -processorpath "$CP" -d classes -s gen \
+    "-Avibetags.root=$(winpath "$WORK/javac-run")" \
+    @sources.txt )
+
+echo "== compiling the same fixture with ECJ $ECJ_VERSION =="
+# Assertion 1. Deliberately not piped into anything: a pipeline reports the last stage's
+# status, and this line exists to catch the case where VibeTags breaks somebody's build.
+( cd "$WORK/ecj-run" && java -jar "$(winpath "$ECJ_JAR")" \
+    -source 21 -target 21 -nowarn \
+    -classpath "$CP" -processorpath "$CP" -d classes -s gen \
+    "-Avibetags.root=$(winpath "$WORK/ecj-run")" \
+    @sources.txt )
+
+JAVAC_LOCKS="$WORK/javac-run/.vibetags-locks"
+ECJ_LOCKS="$WORK/ecj-run/.vibetags-locks"
+status=0
+
+# Both reports must exist before anything counts them. Without this the counts below come
+# back as empty strings, every `[ "$x" -lt 1 ]` fails with "integer expected" rather than
+# taking its branch, and - because those tests sit in `if` conditions, where set -e does not
+# reach - the script printed OK and exited 0. A check that reports success when its subject
+# is missing is worse than no check, so the absence is named here and fails immediately.
+for report in "$JAVAC_LOCKS" "$ECJ_LOCKS"; do
+  if [ ! -f "$report" ]; then
+    echo "FAIL: $report was not produced." >&2
+    echo "      .vibetags-locks is opt-in by file presence, so the seed step must create it" >&2
+    echo "      and the compile must then write it. One of those did not happen." >&2
+    exit 1
+  fi
+done
+
+# grep -c prints its count and THEN exits 1 when the count is zero, which set -e would treat
+# as an error. `|| true` is the whole fix: an `|| echo 0` here appends a second line, the
+# variable becomes "0\n0", and every `[ "$x" -ne "$y" ]` below dies with "integer expected"
+# inside an `if` condition where set -e cannot see it - so the script printed OK and exited
+# 0 with its central assertion never evaluated. The file-existence guard above covers the
+# case this was reaching for, where grep prints nothing at all.
+count_matches() { grep -c "$1" "$2" || true; }
+
+LOCKED_ENTRY='"type":"locked"'
+POSITION_FIELD='"startLine"'
+
+javac_total=$(count_matches "$LOCKED_ENTRY" "$JAVAC_LOCKS")
+ecj_total=$(count_matches "$LOCKED_ENTRY" "$ECJ_LOCKS")
+javac_positioned=$(count_matches "$POSITION_FIELD" "$JAVAC_LOCKS")
+ecj_positioned=$(count_matches "$POSITION_FIELD" "$ECJ_LOCKS")
+
+echo "javac: $javac_total locked entries, $javac_positioned with positions"
+echo "ECJ:   $ecj_total locked entries, $ecj_positioned with positions"
+
+# The control. Without it, every assertion below passes on an empty report.
+if [ "$javac_total" -lt 1 ]; then
+  echo "FAIL: javac produced no @AILocked entries, so this run compares nothing." >&2
+  echo "      Either the fixture stopped carrying @AILocked, or the processor did not run." >&2
+  status=1
+fi
+if [ "$javac_positioned" -ne "$javac_total" ]; then
+  echo "FAIL: javac reported $javac_positioned of $javac_total entries with a position." >&2
+  echo "      Positions come from the Tree API and javac has one, so this is a regression" >&2
+  echo "      in SourcePositionResolver rather than anything to do with ECJ." >&2
+  status=1
+fi
+
+# Assertion 2: degrading costs positions, not guardrails.
+if [ "$ecj_total" -ne "$javac_total" ]; then
+  echo "FAIL: ECJ reported $ecj_total locked entries against javac's $javac_total." >&2
+  echo "      Under a compiler with no Tree API the report must lose positions and nothing" >&2
+  echo "      else; a missing entry is a lock that nobody enforces." >&2
+  status=1
+fi
+
+# Assertion 3: the degradation is the documented one.
+if [ "$ecj_positioned" -ne 0 ]; then
+  echo "FAIL: ECJ reported $ecj_positioned entries carrying a position field." >&2
+  echo "      docs/PROCESSOR.md and USAGE.md both say entries omit positions under ECJ." >&2
+  echo "      Either ECJ grew a Tree API or a position is being fabricated." >&2
+  status=1
+fi
+
+# Assertion 4: no guardrail text is lost, and no type-level element is renamed.
+#
+# Deliberately NOT a byte-for-byte diff of the marker region, which is what this check was
+# first written to do. That comparison fails today, and for a reason worth stating rather
+# than papering over: member element paths render differently under the two compilers,
+# because ElementNaming leans on Element.toString(), whose format the javax.lang.model
+# contract leaves to the implementation.
+#
+#     javac : com.example.security.SecurityConfig.getKeyRotationHours()
+#     ECJ   : com.example.security.SecurityConfig.public int getKeyRotationHours()
+#
+# That is a real defect - .vibetags-locks is what the locked-files Action diffs a pull
+# request against, and granular rule filenames are derived from the same string - but it is
+# a change to core element identity, not to a CI leg, so it is filed separately rather than
+# smuggled in here. Until it is fixed, this asserts the two things that ARE true and that
+# the word "degrades" has to mean: every guardrail's text survives, and every type-level
+# path is identical.
+region() { sed -n "/VIBETAGS-START/,/VIBETAGS-END/p" "$1"; }
+region "$WORK/javac-run/CLAUDE.md" > "$WORK/javac.region"
+region "$WORK/ecj-run/CLAUDE.md" > "$WORK/ecj.region"
+
+# Every <reason>, <note>, <constraint> and friend, sorted - the guardrail prose itself.
+guardrail_text() {
+  grep -o "<reason>.*</reason>\|<note>.*</note>\|<constraint>.*</constraint>" "$1" \
+    | sort | uniq
+}
+# Every path= that names a type rather than a member. Members are excluded only because of
+# the toString() divergence above; when that is fixed, drop the filter.
+type_paths() {
+  grep -o 'path="[^"]*"' "$1" | grep -v "(" | sort | uniq
+}
+
+if [ ! -s "$WORK/javac.region" ]; then
+  echo "FAIL: no VIBETAGS marker region in the javac CLAUDE.md - nothing to compare." >&2
+  status=1
+else
+  guardrail_text "$WORK/javac.region" > "$WORK/javac.text"
+  guardrail_text "$WORK/ecj.region" > "$WORK/ecj.text"
+  if [ ! -s "$WORK/javac.text" ]; then
+    echo "FAIL: the javac region carries no guardrail prose, so this compares nothing." >&2
+    status=1
+  elif ! diff -u "$WORK/javac.text" "$WORK/ecj.text" > "$WORK/text.diff"; then
+    echo "FAIL: guardrail text differs between javac and ECJ." >&2
+    echo "      Positions may degrade; the instruction an agent reads may not." >&2
+    head -40 "$WORK/text.diff" >&2
+    status=1
+  fi
+
+  type_paths "$WORK/javac.region" > "$WORK/javac.types"
+  type_paths "$WORK/ecj.region" > "$WORK/ecj.types"
+  if ! diff -u "$WORK/javac.types" "$WORK/ecj.types" > "$WORK/types.diff"; then
+    echo "FAIL: type-level element paths differ between javac and ECJ." >&2
+    echo "      A guarded class must have the same identity under either compiler." >&2
+    head -40 "$WORK/types.diff" >&2
+    status=1
+  fi
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "OK: the processor degrades under ECJ exactly as documented -"
+  echo "    $ecj_total locked entries preserved, 0 positions,"
+  echo "    $(wc -l < "$WORK/javac.text") guardrail texts and"
+  echo "    $(wc -l < "$WORK/javac.types") type paths identical to the javac control."
+fi
+exit "$status"

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -92,6 +92,12 @@
         <snakeyaml.version>2.6</snakeyaml.version>
         <jmh.version>1.37</jmh.version>
 
+        <!-- Verification-only tooling: never on any module's classpath. ECJ is how CI checks
+             the documented claim that the processor degrades rather than fails under a compiler
+             with no Tree API (docs/PROCESSOR.md, USAGE.md). scripts/ecj-degradation-check.sh
+             reads this property so the version has one home, like every other pin here. -->
+        <ecj.version>3.44.0</ecj.version>
+
         <!-- Build plugins -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>


### PR DESCRIPTION
Closes #475, implementing **option 3** — the one that needs no production seam.

## The decision

#475 asked for a decision, not a patch. Three options were on the table:

1. Accept the current coverage and document these classes as fault-path-heavy.
2. Introduce seams — an injectable `FileSystem`, a `Supplier<Trees>` — so tests can inject failures.
3. Compile a fixture under ECJ in one CI leg, exercising the no-Tree-API paths honestly.

Option 3, as the issue itself recommended. Option 2 would add permanent production surface to two classes this repo marks high-sensitivity, existing only so a test could fail it. Option 3 adds none, and it checks something the project *claims in its own docs* and never verified:

> **docs/PROCESSOR.md** — "under genuinely non-javac compilers (ECJ) entries omit position fields"
> **USAGE.md** — "under other compilers (ECJ) entries omit positions and tools fall back to file-level matching"

## What the leg does

`scripts/ecj-degradation-check.sh` compiles `examples/basic` twice — javac and ECJ, same fixture, same processor path — and compares. Four assertions:

1. **ECJ exits 0.** The promise the whole design rests on is that VibeTags never fails somebody's build.
2. **Both compilers report the same `@AILocked` elements.** Degrading costs positions, not guardrails.
3. **Every javac entry carries a position; no ECJ entry does.**
4. **Every guardrail's prose and every type-level element path matches.**

Measured on this branch:

```
javac: 9 locked entries, 9 with positions
ECJ:   9 locked entries, 0 with positions
OK: 9 locked entries preserved, 0 positions,
    21 guardrail texts and 38 type paths identical to the javac control.
```

## The control is load-bearing, and was tested as such

Assertion 3 passes just as well on a report containing nothing at all — which is exactly how a check like this rots into decoration. So the javac half is asserted too, and **that assertion was verified by making it fire**: pointing the control run at ECJ as well turns the run red with `javac reported 0 of 9 entries with a position` instead of green.

**That probe found two false greens in my own check**, both now fixed and both commented at the line:

- A missing `.vibetags-locks` left every count an empty string. Each `[ "$x" -ne "$y" ]` then died with `integer expected` — *inside an `if` condition, where `set -e` does not reach* — so the script printed `OK` and exited 0 with its central assertions never evaluated. The reports are now required to exist before anything counts them.
- `grep -c` prints its count **and then exits 1** when the count is zero. An `|| echo 0` therefore made the variable `"0\n0"` and reproduced the same silent skip. `|| true` is the whole fix.

Both were caught by deliberately breaking the check, not by reading it.

## What it found in the product: #480

Assertion 4 originally diffed the entire marker region byte-for-byte, expecting only positions to differ. It failed — on element *paths*:

```
javac : com.example.security.SecurityConfig.getKeyRotationHours()
ECJ   : com.example.security.SecurityConfig.public int getKeyRotationHours()
```

`ElementNaming` builds a member's identity from `Element.toString()`, whose format `javax.lang.model` leaves to the implementation. That string is what `.vibetags-locks` records (the report the shipped `action/locked-files` diffs PRs against), what `granularQName` turns into rule *filenames*, and what every `path=` attribute carries.

That is a change to core element identity, not to a CI leg, so it is **filed as #480** with the reproduction and a sketch of the fix, rather than smuggled in here. Assertion 4 is narrowed to guardrail prose and type-level paths — both of which match exactly — with a comment at the line pointing at the issue and saying which filter to drop once it is fixed.

Nine minutes of ECJ found a compiler-dependent identity in the file a merge gate reads. That is the argument for the leg.

## Details

- **The ECJ version lives in `vibetags-parent/pom.xml`** as `<ecj.version>`, with every other third-party pin (invariant 14). The script reads it from there, so there is one literal. `BuildVersionParityTest` is green with it.
- The script runs on Linux, macOS and Git Bash — it detects the classpath separator and `cygpath`s paths on Windows, so a developer can run it before pushing. Verified on Windows; CI runs it on `ubuntu-latest`.
- `docs/WORKFLOW.md` documents the new job. `docs/PROCESSOR.md` and `USAGE.md` now say the ECJ claim is measured instead of just asserting it.

## Verification

- `scripts/ecj-degradation-check.sh` — green, output above.
- Two negative probes, both red as intended (details above).
- `mvn test` — 1624 pass, 0 fail.
- `gitleaks`, `end-of-file-fixer`, `trailing-whitespace` passed.
- Script mode committed as `100755`, so CI does not hit `exit 126`.

### Gate not run here

The `checkstyle` pre-commit hook was **skipped** — it runs in Docker, which was not running on this machine. Not a pass; the Maven `checkstyle:check` binding covers the same rules in CI.

## Coverage, honestly

This does **not** move the codecov number — the ECJ leg is a shell check, not JaCoCo-instrumented. It covers the *behaviour* those uncovered lines exist to provide, which is what #475 argued was actually at stake. The `ModuleSidecar` / `GuardrailFileWriter` / `AIGuardrailProcessor` fault paths in that issue's table (272 of the 643 lines) are untouched by this and still need option 1 or 2; #475's table is the record of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUjemLTYEwQHhjmztrrapT
