### PR TITLE
chore(deps): async-test-lib 1.9.4 -> 1.9.8

### DIFF
--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -88,7 +88,7 @@
         <junit.platform.version>6.1.3</junit.platform.version>
         <mockito.version>5.23.0</mockito.version>
         <archunit.version>1.5.0</archunit.version>
-        <async-test-lib.version>1.9.4</async-test-lib.version>
+        <async-test-lib.version>1.9.8</async-test-lib.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <jmh.version>1.37</jmh.version>
 


### PR DESCRIPTION
Bumps `async-test-lib` from **1.9.4 to 1.9.8**, as part of the upstream release's downstream
regression sweep.

## What this spans

Four releases: 1.9.5, 1.9.6, 1.9.7 and 1.9.8. Between them the library added eleven detectors
(135 to 146), the `collections=true` agent option, a lockset model that understands `synchronized`
methods, `ReentrantLock`, `StampedLock` and read-write locks, and a fix for a dynamic-attach defect
that left some classes silently woven by nothing.

That last one is worth naming here. `@AsyncTest` self-attaches the agent unless `-javaagent` is
set, and before 1.9.8 the attach's own retransformation pass could load classes that were then
handed to no transformer and covered by no snapshot - no error, no log line. Upstream measured it
costing 14 of 20 detections in its own corpus purely from test-class ordering.

## Both build systems, because this repo declares it twice

`vibetags-parent/pom.xml` holds the property and `vibetags/build.gradle` reads it through
`pomVersion`, so the single edit moves both tiers together. Both were run.

Verified against `se.deversity.async-test-lib:async-test-lib:1.9.8` resolved from Maven Central and
sha1-checked (`429ba0481676705964ffba6aa1a83be57c0ccb35`), not an upstream working-tree build.

```
mvn -B test -Pe2e                      2345 tests, 0 failures, 0 errors, 0 skipped
./gradlew --no-daemon cleanTest test -Pe2e   2345 tests, 0 failures, 0 errors, 0 skipped
```

`-Pe2e` is not optional: most of the five `@AsyncTest` classes carry `@Tag("e2e")`, and a plain
`mvn test` reports 957 green tests having run one of the five - which would sign off on a bump
that never touched the other four.

All five ran on both build systems, counted from `build/test-results/test/*.xml` and Surefire
rather than from the console, since Gradle prints `BUILD SUCCESSFUL` without listing a single test:

`GuardrailFileWriterAsyncTest`, `ModuleSidecarAsyncTest`, `VibeTagsLoggerAsyncTest`,
`VibeTagsLoggerConcurrencyTest`, `WriteCacheAsyncTest`.

## Nothing changed in this repo but the version

Three upstream detector behaviours moved in 1.9.8 and none altered a result here:
`CacheConcurrencyDetector` now asks the `ConcurrentMap` contract instead of
`instanceof ConcurrentHashMap`, `AtomicityValidator` requires a published value to go quiet before
excusing a settled single-check cache, and `JdbcConnectionSharedDetector` distinguishes sequential
pool reuse from concurrent sharing.

Upstream release notes: https://github.com/PIsberg/async-test-lib/releases/tag/v1.9.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZzL8ojoXZu8SCBMyuauCP
