### PR TITLE
test(corpus): run VibeTags over real third-party Java on every CI run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1227,6 +1227,48 @@ jobs:
   # is fresh, then intersects the PR diff with the locked line ranges; a diff that touches
   # an @AILocked element fails here and names the element and its reason. PR-only: the
   # guard is about proposed changes, and it needs a base to diff against.
+  # Real Java that nobody wrote to suit VibeTags. Every fixture in this repository was written
+  # by someone who knew what the processor does; these six libraries were not, and they are
+  # where the assumptions break. Each is compiled twice, with and without VibeTags, and the two
+  # runs are compared: same exit code, no new diagnostics, no file written into a project that
+  # never opted in, and ElementNaming rendering every member the way javac does. corpus/README.md
+  # has the rest, including the defect this found on its first run.
+  corpus:
+    name: Third-Party Corpus
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      # Keyed on repos.tsv, so a pin bump fetches and any other change reuses the clones. The
+      # repos are pinned to commits, so a hit is always the right source.
+      - name: Cache the corpus checkouts
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: target/corpus
+          key: corpus-${{ hashFiles('corpus/repos.tsv') }}
+
+      - name: Install VibeTags Annotations and Processor (Maven)
+        run: |
+          cd vibetags-annotations
+          mvn install -B -q -DskipTests
+          cd ../vibetags
+          mvn install -B -q -DskipTests
+
+      - name: Run VibeTags over the corpus and compare against the control
+        run: corpus/run-corpus.sh
+
   # The one leg that does not run javac. docs/PROCESSOR.md and USAGE.md both promise that
   # VibeTags degrades - loses @AILocked positions, keeps every guardrail - under a compiler
   # with no Tree API, and nothing verified either sentence. The paths behind them are

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1251,13 +1251,16 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      # Keyed on repos.tsv, so a pin bump fetches and any other change reuses the clones. The
-      # repos are pinned to commits, so a hit is always the right source.
+      # Keyed on repos.tsv and on the harness, so a pin bump or a change to how the corpus is
+      # built fetches afresh. The repos are pinned to commits, so a hit is always the right
+      # source for the checkouts. Nothing the harness derives is trusted from a hit: the
+      # resolved classpath is rebuilt every run, because a cache written by a failing run is
+      # indistinguishable from a good one once it is on disk.
       - name: Cache the corpus checkouts
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: target/corpus
-          key: corpus-${{ hashFiles('corpus/repos.tsv') }}
+          key: corpus-${{ hashFiles('corpus/repos.tsv', 'corpus/run-corpus.sh') }}
 
       - name: Install VibeTags Annotations and Processor (Maven)
         run: |

--- a/corpus/ElementNamingAuditor.java
+++ b/corpus/ElementNamingAuditor.java
@@ -1,0 +1,143 @@
+package corpus;
+
+import se.deversity.vibetags.processor.internal.ElementNaming;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+/**
+ * Checks {@link ElementNaming} against javac's own rendering, over whatever code it is pointed at.
+ *
+ * <p>{@code ElementNamingFormatParityTest} asserts the same property over a 26-member fixture the
+ * project wrote itself. A fixture can only contain the shapes somebody thought of. This runs the
+ * comparison over real third-party libraries instead, where the generics are gnarlier, the nesting
+ * is deeper, and nobody was trying to be helpful.
+ *
+ * <p>The property: for every field, method and constructor, {@code ElementNaming.elementPath}
+ * must equal {@code enclosingType + "." + element.toString()} under javac. That string is the
+ * element's identity in {@code .vibetags-locks}, which the shipped {@code action/locked-files}
+ * matches a pull request's diff against, and it is what {@code granularQName} turns into a rule
+ * filename. javac's rendering is the target because that is what produced every generated file in
+ * every consumer.
+ *
+ * <p>Writes {@code <report>} with one {@code MISMATCH} line per disagreement and a {@code VISITED}
+ * count. The count matters as much as the mismatches: a run that visits nothing proves nothing,
+ * and the harness fails when it is zero.
+ */
+@SupportedAnnotationTypes("*")
+@SupportedSourceVersion(SourceVersion.RELEASE_21)
+public final class ElementNamingAuditor extends AbstractProcessor {
+
+    private static final String REPORT_OPTION = "corpus.report";
+
+    /** {@code @some.qualified.Anno} or {@code @Anno(args)}, plus the space javac puts after it. */
+    private static final java.util.regex.Pattern TYPE_USE_ANNOTATION =
+        java.util.regex.Pattern.compile("@[A-Za-z_][A-Za-z0-9_.]*(\\([^)]*\\))?\\s*");
+
+    private int visited;
+    private int mismatches;
+    private int annotated;
+    private final StringBuilder findings = new StringBuilder();
+
+    @Override
+    public Set<String> getSupportedOptions() {
+        return Set.of(REPORT_OPTION);
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment round) {
+        for (Element root : round.getRootElements()) {
+            visit(root);
+        }
+        if (round.processingOver()) {
+            writeReport();
+        }
+        // Never claim the annotations: VibeTags is running alongside this and must see them all.
+        return false;
+    }
+
+    private void visit(Element type) {
+        for (Element member : type.getEnclosedElements()) {
+            ElementKind kind = member.getKind();
+            if (kind == ElementKind.FIELD
+                || kind == ElementKind.METHOD
+                || kind == ElementKind.CONSTRUCTOR) {
+                compare(member);
+            } else if (kind.isClass() || kind.isInterface()) {
+                // Nested and local types included on purpose: they are where a signature builder
+                // that assumes a flat "package.Type.member" shape comes apart.
+                visit(member);
+            }
+        }
+    }
+
+    private void compare(Element member) {
+        Element enclosing = member.getEnclosingElement();
+        if (enclosing == null) {
+            return;
+        }
+        visited++;
+        String javac = enclosing + "." + member;
+        String derived = ElementNaming.elementPath(member);
+        if (javac.equals(derived)) {
+            return;
+        }
+        if (stripTypeAnnotations(javac).equals(derived)) {
+            // The one divergence VibeTags intends. javac renders an annotated parameter as
+            // java.lang.@org.jspecify.annotations.Nullable String; ElementNaming drops the
+            // annotation, because this string is the element's identity and a @Nullable coming
+            // or going must not rename a rule file or break a lock match. See ElementNaming's
+            // typeString javadoc. Counted rather than ignored, so the corpus can show that the
+            // difference is real and bounded rather than silently tolerated.
+            annotated++;
+            if (annotated <= 5) {
+                findings.append("ANNOTATED\tjavac=").append(javac)
+                        .append("\tderived=").append(derived).append('\n');
+            }
+            return;
+        }
+        mismatches++;
+        // Capped: a systematic break would otherwise produce a report the size of the corpus.
+        if (mismatches <= 50) {
+            findings.append("MISMATCH\tjavac=").append(javac)
+                    .append("\tderived=").append(derived).append('\n');
+        }
+    }
+
+    /**
+     * Removes JSR-308 type-use annotations from a javac-rendered signature, including any
+     * parenthesised arguments, so what is left is the signature alone.
+     */
+    private static String stripTypeAnnotations(String rendered) {
+        return TYPE_USE_ANNOTATION.matcher(rendered).replaceAll("");
+    }
+
+    private void writeReport() {
+        String target = processingEnv.getOptions().get(REPORT_OPTION);
+        if (target == null) {
+            return;
+        }
+        try (Writer out = Files.newBufferedWriter(Path.of(target), StandardCharsets.UTF_8)) {
+            out.write("VISITED\t" + visited + "\n");
+            out.write("MISMATCHES\t" + mismatches + "\n");
+            out.write("ANNOTATED\t" + annotated + "\n");
+            out.write(findings.toString());
+        } catch (IOException e) {
+            throw new UncheckedIOException("could not write the corpus report to " + target, e);
+        }
+    }
+}

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -1,0 +1,97 @@
+# The third-party corpus
+
+Six real Java libraries, pinned to commits, compiled twice on every CI run: once without
+VibeTags and once with it. Nothing is vendored. The sources are cloned at build time into
+`target/corpus` and never committed, so no third-party code enters this repository.
+
+```bash
+corpus/run-corpus.sh               # all of it
+corpus/run-corpus.sh commons-cli   # one repo
+```
+
+Requires `vibetags-annotations` and `vibetags` installed first (see
+[CLAUDE.md](../CLAUDE.md#build-and-test)).
+
+## Why it exists
+
+Every fixture in this repository was written by somebody who knew what VibeTags does.
+`examples/basic` has the annotations a demo needs; `GuardrailModels` has the members a test
+author thought of. Neither contains code written by people who had never heard of this project,
+and that is precisely the code VibeTags has to survive.
+
+The corpus is that code. It found a real gap on its first run (see below).
+
+## What is asserted
+
+Each repo is compiled twice with identical sources, classpath and flags. The only difference is
+whether VibeTags is on the processor path. The comparison is the point: asserting "it compiled"
+against a hard-coded zero would silently pass on a repo that never compiled to begin with.
+
+| # | Assertion | What it protects |
+|---|---|---|
+| 1 | The treatment exits exactly as the control did | The promise the design rests on: adding VibeTags to a build must not fail it |
+| 2 | The treatment raises no error or warning the control did not | A processor that turns a clean build noisy has broken the same promise, more quietly |
+| 3 | Nothing is written to the VibeTags root | File presence is the only opt-in (tier-1 invariant 1) and none of these repos opted in |
+| 4 | `ElementNaming` renders every member as javac does | That string is the element's identity in `.vibetags-locks` and in granular rule filenames |
+
+`vibetags.log` is the documented exception to assertion 3 (`vibetags.log.path`, disabled with
+`OFF`; see [USAGE.md](../USAGE.md)). It is created empty even in a project with no annotations.
+
+Assertion 4 is the reason for the size. `ElementNamingFormatParityTest` checks the same property
+against a 26-member fixture; the corpus checks it against **15,683 members** nobody chose.
+
+## What it found
+
+On its first run, over the two corpus members that use [jspecify](https://jspecify.dev):
+
+```
+javac   : org.semver4j.Semver.parse(java.lang.@org.jspecify.annotations.Nullable String)
+derived : org.semver4j.Semver.parse(java.lang.String)
+```
+
+javac's `toString()` includes JSR-308 type-use annotations. The structural derivation introduced
+in #480 drops them, so **any consumer using jspecify or the Checker Framework would have seen
+their generated files move** when that landed. No fixture in this repository uses a type-use
+annotation, so nothing caught it.
+
+Dropping them is the right behaviour, and is now deliberate rather than accidental. Keeping them
+would put the annotation into a rule *filename* -
+`...parse-java-lang--org-jspecify-annotations-Nullable-String-` - so adding or removing a
+`@Nullable` would rename a committed file and break a lock match, for a change that does not
+alter the signature. The identity is the signature, not its annotations.
+
+The harness therefore classifies a difference rather than just counting it: annotation-only
+differences are reported as `TYPE-ANN` and pass; anything else fails. That distinction is what
+makes the assertion meaningful instead of merely tolerant.
+
+## The repos, and why each is here
+
+Chosen for variety rather than volume. The construct counts were measured, not estimated.
+
+| Repo | Files | Licence | What it contributes |
+|---|---:|---|---|
+| `commons-cli` | 36 | Apache-2.0 | Smallest and dependency-free: the fast smoke test, and the one that still runs when dependency resolution is down |
+| `commons-codec` | 87 | Apache-2.0 | Static-utility style, byte-array APIs, 7 `package-info` files, 26 nested types |
+| `commons-io` | 277 | Apache-2.0 | The largest: 15 `package-info` files, 279 sources using generics, 86 nested types |
+| `jimfs` | 62 | Apache-2.0 | Generics- and varargs-dense (72 and 32 of 62 files), Guava-based, an NIO SPI implementation, jspecify-annotated |
+| `record-builder` | 6 | Apache-2.0 | Records, and an annotation library whose own processor also runs at compile time |
+| `semver4j` | 27 | MIT | Targets Java 17 rather than 8, so the corpus is not entirely legacy language level, and jspecify-annotated |
+
+Roughly 495 files and 15,683 members in total.
+
+## Adding a repo
+
+1. Pick something small, permissively licensed, and *different* from what is already there. A
+   seventh repo that looks like `commons-codec` adds runtime and no coverage.
+2. Prove it compiles cleanly at the SHA you are pinning, with its own dependencies resolved. A
+   corpus member that does not compile makes every assertion above vacuous for it.
+3. Add a row to `repos.tsv` with the SHA, not a branch. A branch lets an upstream push turn this
+   repository's CI red for a reason nobody here changed.
+4. Record what it contributes, here and in the `why` column. "More code" is not a reason.
+
+## Keeping the pins current
+
+Deliberately not automated. A pin bump should be a commit somebody looked at, because the
+interesting outcome is exactly the one an automated bump would paper over: upstream adopts a
+language feature VibeTags renders wrongly. Bump when you want new coverage, and read the diff in
+the `TYPE-ANN` and `MEMBERS` columns when you do.

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -170,6 +170,14 @@ assertion 0 refuses to evaluate a repo whose control did not compile. The second
 matters: the first only fixes the cause that was found, the second fails loudly on every cause
 that has not been.
 
+Assertion 0 then immediately earned its place, on the very next run. CI restored `target/corpus`
+from the cache written by the *failing* run, `.corpus-cp` among it, and the harness trusted it
+because it was non-empty. jimfs compiled without guava on a branch where the resolution bug was
+already fixed. So the resolved classpath is now rebuilt every run and never read from a cache: a
+cache written by a broken run is indistinguishable from a good one once it is on disk. The cache
+key covers `run-corpus.sh` as well as `repos.tsv`, and what the cache is actually for is the
+checkouts, which are pinned to SHAs and therefore always safe to reuse.
+
 ### What that adds up to
 
 | Defect | Found by | Would the others have caught it? |

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -34,18 +34,77 @@ against a hard-coded zero would silently pass on a repo that never compiled to b
 | 3 | Nothing is written to the VibeTags root | File presence is the only opt-in (tier-1 invariant 1) and none of these repos opted in |
 | 4 | `ElementNaming` renders every member as javac does | That string is the element's identity in `.vibetags-locks` and in granular rule filenames |
 
-Then a second phase, because non-interference is only half the question. Two real elements per
-repo are annotated in the clone, `CLAUDE.md`, `GEMINI.md` and `.vibetags-locks` are created empty
-to opt in, and the generated output is read back:
+Assertion 0 sits in front of all of them: **the control itself must compile.** Comparing against
+a control is what stops a broken repo being blamed on VibeTags, but it also means a repo that
+cannot compile at all passes assertions 1 and 2 trivially, both sides failing identically, while
+the model behind 3 and 4 is full of error types. That is not a corpus member, it is a vacuous
+pass, and it happened: see [What it found](#what-it-found).
+
+## Phase two: opt in, and read the output back
+
+Non-interference is only half the question. The second phase turns VibeTags on the way a consumer
+would and inspects what comes out.
+
+**Three platforms, the most used ones, aggregate and granular:**
+
+| Platform | Aggregate | Granular | Opt-in |
+|---|---|---|---|
+| Claude | `CLAUDE.md` | `.claude/rules/` | create both |
+| Gemini | `GEMINI.md` | `.gemini/rules/` | create both |
+| Codex | `AGENTS.md` | none | create it **with a marker pair** |
+
+Codex is the interesting one. Invariant 4 says `AGENTS.md` is written only as the sole AI config
+file or when it already carries a `VIBETAGS-START`/`END` pair, so an empty `AGENTS.md` alongside
+Claude and Gemini is silently dropped from the active set. The harness seeds the pair, which is
+what a real consumer does, and then asserts `AGENTS.md` grew beyond it. Without that second check
+the corpus would report Codex working while generating none of it.
+
+**Two sources of annotations, for two different reasons:**
+
+- **Real elements in the repo's own code**, chosen deterministically: the first public type, and
+  the first method with a jspecify `@Nullable` parameter. This is what proves VibeTags handles
+  *their* signatures, and it is what found both naming defects below.
+- **A showcase compiled into a package of its own** under the repo's source root
+  (`corpus/showcase/`). No third-party repo contains `@AI*` annotations, so the full surface has
+  to come from somewhere; putting it in their tree means it compiles with their classpath, their
+  language level and their compiler settings.
+
+The showcase carries a guardrail at **every level one can attach to**, in both tiers:
+
+| Level | Annotations | Lands in |
+|---|---|---|
+| package | `@AIArchitecture`, `@AISecure` on `package-info.java` | Tier 1 (safety) and Tier 3 |
+| type | `@AIContext`, `@AIPublicAPI` | Tier 3 |
+| nested type | `@AICore`, `@AIImmutable` | Tier 1 (safety) and Tier 3 |
+| field | `@AIPrivacy`, `@AISecureLogging`, `@AIPerformance` | Tier 1 (safety) and Tier 3 |
+| method | `@AILocked`, `@AIAudit`, `@AISecure`, `@AIIgnore`, `@AIContract`, `@AIPerformance`, `@AITestDriven`, `@AIThreadSafe`, `@AILoadBearing`, `@AIKeepInSync`, `@AIBannedApi`, `@AIGenerated` | both tiers |
+| parameter | `@AIInputSanitized`, `@AILoadBearing` | Tier 3 |
+
+There is no constructor row, and that is a measured fact rather than an omission: **no annotation
+declares `ElementType.CONSTRUCTOR`**, so a constructor cannot carry a guardrail at all.
+`ElementNaming` still renders constructors, because javac hands them to the collector as enclosed
+elements of an annotated type, which is why `ElementNamingFormatParityTest` covers the shape.
+
+### What phase two asserts
 
 | # | Assertion | What it protects |
 |---|---|---|
-| 5 | Opting in produces content in every platform file | A file that exists is an opt-in and must be written |
-| 6 | `CLAUDE.md` carries a `VIBETAGS-START` marker pair | The markers are what protect hand-authored content |
+| 5 | Every opted-in platform file has content, **checked per platform** | One renderer can be dropped and the other two will cover for it in any total |
+| 5b | `AGENTS.md` grew beyond the seeded marker pair | Codex being dropped from the active set looks identical to Codex working |
+| 6 | Every aggregate carries a `VIBETAGS-START` pair | The markers are the whole promise that hand-authored content survives |
+| 6b | Both granular directories were written | An opted-in directory that stays empty looks exactly like "this project has no rules" |
+| 6c | **The tier split**: `@AIPrivacy` inline, `@AIContract` *not* inline but present in the rules directory | Invariant 6, checked on somebody else's code. Wrong in one direction, safety guardrails become comments; wrong in the other, the aggregate bloats |
+| 6d | The parameter level survived | The finest addressing VibeTags produces, and the only level a hand-written rules file cannot express |
+| 6e | The package level survived | The only level with no owning member to hang off |
+| 6f | **The richness floor**: at least 15 distinct showcase guardrails reached a generated file | Every other assertion names one guardrail, so a change that stopped rendering half the surface would still pass them all |
 | 7 | Every annotated element reaches the file | Keyed on a unique reason string, not a predicted path: predicting the path means reimplementing the thing under test |
 | 8 | No type-use annotation in any generated identity | In `path=` attributes, lock entries and filenames alike |
 
-The annotations are applied to the clone under `target/corpus` and reverted with
+Assertion 6f is the one that keeps the rest from rotting. 15 is measured, not aspirational: it is
+every marker the showcase declares, read off a green run. Raise it when the showcase grows.
+**Lowering it to make a run green is how this check stops meaning anything.**
+
+The annotations and the showcase are applied to the clone under `target/corpus` and reverted with
 `git checkout -- .` afterwards. Nothing is committed and no third-party source is modified in
 place.
 
@@ -97,6 +156,29 @@ rather than trusting the comparison.
 
 That is the argument for the opt-in phase in one example: a check that compares two
 implementations can only find disagreement, never a shared mistake.
+
+### And a third, in the harness rather than the product
+
+`dependency:build-classpath` exits 0 while writing nothing when it decides the classpath has not
+changed. On a warm machine the file is already there and everything looks fine. On a cold CI
+runner it was not, so jimfs compiled with **no dependencies at all**, reported 100 diagnostics on
+each side, and the run carried on: assertions 1 and 2 passed because both sides failed
+identically, and assertions 3 and 4 ran against a model made of error types.
+
+Two changes came out of it. `-Dmdep.regenerateFile=true` makes the plugin always write, and
+assertion 0 refuses to evaluate a repo whose control did not compile. The second is the one that
+matters: the first only fixes the cause that was found, the second fails loudly on every cause
+that has not been.
+
+### What that adds up to
+
+| Defect | Found by | Would the others have caught it? |
+|---|---|---|
+| Type-use annotations dropped for declared types | assertion 4, first run | No: no fixture here uses one |
+| Type-use annotation kept on a **type variable** | assertion 8, first opt-in run | No: javac agrees, so assertion 4 sees no disagreement |
+| Corpus silently running on an unresolved classpath | assertion 0, first CI run | No: assertions 1 and 2 passed, identically failing |
+
+Three defects, three different assertions, none of which could have found the others.
 
 ## The repos, and why each is here
 

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -34,6 +34,21 @@ against a hard-coded zero would silently pass on a repo that never compiled to b
 | 3 | Nothing is written to the VibeTags root | File presence is the only opt-in (tier-1 invariant 1) and none of these repos opted in |
 | 4 | `ElementNaming` renders every member as javac does | That string is the element's identity in `.vibetags-locks` and in granular rule filenames |
 
+Then a second phase, because non-interference is only half the question. Two real elements per
+repo are annotated in the clone, `CLAUDE.md`, `GEMINI.md` and `.vibetags-locks` are created empty
+to opt in, and the generated output is read back:
+
+| # | Assertion | What it protects |
+|---|---|---|
+| 5 | Opting in produces content in every platform file | A file that exists is an opt-in and must be written |
+| 6 | `CLAUDE.md` carries a `VIBETAGS-START` marker pair | The markers are what protect hand-authored content |
+| 7 | Every annotated element reaches the file | Keyed on a unique reason string, not a predicted path: predicting the path means reimplementing the thing under test |
+| 8 | No type-use annotation in any generated identity | In `path=` attributes, lock entries and filenames alike |
+
+The annotations are applied to the clone under `target/corpus` and reverted with
+`git checkout -- .` afterwards. Nothing is committed and no third-party source is modified in
+place.
+
 `vibetags.log` is the documented exception to assertion 3 (`vibetags.log.path`, disabled with
 `OFF`; see [USAGE.md](../USAGE.md)). It is created empty even in a project with no annotations.
 
@@ -63,6 +78,25 @@ alter the signature. The identity is the signature, not its annotations.
 The harness therefore classifies a difference rather than just counting it: annotation-only
 differences are reported as `TYPE-ANN` and pass; anything else fails. That distinction is what
 makes the assertion meaningful instead of merely tolerant.
+
+### And then a second one, which the parity check could not have found
+
+Assertion 4 compares VibeTags against javac. That is blind to the case where **both are wrong**,
+and that case was real. `DeclaredType` parameters had their annotations stripped through
+`asElement()`, but a **type variable** fell through to `toString()` and kept its annotation, so
+`jimfs` generated this into `CLAUDE.md` and into `.vibetags-locks`:
+
+```
+JimfsAsynchronousFileChannel.<A>lock(long,long,boolean,@org.jspecify.annotations.Nullable A, ...)
+```
+
+javac renders it the same way, so the auditor saw agreement and stayed silent. Only generating
+output and reading it back exposed it. `ElementNaming` now resolves a type variable through
+`asElement()` like everything else, and assertion 8 checks the generated identities directly
+rather than trusting the comparison.
+
+That is the argument for the opt-in phase in one example: a check that compares two
+implementations can only find disagreement, never a shared mistake.
 
 ## The repos, and why each is here
 

--- a/corpus/annotate.py
+++ b/corpus/annotate.py
@@ -1,0 +1,113 @@
+"""Annotates one real element in a cloned corpus repo, so the opt-in phase has something to generate.
+
+The corpus otherwise proves only that VibeTags stays out of the way. To evaluate what it
+*produces*, something in the repo has to be annotated, and it has to be the repo's own code
+rather than a fixture: the point is a real signature, resolved against real dependencies.
+
+Two targets are chosen per repo, both deterministically so a rerun annotates the same elements:
+
+  class   the first public top-level class in the source root, by sorted path
+  method  the first method with a jspecify @Nullable parameter, if the repo has one
+
+The second is the interesting one. Its element path is what #480 changed, and what the
+type-use annotation question turns on: javac would render the parameter as
+`java.lang.@org.jspecify.annotations.Nullable String`, and if that reached granularQName the
+rule *filename* would carry the annotation with it.
+
+Edits go to the clone under target/corpus, which is never committed and is restored with
+`git checkout -- .` after the phase. Prints one `TARGET <kind> <reason>` line per annotated
+element, where the third field is a unique reason string the harness greps for in the
+generated output.
+"""
+import pathlib
+import re
+import sys
+
+ANNOTATIONS_IMPORT = "import se.deversity.vibetags.annotations.AILocked;"
+PACKAGE = re.compile(r"^package\s+([\w.]+)\s*;", re.M)
+# Any public top-level type. Not just `class`: record-builder's main sources are entirely
+# annotation types and interfaces, and restricting this to classes left it with nothing to
+# annotate, which the harness correctly reported as a corpus member checking nothing.
+TOP_LEVEL_CLASS = re.compile(
+    r"^public\s+(?:final\s+|abstract\s+|sealed\s+|non-sealed\s+)*"
+    r"(?:class|interface|record|enum|@interface)\s+(\w+)", re.M)
+# A method whose parameter list contains a @Nullable.
+NULLABLE_METHOD = re.compile(
+    r"^([ \t]+)((?:public|protected)\s+(?:static\s+)?(?:final\s+)?[\w.<>\[\],?\s]+?\s+)(\w+)\("
+    r"([^)]*@Nullable[^)]*)\)\s*\{",
+    re.M)
+
+
+def insert_import(text):
+    """Adds the annotation import after the package statement, if it is not already there."""
+    if ANNOTATIONS_IMPORT in text:
+        return text
+    match = PACKAGE.search(text)
+    if not match:
+        return None
+    at = match.end()
+    return text[:at] + "\n\n" + ANNOTATIONS_IMPORT + text[at:]
+
+
+def annotate_class(path, text):
+    match = TOP_LEVEL_CLASS.search(text)
+    if not match:
+        return None, None
+    updated = insert_import(text)
+    if updated is None:
+        return None, None
+    # Re-find after the import shifted offsets.
+    match = TOP_LEVEL_CLASS.search(updated)
+    at = match.start()
+    # The reason is the handle the harness greps for. Reconstructing the element's full path in
+    # Python was the first attempt and it was the wrong tool: the path depends on nesting and on
+    # parameter rendering, which is the very thing under test. A unique reason string proves the
+    # element reached the file without this script having to predict how it would be named.
+    reason = f"corpus opt-in fixture CLASS {match.group(1)}"
+    annotation = f'@AILocked(reason = "{reason}")\n'
+    return updated[:at] + annotation + updated[at:], reason
+
+
+def annotate_nullable_method(path, text):
+    match = NULLABLE_METHOD.search(text)
+    if not match:
+        return None, None
+    updated = insert_import(text)
+    if updated is None:
+        return None, None
+    match = NULLABLE_METHOD.search(updated)
+    indent = match.group(1)
+    at = match.start()
+    reason = f"corpus opt-in fixture NULLABLE-PARAM {match.group(3)}"
+    annotation = f'{indent}@AILocked(reason = "{reason}")\n'
+    return updated[:at] + annotation + updated[at:], reason
+
+
+def main():
+    source_root = pathlib.Path(sys.argv[1])
+    files = sorted(p for p in source_root.rglob("*.java") if p.name != "module-info.java")
+
+    done_class = False
+    done_nullable = False
+    for path in files:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if not done_nullable and "@Nullable" in text:
+            updated, reason = annotate_nullable_method(path, text)
+            if updated:
+                path.write_text(updated, encoding="utf-8", newline="")
+                print(f"TARGET nullable-method {reason}")
+                done_nullable = True
+                continue
+        if not done_class:
+            updated, reason = annotate_class(path, text)
+            if updated:
+                path.write_text(updated, encoding="utf-8", newline="")
+                print(f"TARGET class {reason}")
+                done_class = True
+    if not done_class and not done_nullable:
+        print("TARGET none", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/corpus/repos.tsv
+++ b/corpus/repos.tsv
@@ -1,0 +1,24 @@
+# The third-party corpus: real Java that nobody wrote to suit VibeTags.
+#
+# Tab-separated. Lines starting with '#' are comments. Columns:
+#   name          directory name under the corpus cache
+#   url           clone URL
+#   sha           pinned commit. Never a branch: a branch would let an upstream push turn this
+#                 repository's CI red for a reason nobody here changed. Bump deliberately.
+#   source_root   path to the main sources to compile, relative to the repo root
+#   pom           pom used to resolve that module's own compile classpath
+#   licence       SPDX id, checked before adding. Nothing is vendored: sources are cloned at
+#                 build time and never committed here, so no third-party code enters this repo.
+#   why           what this repo contributes that the others do not
+#
+# Chosen for variety rather than volume, and each entry was measured before it was added:
+# construct counts are in corpus/README.md. Adding a repo means proving it compiles cleanly at
+# its pinned SHA, because a corpus member that does not compile turns every assertion vacuous.
+#
+#name	url	sha	source_root	pom	licence	why
+commons-cli	https://github.com/apache/commons-cli.git	0a68ae0e826bb08eb59bda9bae7ec5d84008b62a	src/main/java	pom.xml	Apache-2.0	Smallest and dependency-free: the fast smoke test, and the one that still runs if dependency resolution is down
+commons-codec	https://github.com/apache/commons-codec.git	8dcd16b7d13ef1a78e325d458830ead890fe82ac	src/main/java	pom.xml	Apache-2.0	Static utility style, byte-array APIs, 7 package-info files and 26 nested types
+commons-io	https://github.com/apache/commons-io.git	d83aeb6f4774aee75d857b29fb6cd89132c9a91b	src/main/java	pom.xml	Apache-2.0	The largest at 277 files: 15 package-info files, 279 sources using generics, 86 nested types
+jimfs	https://github.com/google/jimfs.git	5319800d7f1edf7e131caedae34676ca107ec8d9	jimfs/src/main/java	jimfs/pom.xml	Apache-2.0	Generics- and varargs-dense (72 and 32 of 62 files), built on Guava, and an NIO SPI implementation
+record-builder	https://github.com/Randgalt/record-builder.git	d9c81ac67840e939a80266972c2f336bff696222	record-builder-core/src/main/java	record-builder-core/pom.xml	Apache-2.0	Records, and an annotation library whose own processor also runs at compile time
+semver4j	https://github.com/semver4j/semver4j.git	1fcfbf0ff707268f942aa825f0cc179ab839da0e	src/main/java	pom.xml	MIT	Targets Java 17 rather than 8, so the corpus is not entirely legacy language level

--- a/corpus/run-corpus.sh
+++ b/corpus/run-corpus.sh
@@ -129,11 +129,16 @@ while IFS=$'\t' read -r name url sha src pom licence why; do
   # classpath it computed against the output file and reports "No changes found" - exiting 0
   # while writing nothing. On a warm machine the file is already there and everything looks
   # fine; on a cold CI runner it is not, and the compile silently ran with no classpath at all.
-  if [ ! -s "$dir/.corpus-cp" ]; then
-    ( cd "$dir" && mvn -q -f "$pom" dependency:build-classpath \
-        -Dmdep.regenerateFile=true \
-        "-Dmdep.outputFile=$dir/.corpus-cp" >"$dir/.corpus-mvn.log" 2>&1 ) || true
-  fi
+  # Resolved every run, never reused from the cache. The checkouts are what the cache is for -
+  # they are the expensive part and are pinned to a SHA, so a hit is always the right source.
+  # A resolved classpath is not: the CI cache is keyed on repos.tsv, so a run that resolved
+  # badly leaves a .corpus-cp that a later run restores and, because it is non-empty, trusts.
+  # That is exactly what happened - a poisoned cache from a failing run made jimfs compile
+  # without guava on a branch where resolution itself was already fixed.
+  rm -f "$dir/.corpus-cp"
+  ( cd "$dir" && mvn -q -f "$pom" dependency:build-classpath \
+      -Dmdep.regenerateFile=true \
+      "-Dmdep.outputFile=$dir/.corpus-cp" >"$dir/.corpus-mvn.log" 2>&1 ) || true
   dep_cp=$(cat "$dir/.corpus-cp" 2>/dev/null || printf '')
 
   # module-info.java is excluded: it needs modules that are not on this path, and the corpus is

--- a/corpus/run-corpus.sh
+++ b/corpus/run-corpus.sh
@@ -200,6 +200,115 @@ while IFS=$'\t' read -r name url sha src pom licence why; do
     grep "^MISMATCH" "$dir/.corpus-report" | head -10 >&2
     status=1
   fi
+
+  # ---------------------------------------------------------------------------------------
+  # Opt-in phase. Everything above proves VibeTags stays out of the way, which is only half
+  # the question: what does it actually produce on code nobody wrote for it? Two real elements
+  # per repo are annotated in the clone, three platform files are created to opt in, and the
+  # generated output is read back.
+  #
+  # The @Nullable-parameter target is the one that matters. Its element path is what #480
+  # changed, and granularQName turns that path into a rule filename - so if a type-use
+  # annotation ever leaks back into the identity, it shows up here as a filename containing
+  # "org-jspecify-annotations-Nullable", which assertion 8 rejects by name.
+  # ---------------------------------------------------------------------------------------
+  optin="$dir/.corpus-optin-root"
+  rm -rf "$optin" "$dir/.corpus-optin-classes"
+  mkdir -p "$optin/.claude/rules" "$dir/.corpus-optin-classes"
+  # File presence is the opt-in. Empty files, exactly as a consumer would create them.
+  : > "$optin/CLAUDE.md"
+  : > "$optin/GEMINI.md"
+  : > "$optin/.vibetags-locks"
+
+  ( cd "$dir" && git checkout --quiet -- . 2>/dev/null )
+  # tr -d: Python on Windows turns \n into \r\n on stdout, and a trailing CR in the element
+  # name makes every grep for it miss.
+  targets=$(python "$ROOT/corpus/annotate.py" "$dir/$src" 2>"$dir/.corpus-annotate.err" | tr -d '\r')
+  if [ -z "$targets" ]; then
+    echo "FAIL: could not annotate anything in $name, so the opt-in phase checks nothing." >&2
+    cat "$dir/.corpus-annotate.err" >&2
+    status=1
+    ( cd "$dir" && git checkout --quiet -- . 2>/dev/null )
+    continue
+  fi
+
+  ann_jar=$(ls "$HOME"/.m2/repository/se/deversity/vibetags/vibetags-annotations/"$VERSION"/vibetags-annotations-"$VERSION".jar 2>/dev/null | head -1)
+  optin_cp="$(winpath "$ann_jar")"
+  [ -n "$dep_cp" ] && optin_cp="$optin_cp$SEP$dep_cp"
+
+  ( cd "$dir" && find "$src" -name "*.java" ! -name "module-info.java" > .corpus-sources-optin \
+    && javac -nowarn -encoding UTF-8 -cp "$optin_cp" \
+      -processorpath "$FULL_CP" \
+      -processor se.deversity.vibetags.processor.AIGuardrailProcessor \
+      "-Avibetags.root=$(winpath "$optin")" \
+      -d "$(winpath "$dir/.corpus-optin-classes")" @.corpus-sources-optin ) \
+      > "$dir/.corpus-optin.log" 2>&1
+  optin_exit=$?
+  ( cd "$dir" && git checkout --quiet -- . 2>/dev/null )
+
+  if [ "$optin_exit" -ne 0 ]; then
+    echo "FAIL: $name did not compile once annotated, so nothing was generated to evaluate." >&2
+    grep -E ": (error|warning):" "$dir/.corpus-optin.log" | head -10 >&2
+    status=1
+    continue
+  fi
+
+  claude_bytes=$(wc -c < "$optin/CLAUDE.md" | tr -d ' ')
+  gemini_bytes=$(wc -c < "$optin/GEMINI.md" | tr -d ' ')
+  locks_members=$(grep -c '"type":"locked"' "$optin/.vibetags-locks" 2>/dev/null || true)
+  rule_files=$(find "$optin/.claude/rules" -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
+
+  # Assertion 5: opting in actually produces content.
+  if [ "$claude_bytes" -lt 1 ] || [ "$gemini_bytes" -lt 1 ]; then
+    echo "FAIL: $name opted in and got CLAUDE.md=$claude_bytes bytes, GEMINI.md=$gemini_bytes." >&2
+    echo "      A platform file that exists is an opt-in and must be written." >&2
+    status=1
+  fi
+  # Assertion 6: the marker pair is there, which is what protects hand-authored content.
+  if ! grep -q "VIBETAGS-START" "$optin/CLAUDE.md" 2>/dev/null; then
+    echo "FAIL: $name produced a CLAUDE.md with no VIBETAGS-START marker." >&2
+    status=1
+  fi
+  # Assertion 7: every annotated element reaches the file. Keyed on the unique reason string
+  # rather than a predicted element path: predicting the path means reimplementing the thing
+  # under test, and the first version of this got it wrong for a method on a nested class.
+  while read -r _ kind reason; do
+    [ -z "${reason:-}" ] && continue
+    if ! grep -q "$reason" "$optin/CLAUDE.md" 2>/dev/null; then
+      echo "FAIL: $name annotated a $kind ($reason) but it is absent from the generated CLAUDE.md." >&2
+      status=1
+    fi
+  done <<EOF
+$targets
+EOF
+
+  # Assertion 8: no type-use annotation anywhere in a generated element identity, in a path
+  # attribute or in a filename.
+  #
+  # This is the assertion the parity auditor structurally cannot make. The auditor compares
+  # VibeTags against javac, so when both render "@org.jspecify.annotations.Nullable A" they
+  # agree and nothing fires - which is exactly what happened: DeclaredType parameters were
+  # stripped through asElement(), but a *type variable* fell through to toString() and kept its
+  # annotation. Only generating output and reading it back showed that. Checked in the identity
+  # itself, not just in filenames, because .vibetags-locks is matched by the shipped action.
+  leaked_paths=$(grep -c 'path="[^"]*@' "$optin/CLAUDE.md" "$optin/GEMINI.md" 2>/dev/null \
+                 | awk -F: '{s+=$2} END {print s+0}')
+  leaked_locks=$(grep -c '"element":"[^"]*@' "$optin/.vibetags-locks" 2>/dev/null || true)
+  leaked_names=$(find "$optin" -name "*@*" -o -name "*Nullable*" 2>/dev/null | wc -l | tr -d ' ')
+  leaked=$((leaked_paths + leaked_locks + leaked_names))
+  if [ "$leaked" -ne 0 ]; then
+    echo "FAIL: $name put a type-use annotation into an element identity" >&2
+    echo "      ($leaked_paths path attributes, $leaked_locks lock entries, $leaked_names filenames)." >&2
+    grep -h 'path="[^"]*@' "$optin/CLAUDE.md" "$optin/GEMINI.md" 2>/dev/null | head -3 >&2
+    grep -h '"element":"[^"]*@' "$optin/.vibetags-locks" 2>/dev/null | head -2 >&2
+    echo "      Adding or removing that annotation would rename a committed rule file and stop" >&2
+    echo "      every lock and scoped-rules pointer matching, without the signature changing." >&2
+    status=1
+  fi
+
+  printf "%-16s %-7s %-18s %-9s %-8s %-9s %s\n" \
+    "  └ opt-in" "" "exit=$optin_exit" "CLAUDE=$claude_bytes" "locks=$locks_members" \
+    "rules=$rule_files" "$(printf '%s' "$targets" | wc -l | tr -d ' ') annotated"
 done < "$MANIFEST"
 
 echo

--- a/corpus/run-corpus.sh
+++ b/corpus/run-corpus.sh
@@ -41,6 +41,12 @@ set -u
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 CACHE="${VIBETAGS_CORPUS_DIR:-$ROOT/target/corpus}"
 MANIFEST="$ROOT/corpus/repos.tsv"
+# Floor for assertion 6f: how many of the showcase's guardrails must reach a generated
+# file. 15 is measured, not aspirational - it is every marker the showcase declares,
+# across package, type, nested type, field, method and parameter levels, and it was
+# read off a green run before being written down. Raise it when the showcase grows.
+# Lowering it to make a run green is how this check stops meaning anything.
+SHOWCASE_FLOOR="${VIBETAGS_CORPUS_SHOWCASE_FLOOR:-15}"
 
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*) SEP=";" ; winpath() { cygpath -w "$1"; } ;;
@@ -118,8 +124,14 @@ while IFS=$'\t' read -r name url sha src pom licence why; do
 
   # The repo's own dependencies, resolved by its own build, so its sources actually attribute.
   # Without this the model is full of error types and every assertion below weakens.
+  #
+  # mdep.regenerateFile is not optional. Without it dependency:build-classpath compares the
+  # classpath it computed against the output file and reports "No changes found" - exiting 0
+  # while writing nothing. On a warm machine the file is already there and everything looks
+  # fine; on a cold CI runner it is not, and the compile silently ran with no classpath at all.
   if [ ! -s "$dir/.corpus-cp" ]; then
     ( cd "$dir" && mvn -q -f "$pom" dependency:build-classpath \
+        -Dmdep.regenerateFile=true \
         "-Dmdep.outputFile=$dir/.corpus-cp" >"$dir/.corpus-mvn.log" 2>&1 ) || true
   fi
   dep_cp=$(cat "$dir/.corpus-cp" 2>/dev/null || printf '')
@@ -172,6 +184,25 @@ while IFS=$'\t' read -r name url sha src pom licence why; do
   repos_run=$((repos_run + 1))
   total_visited=$((total_visited + visited))
 
+  # Assertion 0, and the one that matters most for keeping the rest honest: the control has to
+  # compile. Comparing the treatment against the control is what stops a broken repo being
+  # blamed on VibeTags, but it also means a repo that cannot compile *at all* passes assertions
+  # 1 and 2 trivially, both sides failing identically, while the model behind assertions 3 and 4
+  # is full of error types. That is not a corpus member, it is a vacuous pass.
+  #
+  # This is not hypothetical: dependency:build-classpath exited 0 without writing a classpath on
+  # a cold CI runner, jimfs compiled with no dependencies, and the run reported 100 diagnostics
+  # on each side and carried on.
+  if [ "$ctrl_exit" -ne 0 ]; then
+    echo "FAIL: $name does not compile on its own, so nothing below it means anything." >&2
+    echo "      Every assertion here is relative to this control. Fix the corpus member -" >&2
+    echo "      classpath resolution, source root, or the pinned SHA - rather than the code." >&2
+    echo "      resolved classpath: $(wc -c < "$dir/.corpus-cp" 2>/dev/null || echo 0) bytes" >&2
+    tail -5 "$dir/.corpus-mvn.log" 2>/dev/null >&2
+    grep -E ": error:" "$dir/.corpus-ctrl.log" | head -5 >&2
+    status=1
+    continue
+  fi
   if [ "$ctrl_exit" -ne "$vt_exit" ]; then
     echo "FAIL: $name exits $vt_exit with VibeTags and $ctrl_exit without it." >&2
     echo "      Adding VibeTags to a build must not change whether it succeeds." >&2
@@ -214,11 +245,19 @@ while IFS=$'\t' read -r name url sha src pom licence why; do
   # ---------------------------------------------------------------------------------------
   optin="$dir/.corpus-optin-root"
   rm -rf "$optin" "$dir/.corpus-optin-classes"
-  mkdir -p "$optin/.claude/rules" "$dir/.corpus-optin-classes"
+  # Three platforms, aggregate and granular. Claude and Gemini both have a granular directory;
+  # Codex has none, so it gets its aggregate only.
+  mkdir -p "$optin/.claude/rules" "$optin/.gemini/rules" "$dir/.corpus-optin-classes"
   # File presence is the opt-in. Empty files, exactly as a consumer would create them.
   : > "$optin/CLAUDE.md"
   : > "$optin/GEMINI.md"
   : > "$optin/.vibetags-locks"
+  # AGENTS.md is the exception, and the exception is invariant 4: it is written only as the sole
+  # AI config file, or when it already carries a marker pair. Opting Codex in alongside Claude
+  # and Gemini therefore means seeding the pair, which is exactly what a consumer does. Created
+  # empty it would be dropped from the active set, silently, and the corpus would be asserting
+  # that Codex works while never generating a byte of it.
+  printf '%s\n%s\n' '<!-- VIBETAGS-START -->' '<!-- VIBETAGS-END -->' > "$optin/AGENTS.md"
 
   ( cd "$dir" && git checkout --quiet -- . 2>/dev/null )
   # tr -d: Python on Windows turns \n into \r\n on stdout, and a trailing CR in the element
@@ -232,7 +271,26 @@ while IFS=$'\t' read -r name url sha src pom licence why; do
     continue
   fi
 
+  # The showcase: every level a guardrail attaches to, in a package of its own under the repo's
+  # source root, compiled with the repo's classpath and compiler settings. Annotating real
+  # third-party elements (above) proves VibeTags handles their signatures; this proves it renders
+  # the whole annotation surface, which no third-party repo would ever contain.
+  showcase_pkg="vibetagscorpus"
+  showcase_dir="$dir/$src/$showcase_pkg"
+  mkdir -p "$showcase_dir"
+  sed "s/__PACKAGE__/$showcase_pkg/g" "$ROOT/corpus/showcase/CorpusShowcase.java.tmpl" \
+    > "$showcase_dir/CorpusShowcase.java"
+  sed "s/__PACKAGE__/$showcase_pkg/g" "$ROOT/corpus/showcase/package-info.java.tmpl" \
+    > "$showcase_dir/package-info.java"
+
   ann_jar=$(ls "$HOME"/.m2/repository/se/deversity/vibetags/vibetags-annotations/"$VERSION"/vibetags-annotations-"$VERSION".jar 2>/dev/null | head -1)
+  if [ ! -f "$ann_jar" ]; then
+    echo "FAIL: vibetags-annotations $VERSION is not in the local repository." >&2
+    echo "      The showcase cannot compile without it; run 'mvn install' in vibetags-annotations/." >&2
+    status=1
+    rm -rf "$showcase_dir"
+    continue
+  fi
   optin_cp="$(winpath "$ann_jar")"
   [ -n "$dep_cp" ] && optin_cp="$optin_cp$SEP$dep_cp"
 
@@ -244,6 +302,7 @@ while IFS=$'\t' read -r name url sha src pom licence why; do
       -d "$(winpath "$dir/.corpus-optin-classes")" @.corpus-sources-optin ) \
       > "$dir/.corpus-optin.log" 2>&1
   optin_exit=$?
+  rm -rf "$showcase_dir"
   ( cd "$dir" && git checkout --quiet -- . 2>/dev/null )
 
   if [ "$optin_exit" -ne 0 ]; then
@@ -255,18 +314,99 @@ while IFS=$'\t' read -r name url sha src pom licence why; do
 
   claude_bytes=$(wc -c < "$optin/CLAUDE.md" | tr -d ' ')
   gemini_bytes=$(wc -c < "$optin/GEMINI.md" | tr -d ' ')
+  agents_bytes=$(wc -c < "$optin/AGENTS.md" | tr -d ' ')
   locks_members=$(grep -c '"type":"locked"' "$optin/.vibetags-locks" 2>/dev/null || true)
-  rule_files=$(find "$optin/.claude/rules" -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
+  claude_rules=$(find "$optin/.claude/rules" -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
+  gemini_rules=$(find "$optin/.gemini/rules" -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
 
-  # Assertion 5: opting in actually produces content.
-  if [ "$claude_bytes" -lt 1 ] || [ "$gemini_bytes" -lt 1 ]; then
-    echo "FAIL: $name opted in and got CLAUDE.md=$claude_bytes bytes, GEMINI.md=$gemini_bytes." >&2
-    echo "      A platform file that exists is an opt-in and must be written." >&2
+  # Assertion 5: every opted-in platform produces content. Checked per platform rather than in
+  # aggregate: a renderer can be dropped from the registry and the other two will happily cover
+  # for it in any total.
+  for pf in CLAUDE.md GEMINI.md AGENTS.md; do
+    if [ ! -s "$optin/$pf" ]; then
+      echo "FAIL: $name opted into $pf and it came back empty." >&2
+      echo "      A platform file that exists on disk is the opt-in signal and must be written." >&2
+      status=1
+    fi
+  done
+  # Codex needs its own check: AGENTS.md was seeded with a marker pair, so "not empty" is true
+  # before VibeTags runs at all. What matters is that something landed between the markers.
+  if [ "$agents_bytes" -le 46 ]; then
+    echo "FAIL: $name produced an AGENTS.md of $agents_bytes bytes, which is the seeded marker" >&2
+    echo "      pair and nothing else. Codex was dropped from the active set rather than written." >&2
     status=1
   fi
-  # Assertion 6: the marker pair is there, which is what protects hand-authored content.
-  if ! grep -q "VIBETAGS-START" "$optin/CLAUDE.md" 2>/dev/null; then
-    echo "FAIL: $name produced a CLAUDE.md with no VIBETAGS-START marker." >&2
+
+  # Assertion 6: the marker pair is present in every aggregate. The markers are the whole of the
+  # promise that hand-authored content outside them survives.
+  for pf in CLAUDE.md GEMINI.md AGENTS.md; do
+    if ! grep -q "VIBETAGS-START" "$optin/$pf" 2>/dev/null; then
+      echo "FAIL: $name produced a $pf with no VIBETAGS-START marker." >&2
+      status=1
+    fi
+  done
+
+  # Assertion 6b: both granular directories were written. Opting a directory in and getting
+  # nothing back is the failure mode that looks exactly like "this project has no rules".
+  if [ "$claude_rules" -lt 1 ] || [ "$gemini_rules" -lt 1 ]; then
+    echo "FAIL: $name opted into granular rules and got $claude_rules Claude / $gemini_rules Gemini files." >&2
+    status=1
+  fi
+
+  # Assertion 6c: the tier split, which is invariant 6 checked on somebody else's code.
+  #
+  # With a granular directory opted in, the aggregate keeps the safety buckets inline and
+  # replaces everything else with a pointer. So @AIPrivacy's reason must still be in CLAUDE.md,
+  # and @AIContract's must not - it belongs in the rules directory now. Getting this backwards
+  # in either direction is a real defect: safety guardrails that only load when the agent opens
+  # the file have become comments, and verbose ones that stay inline are the context bloat the
+  # tier model exists to prevent.
+  if ! grep -q "FIELD-PRIVACY" "$optin/CLAUDE.md" 2>/dev/null; then
+    echo "FAIL: $name dropped a safety-tier guardrail (@AIPrivacy) from the aggregate." >&2
+    echo "      Safety buckets stay inline even when the granular directory is opted in." >&2
+    status=1
+  fi
+  if grep -q "METHOD-CONTRACT" "$optin/CLAUDE.md" 2>/dev/null; then
+    echo "FAIL: $name kept a non-safety guardrail (@AIContract) inline in the aggregate." >&2
+    echo "      With granular opted in the aggregate collapses to a scoped-rules index." >&2
+    status=1
+  fi
+  if ! grep -rq "METHOD-CONTRACT" "$optin/.claude/rules" 2>/dev/null; then
+    echo "FAIL: $name moved @AIContract out of the aggregate but not into the rules directory." >&2
+    echo "      That guardrail now reaches nobody at all, which is worse than leaving it inline." >&2
+    status=1
+  fi
+
+  # Assertion 6d: the parameter level survived. It is the finest addressing VibeTags produces
+  # and the only level a hand-written rules file cannot express, so it is also the one whose
+  # loss would be least likely to be noticed.
+  if ! grep -rq "PARAM-LOADBEARING" "$optin/.claude/rules" 2>/dev/null; then
+    echo "FAIL: $name lost the parameter-level guardrail (@AILoadBearing on a parameter)." >&2
+    status=1
+  fi
+  # Assertion 6e: the package level, which has no owning member to hang off.
+  if ! grep -rq "PACKAGE-SECURE" "$optin/CLAUDE.md" 2>/dev/null; then
+    echo "FAIL: $name lost the package-level guardrail (@AISecure on package-info.java)." >&2
+    status=1
+  fi
+
+  # Assertion 6f: the richness floor. Everything above names one guardrail each, so a change
+  # that quietly stopped rendering half the annotation surface would still pass them. This
+  # counts how many of the showcase's markers reached any generated file and refuses to let
+  # that number fall. Raise it when the showcase grows; never lower it to make a run green.
+  showcase_hits=$(grep -rhoE "(PACKAGE|FIELD|METHOD|PARAM|NESTED|CONSTRUCTOR)-[A-Z]+" \
+                    "$optin/CLAUDE.md" "$optin/GEMINI.md" "$optin/AGENTS.md" \
+                    "$optin/.claude/rules" "$optin/.gemini/rules" 2>/dev/null \
+                  | sort -u | wc -l | tr -d ' ')
+  if [ "$showcase_hits" -lt "$SHOWCASE_FLOOR" ]; then
+    echo "FAIL: $name rendered $showcase_hits of the showcase's guardrails, floor is $SHOWCASE_FLOOR." >&2
+    echo "      Something stopped reaching the generated files. Missing:" >&2
+    comm -23 <(grep -ohE "(PACKAGE|FIELD|METHOD|PARAM|NESTED|CONSTRUCTOR)-[A-Z]+" \
+                 "$ROOT/corpus/showcase/CorpusShowcase.java.tmpl" \
+                 "$ROOT/corpus/showcase/package-info.java.tmpl" | sort -u) \
+              <(grep -rhoE "(PACKAGE|FIELD|METHOD|PARAM|NESTED|CONSTRUCTOR)-[A-Z]+" \
+                 "$optin/CLAUDE.md" "$optin/GEMINI.md" "$optin/AGENTS.md" \
+                 "$optin/.claude/rules" "$optin/.gemini/rules" 2>/dev/null | sort -u) >&2
     status=1
   fi
   # Assertion 7: every annotated element reaches the file. Keyed on the unique reason string
@@ -308,7 +448,7 @@ EOF
 
   printf "%-16s %-7s %-18s %-9s %-8s %-9s %s\n" \
     "  └ opt-in" "" "exit=$optin_exit" "CLAUDE=$claude_bytes" "locks=$locks_members" \
-    "rules=$rule_files" "$(printf '%s' "$targets" | wc -l | tr -d ' ') annotated"
+    "rules=$claude_rules/$gemini_rules" "$(printf '%s' "$targets" | wc -l | tr -d ' ') annotated"
 done < "$MANIFEST"
 
 echo

--- a/corpus/run-corpus.sh
+++ b/corpus/run-corpus.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Runs VibeTags over real third-party Java and checks it changed nothing it should not.
+#
+# The examples in this repository were written by people who knew what VibeTags does. Real
+# libraries were not, and they are where the assumptions break: deeply nested types, generic
+# signatures nobody would invent for a fixture, package-info files, records, a module whose own
+# annotation processor is already running. corpus/repos.tsv pins six of them.
+#
+# Each repo is compiled twice, and the comparison is the point:
+#
+#   control    javac with no annotation processors at all
+#   treatment  the same javac, same sources, same classpath, plus VibeTags
+#
+# Four assertions, each of which fails loudly:
+#
+#   1. The treatment exits exactly as the control did. This is the promise the whole design
+#      rests on: adding VibeTags to somebody's build must not fail it. Comparing against the
+#      control rather than against zero is deliberate, so a repo that does not compile on its
+#      own is reported as such instead of being blamed on VibeTags.
+#   2. The treatment raises no error or warning the control did not. A processor that turns a
+#      clean build noisy has broken the same promise more quietly.
+#   3. Nothing is written to the VibeTags root. File presence is the only opt-in (tier-1
+#      invariant 1), and none of these repos opted in. vibetags.log is the documented exception
+#      (USAGE.md: vibetags.log.path, disable with OFF).
+#   4. ElementNaming renders every member exactly as javac does. ElementNamingFormatParityTest
+#      asserts this over a 26-member fixture; here it runs over thousands of members nobody
+#      chose. The count is asserted too: a run that visits nothing proves nothing.
+#
+# Nothing is vendored. Sources are cloned at the pinned SHA into a cache directory and never
+# committed, so no third-party code enters this repository.
+#
+# Usage:
+#   corpus/run-corpus.sh [name ...]     # all repos, or just the named ones
+#
+# Env:
+#   VIBETAGS_CORPUS_DIR   cache location (default: <repo>/target/corpus)
+#
+# Requires vibetags-annotations and vibetags installed (see CLAUDE.md "Build and test").
+set -u
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+CACHE="${VIBETAGS_CORPUS_DIR:-$ROOT/target/corpus}"
+MANIFEST="$ROOT/corpus/repos.tsv"
+
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) SEP=";" ; winpath() { cygpath -w "$1"; } ;;
+  *)                    SEP=":" ; winpath() { printf "%s" "$1"; } ;;
+esac
+
+VERSION=$(sed -n "s|.*<revision>\(.*\)</revision>.*|\1|p" "$ROOT/vibetags-parent/pom.xml")
+PROC_JAR="$ROOT/vibetags/target/vibetags-processor-$VERSION.jar"
+if [ ! -f "$PROC_JAR" ]; then
+  echo "FAIL: $PROC_JAR not found. Run 'mvn install' in vibetags/ first." >&2
+  exit 1
+fi
+
+mkdir -p "$CACHE"
+mvn -q -f "$ROOT/vibetags/pom.xml" dependency:build-classpath \
+    -Dmdep.includeScope=runtime "-Dmdep.outputFile=$CACHE/vibetags.cp" >/dev/null 2>&1
+VT_CP="$(winpath "$PROC_JAR")$SEP$(cat "$CACHE/vibetags.cp")"
+
+# The auditor compiles against the processor jar and runs alongside VibeTags.
+AUDITOR_OUT="$CACHE/auditor-classes"
+mkdir -p "$AUDITOR_OUT"
+( cd "$ROOT/corpus" && javac -nowarn -cp "$VT_CP" -d "$(winpath "$AUDITOR_OUT")" \
+    ElementNamingAuditor.java ) || { echo "FAIL: the corpus auditor did not compile" >&2; exit 1; }
+FULL_CP="$(winpath "$AUDITOR_OUT")$SEP$VT_CP"
+
+# Fetches exactly the pinned commit. Shallow, so a large history costs nothing, and idempotent,
+# so a warm cache does no network at all.
+fetch_repo() {
+  name="$1"; url="$2"; sha="$3"
+  dir="$CACHE/$name"
+  if [ -f "$dir/.corpus-sha" ] && [ "$(cat "$dir/.corpus-sha")" = "$sha" ]; then
+    return 0
+  fi
+  rm -rf "$dir"
+  mkdir -p "$dir"
+  ( cd "$dir" \
+    && git init --quiet \
+    && git remote add origin "$url" \
+    && git fetch --quiet --depth 1 origin "$sha" \
+    && git checkout --quiet FETCH_HEAD ) || return 1
+  printf '%s' "$sha" > "$dir/.corpus-sha"
+}
+
+# Counts diagnostics javac actually raised. Note: lines are excluded on purpose - they are how
+# processors report ordinary information and are not a broken build.
+diagnostics() {
+  grep -cE "^[^ ].*: (error|warning):" "$1" 2>/dev/null || true
+}
+
+status=0
+repos_run=0
+total_visited=0
+total_annotated=0
+printf "%-16s %-7s %-18s %-9s %-8s %-9s %s\n" \
+  REPO FILES "EXIT ctrl/vt" "DIAGS c/v" WROTE MEMBERS TYPE-ANN
+
+while IFS=$'\t' read -r name url sha src pom licence why; do
+  case "$name" in ''|'#'*) continue ;; esac
+  if [ "$#" -gt 0 ]; then
+    case " $* " in *" $name "*) ;; *) continue ;; esac
+  fi
+
+  if ! fetch_repo "$name" "$url" "$sha"; then
+    echo "FAIL: could not fetch $name at $sha" >&2
+    status=1
+    continue
+  fi
+
+  dir="$CACHE/$name"
+  if [ ! -d "$dir/$src" ]; then
+    echo "FAIL: $name has no source root at $src (pinned SHA moved it?)" >&2
+    status=1
+    continue
+  fi
+
+  # The repo's own dependencies, resolved by its own build, so its sources actually attribute.
+  # Without this the model is full of error types and every assertion below weakens.
+  if [ ! -s "$dir/.corpus-cp" ]; then
+    ( cd "$dir" && mvn -q -f "$pom" dependency:build-classpath \
+        "-Dmdep.outputFile=$dir/.corpus-cp" >"$dir/.corpus-mvn.log" 2>&1 ) || true
+  fi
+  dep_cp=$(cat "$dir/.corpus-cp" 2>/dev/null || printf '')
+
+  # module-info.java is excluded: it needs modules that are not on this path, and the corpus is
+  # about ordinary compilation units rather than JPMS resolution.
+  ( cd "$dir" && find "$src" -name "*.java" ! -name "module-info.java" > .corpus-sources )
+  files=$(wc -l < "$dir/.corpus-sources" | tr -d ' ')
+
+  vt_root="$dir/.corpus-vibetags-root"
+  rm -rf "$vt_root" "$dir/.corpus-ctrl" "$dir/.corpus-vt"
+  mkdir -p "$vt_root" "$dir/.corpus-ctrl" "$dir/.corpus-vt"
+
+  cp_arg=""
+  [ -n "$dep_cp" ] && cp_arg="-cp $dep_cp"
+
+  # Control. Not piped: a pipeline reports the last stage's status, and this exit code is half
+  # of assertion 1.
+  ( cd "$dir" && javac -proc:none -nowarn -encoding UTF-8 $cp_arg \
+      -d "$(winpath "$dir/.corpus-ctrl")" @.corpus-sources ) > "$dir/.corpus-ctrl.log" 2>&1
+  ctrl_exit=$?
+
+  # Treatment: identical, plus VibeTags and the auditor.
+  ( cd "$dir" && javac -nowarn -encoding UTF-8 $cp_arg \
+      -processorpath "$FULL_CP" \
+      -processor se.deversity.vibetags.processor.AIGuardrailProcessor,corpus.ElementNamingAuditor \
+      "-Avibetags.root=$(winpath "$vt_root")" \
+      "-Acorpus.report=$(winpath "$dir/.corpus-report")" \
+      -d "$(winpath "$dir/.corpus-vt")" @.corpus-sources ) > "$dir/.corpus-vt.log" 2>&1
+  vt_exit=$?
+
+  ctrl_diag=$(diagnostics "$dir/.corpus-ctrl.log")
+  vt_diag=$(diagnostics "$dir/.corpus-vt.log")
+
+  # Assertion 3. vibetags.log is documented and expected; anything else is a file created in a
+  # project that never opted in.
+  wrote=$(find "$vt_root" -type f ! -name "vibetags.log" | wc -l | tr -d ' ')
+
+  visited=$(sed -n 's/^VISITED\t//p' "$dir/.corpus-report" 2>/dev/null | head -1)
+  mismatches=$(sed -n 's/^MISMATCHES\t//p' "$dir/.corpus-report" 2>/dev/null | head -1)
+  annotated=$(sed -n 's/^ANNOTATED\t//p' "$dir/.corpus-report" 2>/dev/null | head -1)
+  visited=${visited:-0}
+  mismatches=${mismatches:-0}
+  annotated=${annotated:-0}
+  total_annotated=$((total_annotated + annotated))
+
+  printf "%-16s %-7s %-18s %-9s %-8s %-9s %s\n" \
+    "$name" "$files" "$ctrl_exit/$vt_exit" "$ctrl_diag/$vt_diag" "$wrote" "$visited" "$annotated"
+
+  repos_run=$((repos_run + 1))
+  total_visited=$((total_visited + visited))
+
+  if [ "$ctrl_exit" -ne "$vt_exit" ]; then
+    echo "FAIL: $name exits $vt_exit with VibeTags and $ctrl_exit without it." >&2
+    echo "      Adding VibeTags to a build must not change whether it succeeds." >&2
+    grep -E ": (error|warning):" "$dir/.corpus-vt.log" | head -10 >&2
+    status=1
+  fi
+  if [ "$vt_diag" -gt "$ctrl_diag" ]; then
+    echo "FAIL: $name raises $vt_diag diagnostics with VibeTags against $ctrl_diag without." >&2
+    echo "      A processor that turns a clean build noisy has broken the same promise." >&2
+    diff <(grep -E ": (error|warning):" "$dir/.corpus-ctrl.log" | sort) \
+         <(grep -E ": (error|warning):" "$dir/.corpus-vt.log" | sort) | head -10 >&2
+    status=1
+  fi
+  if [ "$wrote" -ne 0 ]; then
+    echo "FAIL: $name had $wrote file(s) written into a project that never opted in:" >&2
+    find "$vt_root" -type f ! -name "vibetags.log" | head -10 >&2
+    status=1
+  fi
+  if [ "$visited" -lt 1 ]; then
+    echo "FAIL: the auditor visited no members in $name, so its result means nothing." >&2
+    status=1
+  fi
+  if [ "$mismatches" -ne 0 ]; then
+    echo "FAIL: $name has $mismatches member(s) whose ElementNaming path differs from javac's." >&2
+    echo "      That string is the element identity in .vibetags-locks and in rule filenames." >&2
+    grep "^MISMATCH" "$dir/.corpus-report" | head -10 >&2
+    status=1
+  fi
+done < "$MANIFEST"
+
+echo
+if [ "$repos_run" -eq 0 ]; then
+  echo "FAIL: no corpus repo ran. An empty corpus reports success while checking nothing." >&2
+  exit 1
+fi
+if [ "$status" -eq 0 ]; then
+  echo "OK: $repos_run repositories, $total_visited members audited."
+  echo "    VibeTags changed no exit code, added no diagnostic, and wrote no file."
+  echo "    $total_annotated member(s) differ from javac by a type-use annotation only, which is"
+  echo "    deliberate (ElementNaming.typeString): the identity is the signature, not its"
+  echo "    annotations. Every other member renders exactly as javac renders it."
+fi
+exit "$status"

--- a/corpus/showcase/CorpusShowcase.java.tmpl
+++ b/corpus/showcase/CorpusShowcase.java.tmpl
@@ -1,0 +1,134 @@
+package __PACKAGE__;
+
+import se.deversity.vibetags.annotations.AIAudit;
+import se.deversity.vibetags.annotations.AIBannedApi;
+import se.deversity.vibetags.annotations.AIContext;
+import se.deversity.vibetags.annotations.AIContract;
+import se.deversity.vibetags.annotations.AICore;
+import se.deversity.vibetags.annotations.AIGenerated;
+import se.deversity.vibetags.annotations.AIIgnore;
+import se.deversity.vibetags.annotations.AIImmutable;
+import se.deversity.vibetags.annotations.AIInputSanitized;
+import se.deversity.vibetags.annotations.AIKeepInSync;
+import se.deversity.vibetags.annotations.AILoadBearing;
+import se.deversity.vibetags.annotations.AILocked;
+import se.deversity.vibetags.annotations.AIPerformance;
+import se.deversity.vibetags.annotations.AIPrivacy;
+import se.deversity.vibetags.annotations.AIPublicAPI;
+import se.deversity.vibetags.annotations.AISecure;
+import se.deversity.vibetags.annotations.AISecureLogging;
+import se.deversity.vibetags.annotations.AITestDriven;
+import se.deversity.vibetags.annotations.AIThreadSafe;
+
+/**
+ * Compiled inside a third-party repository, with that repository's classpath and compiler
+ * settings, to exercise every level a guardrail can attach to and both tiers at once.
+ *
+ * <p>Injected by corpus/run-corpus.sh into a package of its own under the repo's source root,
+ * never committed anywhere and removed with `git checkout -- .` after the run. It is deliberately
+ * plain Java: the corpus spans repositories targeting Java 8 through 17, and a record here would
+ * limit where it can go.
+ *
+ * <p>The split it demonstrates is the one CLAUDE.md's invariant 6 describes. Six safety
+ * annotations stay inline in the Tier-1 aggregate because a guardrail that only loads once the
+ * agent opens the file it protects has become a comment. Everything else moves to Tier 3 and is
+ * replaced by a pointer.
+ */
+@AIContext(focus = "corpus showcase: type level, non-safety, belongs in the granular tier",
+           avoids = "asserting anything about the third-party code around it")
+@AIPublicAPI
+public class CorpusShowcase {
+
+    // ---- field level -------------------------------------------------------------------
+
+    /** Safety tier: privacy stays inline in the aggregate. */
+    @AIPrivacy(reason = "corpus showcase FIELD-PRIVACY: PII must never be logged")
+    private String billingEmail;
+
+    /** Granular tier: same field, a second annotation that moves down. */
+    @AISecureLogging
+    private String authToken;
+
+    /** Granular tier: a performance budget on a plain field. */
+    @AIPerformance(constraint = "corpus showcase FIELD-PERFORMANCE: read on every request")
+    private long tenantId;
+
+    // ---- constructor level: there isn't one ---------------------------------------------
+    //
+    // No annotation declares ElementType.CONSTRUCTOR, so a constructor cannot carry a guardrail.
+    // Measured, not assumed: nothing under vibetags-annotations mentions CONSTRUCTOR at all.
+    // ElementNaming still renders constructors, because javac hands them to the collector as
+    // enclosed elements of an annotated type, which is why ElementNamingFormatParityTest covers
+    // the shape. The levels a guardrail can actually attach to are package, type, field, method
+    // and parameter.
+
+    // ---- method level, safety tier -----------------------------------------------------
+
+    @AILocked(reason = "corpus showcase METHOD-LOCKED: do not edit")
+    public long invoiceNumber(long id) {
+        return id;
+    }
+
+    @AIAudit(checkFor = {"SQL injection", "path traversal"})
+    public void audited(String query) {
+    }
+
+    @AISecure(aspect = "corpus showcase METHOD-SECURE")
+    public void secured() {
+    }
+
+    @AIIgnore(reason = "corpus showcase METHOD-IGNORE: excluded from context")
+    public void ignored() {
+    }
+
+    // ---- method level, granular tier, and the parameter level --------------------------
+
+    /**
+     * The parameter annotation is the finest addressing VibeTags produces, and the only level a
+     * hand-written rules file cannot express at all.
+     */
+    @AIContract(reason = "corpus showcase METHOD-CONTRACT: callers depend on this shape")
+    @AIPerformance(constraint = "corpus showcase METHOD-PERFORMANCE: no allocation in the loop")
+    public String render(
+            @AIInputSanitized({AIInputSanitized.SanitizerType.SQL_INJECTION,
+                               AIInputSanitized.SanitizerType.XSS}) String customerNote,
+            @AILoadBearing(invariant = "corpus showcase PARAM-LOADBEARING: order matters here")
+            String other) {
+        return customerNote + other;
+    }
+
+    @AITestDriven(coverageGoal = 95)
+    public void tested() {
+    }
+
+    @AIThreadSafe(note = "corpus showcase METHOD-THREADSAFE")
+    public void threadSafe() {
+    }
+
+    @AILoadBearing(invariant = "corpus showcase METHOD-LOADBEARING: looks removable, is not")
+    public void loadBearing() {
+    }
+
+    @AIKeepInSync(mirrors = {"corpus/showcase/CorpusShowcase.java.tmpl"})
+    public void mirrored() {
+    }
+
+    @AIBannedApi(forbidden = {"java.util.Date"}, useInstead = "java.time.Instant")
+    public void bannedApis() {
+    }
+
+    @AIGenerated(from = "corpus/showcase/CorpusShowcase.java.tmpl")
+    public void generated() {
+    }
+
+    // ---- nested type level -------------------------------------------------------------
+
+    /** Safety tier at a nested type, which is where a flat "package.Type.member" model breaks. */
+    @AIImmutable(note = "corpus showcase NESTED-IMMUTABLE")
+    @AICore(sensitivity = "high", note = "corpus showcase NESTED-CORE")
+    public static final class Inner {
+        @AILocked(reason = "corpus showcase NESTED-METHOD-LOCKED")
+        public void innerMethod() {
+        }
+    }
+}

--- a/corpus/showcase/package-info.java.tmpl
+++ b/corpus/showcase/package-info.java.tmpl
@@ -1,0 +1,15 @@
+/**
+ * The package level, which is its own element kind and its own compilation unit.
+ *
+ * <p>Thirteen of the annotations accept {@code ElementType.PACKAGE}, and a package-level guardrail
+ * covers every class underneath it, so a stale one misdescribes more code than any other kind.
+ * It is also the only level that has no member to hang off, which makes it the one most easily
+ * dropped by a renderer that assumes every guardrail has an owning type.
+ */
+@AIArchitecture(belongsTo = "corpus showcase PACKAGE-ARCHITECTURE",
+                cannotReference = {"corpus showcase forbidden layer"})
+@AISecure(aspect = "corpus showcase PACKAGE-SECURE")
+package __PACKAGE__;
+
+import se.deversity.vibetags.annotations.AIArchitecture;
+import se.deversity.vibetags.annotations.AISecure;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -108,12 +108,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   treatment exits exactly as the control did, raises no diagnostic the control did not, writes
   nothing into a project that never opted in, and renders every member the way javac does.
 
-  Then a second phase, because non-interference is only half the question. Two real elements per
-  repo are annotated in the clone, the platform files are created empty to opt in, and the output
-  is read back: opting in produces content, the marker pair is present, every annotated element
-  reaches the file, and no generated identity carries a type-use annotation. That last one is the
-  assertion the parity comparison structurally cannot make, since it can only find disagreement
-  between VibeTags and javac and not a mistake they share. It found one immediately.
+  Then a second phase, because non-interference is only half the question. **Claude, Gemini and
+  Codex are all opted in, aggregate and granular**, and the output is read back. Two real elements
+  of the repo's own code are annotated, plus a showcase compiled into a package of its own that
+  carries a guardrail at every level one can attach to: package, type, nested type, field, method
+  and parameter, across both the safety tier and the granular tier.
+
+  Codex needs its marker pair seeded, because invariant 4 means an empty `AGENTS.md` alongside
+  other platforms is dropped from the active set rather than written. The corpus asserts
+  `AGENTS.md` grew beyond that pair, since "dropped" and "working" look identical otherwise.
+
+  Ten assertions cover the result, and the two worth naming are the ones that keep the rest from
+  rotting. **The tier split** is invariant 6 checked on somebody else's code: `@AIPrivacy` must
+  still be inline in the aggregate, `@AIContract` must not be, and must instead be in the rules
+  directory. Wrong in one direction and safety guardrails become comments that load only once the
+  agent already opened the file; wrong in the other and the aggregate bloats. **The richness
+  floor** requires at least 15 distinct showcase guardrails to reach a generated file, because
+  every other assertion names one guardrail and would still pass if half the annotation surface
+  quietly stopped rendering. 15 is measured from a green run, not chosen.
+
+  Full detail, including the three defects the corpus found and why none of its assertions could
+  have found the others, is in [corpus/README.md](../corpus/README.md).
 
   Measured on the first green run: 6 repositories, roughly 495 files, **15,683 members audited**,
   no exit code changed, no diagnostic added, no file written. The corpus contributes what the
@@ -124,8 +139,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Nothing is vendored: sources are cloned at build time into `target/corpus` and never committed,
   so no third-party code enters this repository. Pins are commit SHAs rather than branches, so an
   upstream push cannot turn this repository's CI red for a reason nobody here changed, and bumping
-  them stays a decision somebody makes. The corpus found the type-use annotation divergence above
-  the first time it ran. (#480)
+  them stays a decision somebody makes.
+
+  What it has been worth so far, stated as findings rather than as a claim: **three defects, each
+  caught by a different assertion, none of which could have found the others.** Type-use
+  annotations reaching an element identity for declared types, caught on the first run by the
+  parity check. The same annotations surviving on a *type variable*, invisible to that check
+  because javac renders it identically, and caught only by generating output and reading it back.
+  And the corpus itself running against an unresolved classpath on a cold CI runner, where both
+  the control and the treatment failed identically so every comparison passed while checking
+  nothing. The third one was a defect in the harness, and it is the reason there is now an
+  assertion that a corpus member must compile before anything is concluded from it.
+
+  A fourth thing it settled is not a defect but a fact worth writing down: **no annotation
+  declares `ElementType.CONSTRUCTOR`**, so a constructor cannot carry a guardrail. That was found
+  by trying to annotate one. (#480)
 
 - **CI compiles a fixture under a real ECJ and checks the degradation the docs promise.**
   `docs/PROCESSOR.md` and `USAGE.md` both state that VibeTags degrades rather than fails under a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -74,7 +74,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wildcards, bounded and unbounded generic methods, an overload set, a constructor, a nested type
   and an enum. Found by the ECJ CI leg on its first run. (#480)
 
+  **One deliberate difference from javac, and it moves output for some consumers.** javac's
+  rendering includes JSR-308 type-use annotations, so an annotated parameter reads as
+  `java.lang.@org.jspecify.annotations.Nullable String`. The derivation drops them, which means a
+  project using jspecify or the Checker Framework will see element paths change in its generated
+  files and in `.vibetags-locks`. That is the intended behaviour rather than an oversight:
+  keeping the annotation would put it into a granular rule *filename*, so adding or removing a
+  `@Nullable` would rename a committed file and stop a lock matching, for a change that does not
+  alter the signature. The identity is the signature, not its annotations. No fixture in this
+  repository used a type-use annotation, so nothing here noticed; the third-party corpus below
+  did, on its first run.
+
 ### Added
+
+- **A corpus of real third-party Java, compiled with and without VibeTags on every CI run.**
+  Every fixture in this repository was written by somebody who knew what VibeTags does, and that
+  is the wrong sample: the code VibeTags has to survive was written by people who had never heard
+  of it. `corpus/` pins six permissively licensed libraries to commit SHAs and compiles each one
+  twice with identical sources, classpath and flags, differing only in whether VibeTags is on the
+  processor path.
+
+  Four assertions, each against the control rather than against a hard-coded expectation, so a
+  repo that does not compile on its own is reported as such instead of blamed on VibeTags: the
+  treatment exits exactly as the control did, raises no diagnostic the control did not, writes
+  nothing into a project that never opted in, and renders every member the way javac does.
+
+  Measured on the first green run: 6 repositories, roughly 495 files, **15,683 members audited**,
+  no exit code changed, no diagnostic added, no file written. The corpus contributes what the
+  fixtures cannot: 15 `package-info` files and 279 generic sources from commons-io, varargs
+  density from jimfs, records from record-builder, Java 17 from semver4j, and an annotation
+  library whose own processor runs alongside VibeTags.
+
+  Nothing is vendored: sources are cloned at build time into `target/corpus` and never committed,
+  so no third-party code enters this repository. Pins are commit SHAs rather than branches, so an
+  upstream push cannot turn this repository's CI red for a reason nobody here changed, and bumping
+  them stays a decision somebody makes. The corpus found the type-use annotation divergence above
+  the first time it ran. (#480)
 
 - **CI compiles a fixture under a real ECJ and checks the degradation the docs promise.**
   `docs/PROCESSOR.md` and `USAGE.md` both state that VibeTags degrades rather than fails under a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -85,6 +85,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   repository used a type-use annotation, so nothing here noticed; the third-party corpus below
   did, on its first run.
 
+  A **type variable** kept its annotation even so, because it had no structural route and fell
+  through to `toString()`, so `jimfs` generated
+  `JimfsAsynchronousFileChannel.<A>lock(long,long,boolean,@org.jspecify.annotations.Nullable A,…)`
+  into `CLAUDE.md` and `.vibetags-locks`. The parity check could not see it: javac renders that
+  the same way, so the two agreed and nothing fired. Only generating output on annotated
+  third-party code and reading it back exposed it. Type variables now resolve through
+  `asElement()` like every other type, and anything left with no structural route has its
+  annotations stripped rather than trusted. (#480)
+
 ### Added
 
 - **A corpus of real third-party Java, compiled with and without VibeTags on every CI run.**
@@ -98,6 +107,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   repo that does not compile on its own is reported as such instead of blamed on VibeTags: the
   treatment exits exactly as the control did, raises no diagnostic the control did not, writes
   nothing into a project that never opted in, and renders every member the way javac does.
+
+  Then a second phase, because non-interference is only half the question. Two real elements per
+  repo are annotated in the clone, the platform files are created empty to opt in, and the output
+  is read back: opting in produces content, the marker pair is present, every annotated element
+  reaches the file, and no generated identity carries a type-use annotation. That last one is the
+  assertion the parity comparison structurally cannot make, since it can only find disagreement
+  between VibeTags and javac and not a mistake they share. It found one immediately.
 
   Measured on the first green run: 6 repositories, roughly 495 files, **15,683 members audited**,
   no exit code changed, no diagnostic added, no file written. The corpus contributes what the

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -137,6 +137,38 @@ The same `.github/actions/verify-generated-files` composite action runs after th
 
 Mutation testing used to be a job here. It now lives in its own manually triggered workflow — see section 7.
 
+### Job: `corpus`
+
+Real third-party Java, compiled twice. `corpus/run-corpus.sh` clones six permissively licensed
+libraries at pinned commit SHAs and compiles each one with and without VibeTags on the processor
+path, with identical sources, classpath and flags.
+
+It exists because every fixture in this repository was written by somebody who knew what VibeTags
+does, and that is the wrong sample. The code VibeTags actually has to survive was written by
+people who had never heard of it: deeper nesting, generic signatures nobody would invent for a
+test, `package-info` files, records, and a module whose own annotation processor is already
+running.
+
+Four assertions, each **against the control** rather than a hard-coded expectation, so a repo
+that does not compile on its own is reported as such instead of being blamed on VibeTags:
+
+1. **The treatment exits exactly as the control did.** Adding VibeTags to a build must not fail it.
+2. **No diagnostic the control did not raise.** A processor that turns a clean build noisy has
+   broken the same promise more quietly.
+3. **Nothing written to the VibeTags root.** File presence is the only opt-in and none of these
+   repos opted in. `vibetags.log` is the documented exception.
+4. **`ElementNaming` renders every member the way javac does.**
+   `ElementNamingFormatParityTest` checks that against a 26-member fixture; this checks it
+   against roughly 15,700 members nobody chose.
+
+The checkouts are cached on `corpus/repos.tsv`'s hash, so most runs do no network at all, and
+pins are SHAs so an upstream push cannot turn this repository red. Nothing is vendored.
+
+Assertion 4 found a real divergence the first time it ran: javac includes JSR-308 type-use
+annotations in its rendering and VibeTags deliberately does not, which moves output for any
+consumer using jspecify or the Checker Framework. [corpus/README.md](../corpus/README.md) has
+the reasoning and the full repo table.
+
 ### Job: `ecj-degradation`
 
 The one leg that does not run javac. `scripts/ecj-degradation-check.sh` compiles

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -161,6 +161,16 @@ that does not compile on its own is reported as such instead of being blamed on 
    `ElementNamingFormatParityTest` checks that against a 26-member fixture; this checks it
    against roughly 15,700 members nobody chose.
 
+Assertion 0 comes before all of them: the control has to compile. Otherwise a repo that cannot
+compile passes 1 and 2 trivially, both sides failing identically, while 3 and 4 run against a
+model of error types.
+
+A second phase then opts **Claude, Gemini and Codex** in, aggregate and granular, annotates two
+real elements plus a showcase covering every level a guardrail attaches to (package, type, nested
+type, field, method, parameter) in both tiers, and reads the output back. Ten more assertions,
+including the tier split (invariant 6 on somebody else's code) and a richness floor that fails if
+fewer than 15 distinct showcase guardrails reach a generated file.
+
 The checkouts are cached on `corpus/repos.tsv`'s hash, so most runs do no network at all, and
 pins are SHAs so an upstream push cannot turn this repository red. Nothing is vendored.
 

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ElementNaming.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ElementNaming.java
@@ -135,6 +135,20 @@ public final class ElementNaming {
      * Renders a type the way javac's own {@code toString()} does: qualified names for declared
      * types, type arguments kept and comma-separated with no spaces, and a trailing {@code ...}
      * for the last parameter of a varargs method.
+     *
+     * <p><b>With one deliberate exception: type-use annotations are dropped.</b> javac renders an
+     * annotated parameter as {@code java.lang.@org.jspecify.annotations.Nullable String}, and
+     * reproducing that would put the annotation into the element's identity. That identity is
+     * matched against a pull request's diff by {@code action/locked-files} and turned into a rule
+     * filename by {@link #granularQName}, where it becomes
+     * {@code ...parse-java-lang--org-jspecify-annotations-Nullable-String-}. Adding or removing a
+     * {@code @Nullable} would then rename a committed rule file and stop a lock matching, for a
+     * change that does not alter the signature at all.
+     *
+     * <p>So the identity is the signature, not its annotations. This is checked rather than
+     * assumed: the third-party corpus (see {@code corpus/README.md}) compiles jspecify-annotated
+     * libraries and asserts that annotations are the <em>only</em> thing this renders differently
+     * from javac.
      */
     private static String typeString(TypeMirror type, boolean varargs) {
         if (varargs && type instanceof ArrayType array) {

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ElementNaming.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ElementNaming.java
@@ -12,6 +12,7 @@ import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
 import javax.lang.model.type.WildcardType;
 
 import java.util.List;
@@ -51,6 +52,51 @@ public final class ElementNaming {
      */
     public static String granularQName(Element element) {
         return qualifiedName(element).replace('.', '-').replaceAll("[^a-zA-Z0-9-]", "-");
+    }
+
+    /**
+     * Takes type-use annotations back off a rendering that came from {@code toString()}: an
+     * {@code @}, the qualified annotation name, any parenthesised arguments, and the space javac
+     * writes after it.
+     *
+     * <p>Only reached for the types with no structural route: an error type under an incomplete
+     * classpath, an intersection, a language feature newer than this code. Those are exactly the
+     * cases where nobody is watching, which is why they are stripped rather than trusted, and the
+     * third-party corpus generates real output for jspecify-annotated libraries to check it.
+     *
+     * <p>Scanned by hand rather than with a regular expression. The obvious pattern here nests a
+     * quantifier inside an optional group, which SpotBugs' ReDOS detector rejects, and a linear
+     * scan over a type name is both faster and easier to read than the possessive-quantifier
+     * version that would satisfy it.
+     */
+    private static String stripAnnotations(String rendered) {
+        if (rendered.indexOf('@') < 0) {
+            return rendered;
+        }
+        StringBuilder out = new StringBuilder(rendered.length());
+        int i = 0;
+        while (i < rendered.length()) {
+            char c = rendered.charAt(i);
+            if (c != '@') {
+                out.append(c);
+                i++;
+                continue;
+            }
+            i++; // the '@'
+            while (i < rendered.length()
+                   && (Character.isLetterOrDigit(rendered.charAt(i))
+                       || rendered.charAt(i) == '_' || rendered.charAt(i) == '.')) {
+                i++;
+            }
+            if (i < rendered.length() && rendered.charAt(i) == '(') {
+                int close = rendered.indexOf(')', i);
+                i = close < 0 ? rendered.length() : close + 1;
+            }
+            while (i < rendered.length() && Character.isWhitespace(rendered.charAt(i))) {
+                i++;
+            }
+        }
+        return out.toString();
     }
 
     /**
@@ -178,13 +224,23 @@ public final class ElementNaming {
             }
             return sb.toString();
         }
+        if (type instanceof TypeVariable variable) {
+            // Read through to the declaring element rather than taking toString(). A type
+            // variable at an annotated use renders as "@org.jspecify.annotations.Nullable A",
+            // and that annotation would then be part of the element's identity - the one thing
+            // the whole derivation exists to avoid. The declared parameters get the same
+            // treatment above; this is the use site.
+            Element declared = variable.asElement();
+            String name = declared == null ? "" : simpleNameOf(declared);
+            return name.isEmpty() ? stripAnnotations(type.toString()) : name;
+        }
         if (type.getKind().isPrimitive() || type.getKind() == TypeKind.VOID) {
             return type.getKind().name().toLowerCase(Locale.ROOT);
         }
-        // Type variables, error types under an incomplete classpath, and anything a future
-        // language version adds. toString() is the only thing left, and for a type variable both
-        // compilers print the variable's name, which is what javac renders here anyway.
-        return type.toString();
+        // Error types under an incomplete classpath, intersections, and anything a future
+        // language version adds. toString() is all that is left, with any annotations taken back
+        // off so an exotic type cannot smuggle one into the identity either.
+        return stripAnnotations(type.toString());
     }
 
     /**

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ElementNamingFormatParityTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ElementNamingFormatParityTest.java
@@ -120,25 +120,70 @@ class ElementNamingFormatParityTest {
                 + "PR diff against) and renames granular rule files.");
     }
 
+    /** A fixture whose parameters carry a JSR-308 type-use annotation. */
+    private static final String ANNOTATED_FIXTURE = """
+        package fixture;
+
+        import org.jspecify.annotations.Nullable;
+
+        public class Annotated {
+            public void takesNullable(@Nullable String a, int b) {}
+            public void returnsAndTakes(@Nullable Object o) {}
+        }
+        """;
+
+    @Test
+    @DisplayName("a type-use annotation is left out of the element's identity, on purpose")
+    void typeUseAnnotationsAreNotPartOfTheIdentity() throws IOException {
+        javacRendering.clear();
+        derivedRendering.clear();
+        compile(ANNOTATED_FIXTURE, "Annotated");
+
+        // javac renders the parameter as java.lang.@org.jspecify.annotations.Nullable String.
+        String annotatedByJavac = javacRendering.stream()
+            .filter(s -> s.contains("takesNullable"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError(
+                "the fixture no longer produces an annotated parameter, so this checks nothing: "
+                    + javacRendering));
+        assertTrue(annotatedByJavac.contains("@org.jspecify.annotations.Nullable"),
+            "javac stopped putting type-use annotations in its rendering, which is the whole "
+                + "premise of this test: " + annotatedByJavac);
+
+        String derived = derivedRendering.get(javacRendering.indexOf(annotatedByJavac));
+        assertEquals("fixture.Annotated.takesNullable(java.lang.String,int)", derived,
+            "ElementNaming must render the signature without the annotation. This string is the "
+                + "element's identity: action/locked-files matches a pull request's diff against "
+                + "it, and granularQName turns it into a rule filename. Including the annotation "
+                + "would rename a committed rule file, and break a lock match, every time a "
+                + "@Nullable was added or removed without the signature changing.");
+    }
+
     private void compileFixture() throws IOException {
+        compile(FIXTURE, "Shapes");
+    }
+
+    private void compile(String sourceText, String simpleName) throws IOException {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         assertTrue(compiler != null,
             "no system java compiler — this test compares against javac and cannot run without it");
 
         try (StandardJavaFileManager files = compiler.getStandardFileManager(null, null, null)) {
             JavaFileObject source = new SimpleJavaFileObject(
-                URI.create("string:///fixture/Shapes.java"), JavaFileObject.Kind.SOURCE) {
+                URI.create("string:///fixture/" + simpleName + ".java"), JavaFileObject.Kind.SOURCE) {
                 @Override
                 public CharSequence getCharContent(boolean ignoreEncodingErrors) {
-                    return FIXTURE;
+                    return sourceText;
                 }
             };
 
             JavaCompiler.CompilationTask task = compiler.getTask(
                 null, files, null,
                 // -proc:only: the fixture never needs to become bytecode, and skipping the rest of
-                // the pipeline keeps the test to the model it is actually asserting about.
-                List.of("-proc:only"), null, List.of(source));
+                // the pipeline keeps the test to the model it is actually asserting about. The
+                // classpath is this JVM's, so the annotated fixture can resolve jspecify.
+                List.of("-proc:only", "-cp", System.getProperty("java.class.path")),
+                null, List.of(source));
             task.setProcessors(List.of(new Collector()));
             assertTrue(task.call(), "the fixture failed to compile");
         }


### PR DESCRIPTION
Every fixture in this repository was written by somebody who knew what VibeTags does. `examples/basic` has the annotations a demo needs; `GuardrailModels` has the members a test author thought of. That is the wrong sample — the code VibeTags has to survive was written by people who had never heard of it.

`corpus/` pins **six permissively licensed libraries** to commit SHAs and compiles each **twice**: identical sources, classpath and flags, differing only in whether VibeTags is on the processor path.

## It found a real bug on its first run

That is the argument for having it. javac's rendering includes JSR-308 type-use annotations:

```
javac   : org.semver4j.Semver.parse(java.lang.@org.jspecify.annotations.Nullable String)
derived : org.semver4j.Semver.parse(java.lang.String)
```

The structural derivation introduced in **#480** drops them. So **any consumer using jspecify or the Checker Framework would have seen their element paths move** when #480 landed — in generated files and in `.vibetags-locks`. No fixture in this repository uses a type-use annotation, so nothing here noticed. 54 members across the two jspecify-using repos; the other four match javac exactly across ~13,300 members.

**Dropping them is correct**, and is now deliberate rather than accidental. Keeping them would put the annotation into a granular rule *filename*:

```
...parse-java-lang--org-jspecify-annotations-Nullable-String-
```

so adding or removing a `@Nullable` would rename a committed file and stop a lock matching, for a change that does not touch the signature. The identity is the signature, not its annotations. Now stated in `ElementNaming.typeString`, pinned by a new jspecify-annotated case in `ElementNamingFormatParityTest`, and recorded in the changelog as the consumer-visible change it is.

## What it asserts

Four assertions, each **against the control** rather than a hard-coded expectation, so a repo that does not compile on its own is reported as such instead of being blamed on VibeTags:

| # | Assertion | Protects |
|---|---|---|
| 1 | Treatment exits exactly as the control did | Adding VibeTags to a build must not fail it |
| 2 | No diagnostic the control did not raise | A processor that turns a clean build noisy broke the same promise, quietly |
| 3 | Nothing written to the VibeTags root | File presence is the only opt-in; none of these repos opted in |
| 4 | `ElementNaming` renders every member as javac does | That string is the element identity in `.vibetags-locks` and rule filenames |

First green run:

```
REPO             FILES   EXIT ctrl/vt       DIAGS c/v WROTE    MEMBERS   TYPE-ANN
commons-cli      36      0/0                0/0       0        1522      0
commons-codec    87      0/0                0/0       0        3252      0
commons-io       277     0/0                4/4       0        7972      0
jimfs            62      0/0                0/0       0        2316      36
record-builder   6       0/0                0/0       0        77        0
semver4j         27      0/0                0/0       0        544       18

OK: 6 repositories, 15683 members audited.
```

`ElementNamingFormatParityTest` checks assertion 4 against a 26-member fixture. This checks it against **15,683 members nobody chose**.

## The harness classifies, it does not tolerate

An annotation-only difference is reported as `TYPE-ANN` and passes; anything else fails. **Verified by breaking the derivation deliberately** — appending `_BROKEN` to every derived path produces 1522 mismatches on commons-cli and a red run, rather than being absorbed as "just annotations". Without that check, assertion 4 would degrade into a counter that never fires.

## The repos, chosen by measurement

Not picked by name. Construct counts were measured before each was added:

| Repo | Files | Licence | Contributes |
|---|---:|---|---|
| `commons-cli` | 36 | Apache-2.0 | Dependency-free; runs when dependency resolution is down |
| `commons-codec` | 87 | Apache-2.0 | 7 `package-info` files, 26 nested types |
| `commons-io` | 277 | Apache-2.0 | 15 `package-info` files, 279 generic sources, 86 nested types |
| `jimfs` | 62 | Apache-2.0 | Varargs- and generics-dense, NIO SPI, jspecify-annotated |
| `record-builder` | 6 | Apache-2.0 | Records, and its own processor running alongside VibeTags |
| `semver4j` | 27 | MIT | Java 17 rather than 8, jspecify-annotated |

## Licensing and CI safety

- **Nothing is vendored.** Sources are cloned at build time into `target/corpus` and never committed, so no third-party code enters this repository. All six are Apache-2.0 or MIT.
- **Pins are SHAs, not branches**, so an upstream push cannot turn this repository red for a reason nobody here changed. Bumping stays a decision somebody makes; `corpus/README.md` says why that is deliberately not automated.
- **Checkouts are cached** on `corpus/repos.tsv`'s hash, so most runs do no network at all.

## Verification

- `corpus/run-corpus.sh` — exit 0, output above.
- Negative probe — deliberate break gives a red run naming the mismatches.
- `mvn verify -Pe2e` — **2397 tests**, SpotBugs, PMD, CPD, checkstyle clean (Maven 3.9.16; the spotbugs plugin needs 3.8.9 and this machine defaults to 3.8.6).
- **`mvn clean compile -Pself-annotate -Dvibetags.selfcheck=true` from a deleted `.vibetags-cache`** — green, no generated file moved. Using CI's own command this time, not `compile` without `clean`, which is what let a regression through on #483.
- `gitleaks`, `end-of-file-fixer`, `trailing-whitespace` passed. `run-corpus.sh` committed `100755`.

### Gate not run here

The `checkstyle` pre-commit hook was skipped (needs Docker, not running). Not a pass; the Maven binding covers the same rules and passed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUjemLTYEwQHhjmztrrapT
