### PR TITLE
test(corpus): run VibeTags over real Kotlin, Groovy and Scala, and correct the Groovy claim

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1272,6 +1272,64 @@ jobs:
       - name: Run VibeTags over the corpus and compare against the control
         run: corpus/run-corpus.sh
 
+  # The same question in the three other JVM languages people ship, and none of them reaches the
+  # processor the way Java does: Kotlin only through kapt, Groovy only when joint compilation's
+  # javaAnnotationProcessing is switched on, and Scala not at all. USAGE.md has stated all three
+  # for several releases; this is the leg that runs them. Each repository is built twice by its
+  # own Gradle wrapper and the only difference is corpus/inject-vibetags.init.gradle. The Scala
+  # member asserts a negative on purpose: annotated Scala must generate nothing, while the Java
+  # half of the same build must generate everything. corpus/README.md has the rest.
+  corpus-jvm:
+    name: JVM-Language Corpus (Kotlin, Groovy, Scala)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      # Keyed on the manifest, the harness and the init script, so a pin bump or a change to how
+      # the injection works fetches afresh. The repositories are pinned to commits, so a hit is
+      # always the right source. Nothing derived is trusted from a hit: the processor classpath
+      # is resolved every run, because a classpath written by a failing run is indistinguishable
+      # from a good one once it is on disk.
+      - name: Cache the JVM-language corpus checkouts
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: target/corpus-jvm
+          key: corpus-jvm-${{ hashFiles('corpus/repos-jvm.tsv', 'corpus/run-corpus-jvm.sh', 'corpus/inject-vibetags.init.gradle') }}
+
+      # Six Gradle builds run here, each with --rerun-tasks. Without a warm Gradle cache every
+      # one of them re-downloads a distribution and a dependency graph, which is most of this
+      # job's wall clock and none of what it is measuring.
+      - name: Cache the Gradle distributions and dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: corpus-jvm-gradle-${{ hashFiles('corpus/repos-jvm.tsv') }}
+          restore-keys: corpus-jvm-gradle-
+
+      - name: Install VibeTags Annotations and Processor (Maven)
+        run: |
+          cd vibetags-annotations
+          mvn install -B -q -DskipTests
+          cd ../vibetags
+          mvn install -B -q -DskipTests
+
+      - name: Run VibeTags over Kotlin, Groovy and Scala and compare against the control
+        run: corpus/run-corpus-jvm.sh
+
   # The one leg that does not run javac. docs/PROCESSOR.md and USAGE.md both promise that
   # VibeTags degrades - loses @AILocked positions, keeps every guardrail - under a compiler
   # with no Tree API, and nothing verified either sentence. The paths behind them are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,9 @@ cd examples/basic && mvn clean compile     # consumer fixture; library must be i
 - Per-element guardrails: the generated block below indexes `.claude/rules/`, loaded on demand
   by glob. Whether the rules in this file actually bind an agent is measured, not assumed:
   [evals/README.md](evals/README.md).
+- Third-party corpus: `corpus/run-corpus.sh` (Java, javac) and `corpus/run-corpus-jvm.sh`
+  (Kotlin, Groovy, Scala, each built by its own Gradle). Both run in CI on every PR;
+  [corpus/README.md](corpus/README.md) says what each asserts and what they have found.
 - Run `pre-commit run --all-files` after `git add`, before committing.
 
 ## Reference docs (read on demand)

--- a/USAGE.md
+++ b/USAGE.md
@@ -128,7 +128,7 @@ matrix, and adding one never touches the processor.
 |---|---|---|
 | Java | Full | javac runs the processor directly |
 | Kotlin | Full (kapt) | kapt generates Java stubs and runs JSR 269 processors over them |
-| Groovy | Full (joint compilation) | groovyc generates Java stubs; `javaAnnotationProcessing = true` runs processors over them |
+| Groovy | Types and methods only (joint compilation) | groovyc generates Java stubs; `javaAnnotationProcessing = true` runs processors over them. The stubs carry no fields, so **field-level annotations are dropped** — see below |
 | Scala | Java sources only | scalac has no JSR 269 support; annotated Scala classes compile but are never seen |
 | Clojure | Not possible | no javac in the pipeline, and Clojure metadata annotations emit only CLASS/RUNTIME retention into bytecode — `SOURCE` annotations cannot be expressed at all |
 
@@ -149,9 +149,36 @@ tasks.withType(GroovyCompile).configureEach {
 }
 ```
 
-The stub caveats are the same as kapt's: no method bodies (body-scoped annotations are
-invisible) and stub-relative source positions. Working consumer:
-[`examples/groovy/`](examples/groovy/README.md).
+The stub caveats are the same as kapt's — no method bodies, so body-scoped annotations are
+invisible, and stub-relative source positions — plus two that are Groovy's alone. Both were
+found by running VibeTags over third-party Groovy rather than over this repository's own
+example ([corpus/README.md](corpus/README.md)).
+
+- **Field-level annotations are dropped.** groovyc's stub carries the class, its constructors,
+  its methods and their parameters, and no fields at all. Not renamed, not moved onto a
+  generated accessor: absent. So `@AIPrivacy`, `@AISecureLogging`, `@AIPerformance` on a field,
+  and anything else targeting `ElementType.FIELD`, never reach the processor and generate
+  nothing. There is no warning, because nothing in the compilation ever sees the annotation.
+
+  `@AIPrivacy` is the one that stings: it is a safety-tier guardrail, it is the natural way to
+  mark a PII field, and in Groovy it silently does nothing. Declaring the field `private` does
+  not help — that only stops Groovy turning it into a property, and the stub omits it either
+  way. Put the guardrail on the accessor or the enclosing type instead, or keep the rule in the
+  hand-authored region outside the markers.
+
+  `corpus/run-corpus-jvm.sh` pins this: the Groovy showcase annotates fields on purpose, the
+  harness expects those two markers to be missing, and it fails if they ever start appearing —
+  so the day groovyc emits fields, this section gets rewritten instead of quietly aging.
+
+- **The compiling JDK must be 21 or newer, and a Gradle toolchain overrides the JDK you
+  launched with.** `java { toolchain { languageVersion = JavaLanguageVersion.of(17) } }` runs
+  javac from a JDK 17, which cannot load the processor: `class file version 65.0, this version
+  of the Java Runtime only recognizes class file versions up to 61.0`. The error names no
+  VibeTags file and does not mention the toolchain, so it reads like a corrupt jar. Two of the
+  Groovy projects the corpus surveyed fail this way. It applies to every language, but Groovy
+  and Kotlin Gradle plugins pin an older toolchain far more often than Java projects do.
+
+Working consumer: [`examples/groovy/`](examples/groovy/README.md).
 
 **Scala**: put guardrails on thin annotated Java types next to the Scala code they protect —
 javac compiles `src/main/java` normally in a mixed module. An `@AI*` annotation directly on

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -1,8 +1,12 @@
 # The third-party corpus
 
-Six real Java libraries, pinned to commits, compiled twice on every CI run: once without
-VibeTags and once with it. Nothing is vendored. The sources are cloned at build time into
-`target/corpus` and never committed, so no third-party code enters this repository.
+Nine real libraries, pinned to commits, compiled twice on every CI run: once without VibeTags and
+once with it. Six are Java, compiled by javac, and are what the first half of this document is
+about. The other three are Kotlin, Groovy and Scala, built by their own Gradle wrappers, and have
+[a harness and a section of their own](#the-other-three-jvm-languages).
+
+Nothing is vendored. The sources are cloned at build time into `target/corpus` and
+`target/corpus-jvm` and never committed, so no third-party code enters this repository.
 
 ```bash
 corpus/run-corpus.sh               # all of it
@@ -243,7 +247,189 @@ Chosen for variety rather than volume. The construct counts were measured, not e
 
 Roughly 495 files and 15,683 members in total.
 
-## Adding a repo
+## The other three JVM languages
+
+Everything above is Java, compiled by javac, because that is the compiler JSR 269 belongs to.
+`corpus/run-corpus-jvm.sh` asks the same questions of Kotlin, Groovy and Scala, and it is a
+separate harness rather than three more rows in `repos.tsv` because none of them reaches the
+processor the way Java does.
+
+```bash
+corpus/run-corpus-jvm.sh                  # all of it
+corpus/run-corpus-jvm.sh kotlin-obd-api   # one repo
+```
+
+| Language | Route to the processor |
+|---|---|
+| Kotlin | kapt generates Java stubs and runs the processor over them. KSP does not run JSR 269 processors, so kapt is the only route |
+| Groovy | groovyc generates stubs the same way, but only when `javaAnnotationProcessing` is on, and it is off by default in Gradle |
+| Scala | scalac has no JSR 269 support at all. Only the Java half of a mixed build reaches the processor |
+
+USAGE.md has said all three for several releases. Until this harness existed, none of them had
+been run against code outside this repository.
+
+### How VibeTags gets into a build nobody wrote for it
+
+Each repository is built twice by its own Gradle wrapper, and the only difference between the two
+runs is `corpus/inject-vibetags.init.gradle`:
+
+```
+control    ./gradlew <task>
+treatment  ./gradlew <task> --init-script corpus/inject-vibetags.init.gradle
+```
+
+A Gradle init script is the supported way to add a plugin or a dependency to a build you do not
+own, so nothing here edits a `build.gradle` it did not write. It is switched on by the presence of
+`VIBETAGS_ROOT` in the environment, which is how the control runs the same command line without it.
+
+Two details in that file are load-bearing, and both are there because the first version got them
+wrong:
+
+- **It skips `buildSrc` and included builds.** They are not the build under test — they compile
+  the target project's own build logic, often in another language. splain's `buildSrc` is Kotlin,
+  so without the guard the Scala member would have run kapt over the build logic of a Scala
+  project.
+- **On Kotlin projects it configures kapt only, never javac.** That is how `examples/kotlin` and
+  USAGE.md configure it. Doing both put `-Avibetags.root` on kapt's javac command line as a raw
+  flag as well as into kapt's option map.
+
+`--rerun-tasks` is also not optional. Gradle's up-to-date checks would let the treatment skip
+compilation entirely, because the control had just compiled the same sources from the same inputs,
+and a treatment that never ran a compiler passes every assertion below while testing nothing.
+
+### What is asserted
+
+| # | Assertion | What it protects |
+|---|---|---|
+| J0 | The control build succeeds | Everything else is relative to it; a repository that cannot build passes exit parity trivially, both sides failing identically |
+| J1 | The treatment exits exactly as the control did | Adding VibeTags to somebody's build must not fail it |
+| J2 | No new compiler diagnostic, line by line, against a one-entry allow-list | A processor that turns a clean build noisy has broken the same promise, more quietly |
+| J3 | Nothing written into a project that never opted in | File presence is the only opt-in (tier-1 invariant 1) |
+| J4 | The annotated build still succeeds | Otherwise nothing was generated and J5 onward report on an empty directory |
+| J5 | Every opted-in platform file has content, checked per platform | One renderer can be dropped and the other two cover for it in any total |
+| J5b | `AGENTS.md` grew beyond the seeded marker pair | Codex being dropped from the active set looks identical to Codex working |
+| J6 | Every aggregate carries a `VIBETAGS-START` pair | The markers are the whole promise that hand-authored content survives |
+| J6b | Both granular directories were written | An opted-in directory that stays empty looks exactly like "this project has no rules" |
+| J6c | The tier split: a safety guardrail inline, `@AIContract` not inline but present in the rules directory | Invariant 6, checked through three compilers instead of one |
+| J6d | The parameter level survived | The level most exposed to a stub generator: a parameter name that does not survive into the stub cannot be addressed |
+| J6f | Every marker the showcase declares, minus the language's documented exclusions, reached a generated file | A change that stopped rendering half the surface would still pass every assertion that names one guardrail |
+| J6g | **No marker on the exclusion list appeared** | A limitation that quietly gets fixed leaves the documentation wrong in the generous direction, which nobody notices because the run is green |
+| J8 | No type-use annotation in any generated identity | These compilers reach `ElementNaming` by different routes; there is no reason to assume they agree |
+| J9 | Scala only: no marker from the annotated `.scala` file appears anywhere | USAGE.md's Scala row, turned into a test |
+| J9b | Scala only: the Scala showcase produced class files | Without it, "scalac generated nothing" and "scalac was never asked" are the same green run |
+
+J2 differs from the Java corpus's assertion 2 on purpose. There, javac runs either way and the
+only difference is a `-processor` flag, so "no new diagnostics" is a fair comparison. Here it is
+not: switching VibeTags on adds the kapt task graph to a Kotlin build and joint compilation to a
+Groovy one, and those emit diagnostics about the machinery rather than about VibeTags. Counting
+them fails for the wrong reason; raising a threshold to make them pass blinds the check. So every
+new line must either be absent or be named in the allow-list, which has exactly one entry.
+
+J6f and J6g are a pair, and the pair is the point. Anywhere a language genuinely cannot render a
+guardrail, that marker is named in `excluded_markers()` with the evidence, and both directions are
+then checked: it must not go missing from the expected set, and it must not appear from the
+excluded one.
+
+### The members
+
+| Repo | Lang | Licence | Why this one |
+|---|---|---|---|
+| [`eltonvs/kotlin-obd-api`](https://github.com/eltonvs/kotlin-obd-api) | Kotlin | Apache-2.0 | A plain `kotlin("jvm")` library — not Android, not multiplatform — so kapt applies exactly as USAGE.md documents |
+| [`bentsherman/nf-boost`](https://github.com/bentsherman/nf-boost) | Groovy | Apache-2.0 | A Groovy library whose classes groovyc can turn into valid Java stubs, which most of the candidates could not |
+| [`tek/splain`](https://github.com/tek/splain) | Scala | MIT | One of very few Gradle-built Scala projects on a JDK 21 wrapper; `:core:classes` runs `compileJava` and `compileScala`, which is what makes the two-sided Scala assertion possible |
+
+The Scala member carries two showcases in one build: a Java one that must generate everything, and
+a Scala one that must generate nothing. Both halves are needed. Without the positive half, "nothing
+came from Scala" and "nothing came at all" are the same result.
+
+### What it found
+
+**Groovy drops every field-level annotation, silently.**
+
+This is the finding that justifies the harness. `@AIPrivacy` on a Groovy field generates nothing —
+no file, no warning, no trace. It is one of the six safety annotations, it is the natural way to
+mark a PII field, and until this ran, USAGE.md called the Groovy route "Full (joint compilation)".
+
+The first guess was wrong, which is worth recording: a Groovy field with no access modifier
+becomes a property, so the obvious theory was that the annotation had moved onto a generated
+accessor. It had not. Keeping the stubs (`groovyOptions.keepStubs`) and reading one settles it —
+the stub has the class, both constructors, all twelve methods and both parameters of `render`,
+each with its annotations intact, and no fields whatsoever:
+
+```java
+@AIContext(...) @AIPublicAPI() public class CorpusShowcase
+@AILocked(reason="...CONSTRUCTOR-LOCKED...") public CorpusShowcase
+@AILocked(reason="...METHOD-LOCKED...") public long invoiceNumber(long id) { return (long)0;}
+@AIContract(...) public String render(@AIInputSanitized(...) String customerNote, ...)
+```
+
+`billingEmail`, `authToken` and `tenantId` appear nowhere in it. The annotations are not lost by
+VibeTags; they never reach any processor. Nothing in VibeTags can fix that, so it is documented
+instead — and pinned, because a limitation nothing exercises is a limitation nobody notices has
+been fixed. The Groovy showcase annotates those fields on purpose, `excluded_markers()` names the
+two markers, and J6g fails the day they start appearing.
+
+**Most real Groovy projects cannot switch annotation processing on at all.**
+
+Eight Groovy repositories were tried before one could be used, and the failures were not
+incidental:
+
+| Repository | Outcome once `javaAnnotationProcessing` is on |
+|---|---|
+| `jenkinsci/JenkinsPipelineUnit` | stub rejected: `'_' is a keyword, and may not be used as an identifier` |
+| `int128/gradle-ssh-plugin` | stub rejected: `illegal combination of modifiers: public and private` |
+| `longwa/build-test-data` | stub rejected: `method does not override or implement a method from a supertype` |
+| `jk1/Gradle-License-Report` | toolchain pinned to Java 17: `class file version 65.0` |
+| `allegro/axion-release-plugin` | toolchain pinned to Java 17: same |
+| `jwagenleitner/groovy-wslite` | wrapper too old: `Could not determine java version from '21.0.9'` |
+| `gpc/grails-postgresql-extensions` | **compiles** |
+| `bentsherman/nf-boost` | **compiles** — the member |
+
+Three of the eight compile perfectly well on their own and break the moment stubs are generated,
+each for a different reason. That is a property of groovyc's stub generator, not of VibeTags, and
+a Groovy user hitting it sees a compile error in a file they did not write, in a directory named
+`build/tmp/compileGroovy/groovy-java-stubs`. Worth knowing before recommending the switch.
+
+**A Gradle toolchain below 21 fails in a way that names nothing useful.**
+
+`java { toolchain { languageVersion = JavaLanguageVersion.of(17) } }` runs javac from a JDK 17,
+which cannot load the processor. README has always said "Java 21 or higher"; what it did not say
+is that a toolchain pin overrides the JDK you launched Gradle with, so a developer on JDK 21 gets
+`class file version 65.0` and no mention of VibeTags or of toolchains. Now in USAGE.md.
+
+**kapt reports `vibetags.root` as unrecognised.**
+
+`warning: The following options were not recognized by any processor: '[vibetags.root,
+kapt.kotlin.generated]'` — for an option `AIGuardrailProcessor` declares in `@SupportedOptions`
+and demonstrably receives, since it prints the resolved root from the same task. `examples/kotlin`
+on Kotlin 2.4.10 does not produce it; this member on Kotlin 2.3.10 does. Removing the javac-side
+configuration so only the documented `kapt { arguments { … } }` route remained did not change it.
+
+That is as far as the evidence goes, so it is allow-listed as kapt bookkeeping with the evidence
+written next to it, and tracked as an open question rather than asserted to be harmless.
+
+**And one in the harness, which is the reason J2 can be trusted at all.**
+
+The diagnostic counter could not see the diagnostic it existed for. It required a colon before the
+word — `: warning:` — and javac emits its summary diagnostics with no file prefix at all. So the
+kapt warning above was raised by the treatment, absent from the control, and counted `0` against
+`0`. A parity check blind to an entire class of diagnostic is worse than no parity check, because
+it is reported as a pass.
+
+### Adding a member
+
+1. It must build on JDK 21 with its own wrapper, at the SHA you pin, **and** with annotation
+   processing switched on. Those are two different tests for Groovy, and the second is the one
+   that eliminates most candidates.
+2. Prefer a library over a build plugin. Plugins pin old toolchains for consumer compatibility,
+   which is what disqualified two Groovy candidates outright.
+3. Add a row to `repos-jvm.tsv` with the SHA, never a branch, and say in `why` what it covers that
+   the others do not.
+4. If it cannot render some level, name the markers in `excluded_markers()` **with the evidence**,
+   and write the limitation in USAGE.md in the same change. An exclusion without a reason is how a
+   real defect gets absorbed into the expected set.
+
+## Adding a Java repo
 
 1. Pick something small, permissively licensed, and *different* from what is already there. A
    seventh repo that looks like `commons-codec` adds runtime and no coverage.

--- a/corpus/inject-vibetags.init.gradle
+++ b/corpus/inject-vibetags.init.gradle
@@ -1,0 +1,113 @@
+// Injects VibeTags into a Gradle build that has never heard of it.
+//
+// Passed to a third-party clone as `--init-script corpus/inject-vibetags.init.gradle`. An init
+// script is the one supported way to add a plugin or a dependency to a build you do not own, so
+// the corpus never edits a `build.gradle` it did not write. The clone's own build file is the
+// control; this file is the entire difference between the control run and the treatment run.
+//
+// Configured entirely through the environment, because an init script cannot take arguments:
+//
+//   VIBETAGS_JARS   path-separated processor jar + its runtime classpath
+//   VIBETAGS_ANN    the annotations jar, added to compileOnly so an injected showcase resolves
+//   VIBETAGS_ROOT   where the processor writes; unset means "do not inject at all"
+//
+// Three languages, three different routes to the same JSR 269 processor, and the differences
+// are the whole reason the JVM-language corpus exists:
+//
+//   Java     javac runs the processor directly.
+//   Kotlin   kapt generates Java stubs and runs the processor over them. KSP does not run
+//            JSR 269 processors, so kapt is the only route (USAGE.md, "Kotlin (kapt)").
+//   Groovy   groovyc generates stubs the same way, but only when javaAnnotationProcessing is
+//            switched on, which is off by default in Gradle.
+//   Scala    scalac has no JSR 269 support at all. Nothing here reaches a .scala source, and
+//            the corpus asserts that rather than papering over it.
+
+def jars = System.getenv('VIBETAGS_JARS')
+def annJar = System.getenv('VIBETAGS_ANN')
+def vtRoot = System.getenv('VIBETAGS_ROOT')
+
+if (vtRoot == null || vtRoot.isEmpty() || jars == null || jars.isEmpty()) {
+    // The control run uses the same command line minus the environment, so a missing variable
+    // has to mean "do nothing" rather than "fail". A treatment run that silently did nothing
+    // would be indistinguishable from a passing one, which is why run-corpus-jvm.sh verifies
+    // the processor actually ran instead of trusting this file.
+    return
+}
+
+// buildSrc and any included build gets this init script too, and it is not the build under
+// test: it compiles the target project's own build logic, often in a different language and
+// against the Gradle API. Injecting an annotation processor there would change whether the
+// build script compiles, which is a failure of the harness rather than a finding about VibeTags.
+// splain's buildSrc is Kotlin, so without this guard the Scala member would run kapt over the
+// build logic of a Scala project.
+if (gradle.parent != null) {
+    return
+}
+
+def procFiles = jars.split(java.io.File.pathSeparator).findAll { !it.isEmpty() }
+def rootArg = "-Avibetags.root=${vtRoot}".toString()
+
+gradle.allprojects { project ->
+    project.plugins.withId('java-base') {
+        if (annJar != null && !annJar.isEmpty()) {
+            // The injected showcase imports se.deversity.vibetags.annotations.*. Every @AI*
+            // annotation is RetentionPolicy.SOURCE, so compileOnly is the correct scope and
+            // nothing reaches the class files or the published artifacts.
+            project.configurations.matching { it.name == 'compileOnly' }.configureEach { cfg ->
+                project.dependencies.add(cfg.name, project.files(annJar))
+            }
+        }
+    }
+
+    // Java, and the Java half of a Scala or mixed build.
+    //
+    // Skipped entirely for Kotlin projects, and that is not a shortcut. kapt owns annotation
+    // processing there, exactly as examples/kotlin and USAGE.md configure it: processor on the
+    // kapt path, root passed through `kapt { arguments { ... } }`, nothing on the javac path.
+    // Configuring both routes at once is what the first version of this file did, and it put
+    // `-Avibetags.root` on kapt's javac command line as a raw flag as well as into kapt's own
+    // option map. javac then reported it as unclaimed - "warning: The following options were not
+    // recognized by any processor: '[vibetags.root, kapt.kotlin.generated]'" - a warning the
+    // control build could not have, which failed diagnostic parity for a defect in the harness
+    // rather than in the product. examples/kotlin, built the documented way, never showed it.
+    project.tasks.withType(org.gradle.api.tasks.compile.JavaCompile).configureEach { t ->
+        if (project.pluginManager.hasPlugin('org.jetbrains.kotlin.jvm')) {
+            return
+        }
+        // Appended, never assigned. Several corpus members run annotation processors of their
+        // own; replacing the path would disable them, and a treatment run that quietly dropped
+        // the project's own processor is not a measurement of non-interference, it is a
+        // different build.
+        def existing = t.options.annotationProcessorPath
+        t.options.annotationProcessorPath =
+            existing == null ? project.files(procFiles) : existing.plus(project.files(procFiles))
+        t.options.compilerArgs.add(rootArg)
+    }
+
+    // Groovy. javaAnnotationProcessing is off by default in Gradle, which is why a Groovy
+    // project that adds VibeTags and changes nothing else sees no output at all.
+    project.plugins.withId('groovy') {
+        project.tasks.withType(org.gradle.api.tasks.compile.GroovyCompile).configureEach { t ->
+            t.groovyOptions.javaAnnotationProcessing = true
+            def existing = t.options.annotationProcessorPath
+            t.options.annotationProcessorPath =
+                existing == null ? project.files(procFiles) : existing.plus(project.files(procFiles))
+            t.options.compilerArgs.add(rootArg)
+        }
+    }
+
+    // Kotlin. The kapt plugin ships inside kotlin-gradle-plugin, which is already on the
+    // buildscript classpath of any project applying kotlin("jvm"), so it can be applied by id
+    // from here without adding anything to the init classpath and without having to guess the
+    // project's Kotlin version.
+    project.pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
+        project.pluginManager.apply('org.jetbrains.kotlin.kapt')
+        procFiles.each { jar -> project.dependencies.add('kapt', project.files(jar)) }
+        // kapt compiles generated stubs in a worker directory, so the JVM working directory is
+        // not the project directory and the root must be passed explicitly. This is the same
+        // instruction USAGE.md gives a real Kotlin consumer.
+        project.extensions.getByName('kapt').arguments {
+            arg('vibetags.root', vtRoot)
+        }
+    }
+}

--- a/corpus/repos-jvm.tsv
+++ b/corpus/repos-jvm.tsv
@@ -1,0 +1,29 @@
+# The JVM-language corpus: real Kotlin, Groovy and Scala that nobody wrote to suit VibeTags.
+#
+# Separate from repos.tsv because these are not compiled by javac. Each repository is built by
+# its own Gradle wrapper, twice, and the only difference between the two runs is
+# corpus/inject-vibetags.init.gradle. An init script is the supported way to add a plugin or a
+# dependency to a build you do not own, so nothing here edits a build file it did not write.
+#
+# Tab-separated. Lines starting with '#' are comments. Columns:
+#   name      directory name under the corpus cache
+#   url       clone URL
+#   sha       pinned commit. Never a branch: an upstream push must not be able to turn this
+#             repository's CI red for a reason nobody here changed.
+#   lang      kotlin | groovy | scala. Picks the showcase template and the assertions.
+#   module    Gradle project directory holding the source set; "." for a single-module build
+#   src       source root, relative to module
+#   task      compile task to run. Not `build`: tests and linters are the project's business,
+#             and a repository whose checkstyle dislikes an injected showcase would be reporting
+#             its own opinion rather than anything about VibeTags.
+#   licence   SPDX id, checked before adding. Nothing is vendored.
+#   why       what this repository contributes that the others do not
+#
+# Each entry was control-compiled on JDK 21 at its pinned SHA before being added. A member whose
+# own build does not work makes every assertion below it vacuous, which is the lesson assertion 0
+# in the Java corpus was written from.
+#
+#name	url	sha	lang	module	src	task	licence	why
+kotlin-obd-api	https://github.com/eltonvs/kotlin-obd-api.git	30014eb6e8cd35334ba8f7ea627500f6b1942ff5	kotlin	.	src/main/kotlin	compileKotlin	Apache-2.0	Plain kotlin("jvm") library, no Android and no multiplatform, so kapt applies the way USAGE.md documents it
+groovy-nf-boost	https://github.com/bentsherman/nf-boost.git	92ba0a18ad9808649c54d56c7af33a50b0efc098	groovy	.	src/main/groovy	compileGroovy	Apache-2.0	A Groovy library whose classes groovyc can turn into valid Java stubs, which four of the seven Groovy projects tried could not; see corpus/README.md
+scala-splain	https://github.com/tek/splain.git	60c92b5e6422738087a1ed65c70e41a9ebefbc27	scala	core	src/main/scala	:core:classes	MIT	One of very few Gradle-built Scala projects on a JDK 21 wrapper; :core:classes runs compileJava and compileScala, which is what makes the two-sided Scala assertion possible

--- a/corpus/run-corpus-jvm.sh
+++ b/corpus/run-corpus-jvm.sh
@@ -1,0 +1,488 @@
+#!/usr/bin/env bash
+# Runs VibeTags over real third-party Kotlin, Groovy and Scala, built by their own Gradle.
+#
+# corpus/run-corpus.sh answers "does VibeTags survive code nobody wrote for it". It answers it in
+# Java, with javac, because that is the compiler JSR 269 belongs to. This script asks the same
+# question of the three other JVM languages people actually ship, and none of them reaches the
+# processor the way Java does:
+#
+#   Kotlin   kapt generates Java stubs and runs the processor over them. KSP does not run JSR 269
+#            processors at all, so kapt is the only route.
+#   Groovy   groovyc generates stubs the same way, but only when javaAnnotationProcessing is on,
+#            and it is off by default in Gradle. A Groovy project that adds VibeTags and changes
+#            nothing else generates nothing, silently.
+#   Scala    scalac has no JSR 269 support whatsoever. Annotated Scala compiles cleanly and is
+#            never seen. Only the Java half of a mixed build reaches the processor.
+#
+# USAGE.md has said all three for several releases. Until this script none of them had been run
+# against code outside this repository. The Scala one is asserted as a negative on purpose: the
+# Scala showcase is annotated at every level it can be, and every marker must be absent.
+#
+# Each repository is built twice by its own wrapper, and the only difference between the two runs
+# is corpus/inject-vibetags.init.gradle:
+#
+#   control    ./gradlew <task>
+#   treatment  ./gradlew <task> --init-script corpus/inject-vibetags.init.gradle
+#
+# Usage:
+#   corpus/run-corpus-jvm.sh [name ...]     # all repos, or just the named ones
+#
+# Env:
+#   VIBETAGS_CORPUS_DIR   cache location (default: <repo>/target/corpus-jvm)
+#   VIBETAGS_GRADLE_ARGS  extra flags for every Gradle invocation
+#
+# Requires vibetags-annotations and vibetags installed (see CLAUDE.md "Build and test").
+set -u
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+CACHE="${VIBETAGS_CORPUS_DIR:-$ROOT/target/corpus-jvm}"
+MANIFEST="$ROOT/corpus/repos-jvm.tsv"
+INIT_SCRIPT="$ROOT/corpus/inject-vibetags.init.gradle"
+GRADLE_ARGS="${VIBETAGS_GRADLE_ARGS:---console=plain}"
+
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) SEP=";" ; winpath() { cygpath -w "$1"; } ;;
+  *)                    SEP=":" ; winpath() { printf "%s" "$1"; } ;;
+esac
+
+VERSION=$(sed -n "s|.*<revision>\(.*\)</revision>.*|\1|p" "$ROOT/vibetags-parent/pom.xml")
+PROC_JAR="$ROOT/vibetags/target/vibetags-processor-$VERSION.jar"
+if [ ! -f "$PROC_JAR" ]; then
+  echo "FAIL: $PROC_JAR not found. Run 'mvn install' in vibetags/ first." >&2
+  exit 1
+fi
+ANN_JAR=$(ls "$HOME"/.m2/repository/se/deversity/vibetags/vibetags-annotations/"$VERSION"/vibetags-annotations-"$VERSION".jar 2>/dev/null | head -1)
+if [ ! -f "$ANN_JAR" ]; then
+  echo "FAIL: vibetags-annotations $VERSION is not in the local repository." >&2
+  echo "      The showcase cannot compile without it; run 'mvn install' in vibetags-annotations/." >&2
+  exit 1
+fi
+
+mkdir -p "$CACHE"
+# Regenerated every run, never restored from a cache. A classpath resolved by a run that failed
+# is indistinguishable from a good one once it is on disk, and the Java corpus has already been
+# burned by exactly that (corpus/README.md, "a third, in the harness rather than the product").
+mvn -q -f "$ROOT/vibetags/pom.xml" dependency:build-classpath \
+    -Dmdep.includeScope=runtime -Dmdep.regenerateFile=true \
+    "-Dmdep.outputFile=$CACHE/vibetags.cp" >/dev/null 2>&1
+if [ ! -s "$CACHE/vibetags.cp" ]; then
+  echo "FAIL: could not resolve the processor's runtime classpath." >&2
+  exit 1
+fi
+export VIBETAGS_JARS="$(winpath "$PROC_JAR")$SEP$(cat "$CACHE/vibetags.cp")"
+export VIBETAGS_ANN="$(winpath "$ANN_JAR")"
+
+fetch_repo() {
+  name="$1"; url="$2"; sha="$3"
+  dir="$CACHE/$name"
+  if [ -f "$dir/.corpus-sha" ] && [ "$(cat "$dir/.corpus-sha")" = "$sha" ]; then
+    return 0
+  fi
+  rm -rf "$dir"
+  mkdir -p "$dir"
+  ( cd "$dir" \
+    && git init --quiet \
+    && git remote add origin "$url" \
+    && git fetch --quiet --depth 1 origin "$sha" \
+    && git checkout --quiet FETCH_HEAD ) || return 1
+  printf '%s' "$sha" > "$dir/.corpus-sha"
+}
+
+DIAG_RE="^(w|e): |^(warning|error):|: (error|warning):|^\[(warn|error)\]"
+
+# Counts compiler diagnostics across four compilers' formats. javac and groovyc say
+# "warning:"/"error:", kotlinc prefixes "w:"/"e:", scalac and Zinc bracket them. Gradle's own
+# deprecation notices are excluded: they are identical on both sides, and counting them would
+# add noise to a comparison meant to isolate one variable.
+#
+# The `^(warning|error):` arm is not decoration. javac emits its summary diagnostics with no
+# file prefix at all - "warning: The following options were not recognized by any processor" is
+# the one that matters here - and the first version of this pattern required a colon before the
+# word. It counted 0 against 0 on a treatment run that had in fact raised a warning the control
+# had not, which is a diagnostic-parity check that cannot see the diagnostic it exists for.
+diagnostics() {
+  grep -cE "$DIAG_RE" "$1" 2>/dev/null || true
+}
+
+# Every marker a showcase declares. The floor is not a hand-written number here: it is derived
+# from the template, so growing a showcase raises the bar automatically and a level that stops
+# rendering cannot be absorbed by a margin somebody once left in.
+declared_markers() {
+  grep -ohE "(PACKAGE|FIELD|METHOD|PARAM|NESTED|CONSTRUCTOR)-[A-Z]+" "$@" 2>/dev/null | sort -u
+}
+generated_markers() {
+  grep -rhoE "(PACKAGE|FIELD|METHOD|PARAM|NESTED|CONSTRUCTOR)-[A-Z]+" "$@" 2>/dev/null | sort -u
+}
+
+# Markers a language is known not to be able to render, with the reason. Checked in both
+# directions: one of these appearing is as much a finding as a normal marker going missing,
+# because it means the toolchain changed and the documentation is now wrong the other way.
+#
+# groovy: groovyc's Java stubs carry types, constructors, methods and parameters - and no fields
+# at all. Verified by keeping the stubs (groovyOptions.keepStubs) and reading one: billingEmail,
+# authToken and tenantId are simply not in it. So every FIELD-targeted annotation is dropped
+# before any processor sees it, @AIPrivacy included, which is a safety-tier guardrail. USAGE.md
+# called this route "Full (joint compilation)" until this corpus ran.
+excluded_markers() {
+  case "$1" in
+    groovy) printf '%s\n' "FIELD-PERFORMANCE" "FIELD-PRIVACY" ;;
+    *)      : ;;
+  esac
+}
+
+# The safety-tier marker J6c looks for inline in the aggregate. @AIPrivacy on a field is the
+# sharpest version of that question and is used wherever fields survive; Groovy has to fall back
+# to @AILocked on a method, for the reason above.
+safety_marker() {
+  case "$1" in
+    groovy) printf '%s' "METHOD-LOCKED" ;;
+    *)      printf '%s' "FIELD-PRIVACY" ;;
+  esac
+}
+
+status=0
+repos_run=0
+printf "%-18s %-8s %-16s %-11s %-8s %s\n" REPO LANG "EXIT ctrl/vt" "DIAGS c/v" WROTE NOTE
+
+while IFS=$'\t' read -r name url sha lang module src task licence why; do
+  case "$name" in ''|'#'*) continue ;; esac
+  if [ "$#" -gt 0 ]; then
+    case " $* " in *" $name "*) ;; *) continue ;; esac
+  fi
+
+  if ! fetch_repo "$name" "$url" "$sha"; then
+    echo "FAIL: could not fetch $name at $sha" >&2
+    status=1
+    continue
+  fi
+
+  dir="$CACHE/$name"
+  moddir="$dir/$module"
+  srcdir="$moddir/$src"
+  if [ ! -d "$srcdir" ]; then
+    echo "FAIL: $name has no source root at $module/$src (pinned SHA moved it?)" >&2
+    status=1
+    continue
+  fi
+  if [ ! -f "$dir/gradlew" ]; then
+    echo "FAIL: $name has no Gradle wrapper, so there is no build to inject into." >&2
+    status=1
+    continue
+  fi
+  chmod +x "$dir/gradlew" 2>/dev/null || true
+
+  vt_root="$dir/.corpus-vibetags-root"
+  optin="$dir/.corpus-optin-root"
+  rm -rf "$vt_root" "$optin"
+  mkdir -p "$vt_root"
+
+  # --rerun-tasks is not optional. Gradle's up-to-date checks would let the treatment run skip
+  # compilation entirely, because the control had just compiled the same sources from the same
+  # inputs. A treatment that never ran a compiler passes every assertion below while testing
+  # nothing, which is the same shape of vacuous pass assertion 0 exists for in the Java corpus.
+  gradle_run() {
+    logfile="$1"; shift
+    ( cd "$dir" && ./gradlew $GRADLE_ARGS --rerun-tasks "$@" ) > "$logfile" 2>&1
+  }
+
+  # Control: the project's own build, untouched. VIBETAGS_ROOT is what switches the init script
+  # on, so the control runs with it unset rather than with a different command line.
+  ( unset VIBETAGS_ROOT; gradle_run "$dir/.corpus-ctrl.log" "$task" )
+  ctrl_exit=$?
+
+  VIBETAGS_ROOT="$(winpath "$vt_root")" \
+    gradle_run "$dir/.corpus-vt.log" "$task" --init-script "$(winpath "$INIT_SCRIPT")"
+  vt_exit=$?
+
+  ctrl_diag=$(diagnostics "$dir/.corpus-ctrl.log")
+  vt_diag=$(diagnostics "$dir/.corpus-vt.log")
+  wrote=$(find "$vt_root" -type f 2>/dev/null | wc -l | tr -d ' ')
+
+  printf "%-18s %-8s %-16s %-11s %-8s %s\n" \
+    "$name" "$lang" "$ctrl_exit/$vt_exit" "$ctrl_diag/$vt_diag" "$wrote" ""
+
+  repos_run=$((repos_run + 1))
+
+  # J0. The control has to build. Every assertion here is relative to it, so a repository that
+  # cannot build on its own passes exit parity and diagnostic parity trivially, both sides
+  # failing identically, and proves nothing.
+  if [ "$ctrl_exit" -ne 0 ]; then
+    echo "FAIL: $name does not build on its own, so nothing below it means anything." >&2
+    echo "      Fix the corpus member - pinned SHA, module path, task or JDK - not the code." >&2
+    grep -v "JAVA_TOOL_OPTIONS" "$dir/.corpus-ctrl.log" | tail -15 >&2
+    status=1
+    continue
+  fi
+  # J1. Adding VibeTags to somebody's build must not change whether it succeeds.
+  if [ "$ctrl_exit" -ne "$vt_exit" ]; then
+    echo "FAIL: $name exits $vt_exit with VibeTags and $ctrl_exit without it." >&2
+    grep -v "JAVA_TOOL_OPTIONS" "$dir/.corpus-vt.log" | tail -20 >&2
+    status=1
+  fi
+  # J2. A processor that turns a clean build noisy has broken the same promise, more quietly.
+  #
+  # Compared line by line rather than by count, and that is a deliberate departure from the Java
+  # corpus. There, javac runs either way and the only difference is a -processor flag, so "no new
+  # diagnostics" is a fair test. Here it is not: switching VibeTags on adds the kapt task graph to
+  # a Kotlin build and joint compilation to a Groovy one, and those emit diagnostics of their own
+  # about the annotation-processing machinery rather than about VibeTags. Counting them makes the
+  # check fail for the wrong reason, and raising a threshold to make it pass would blind it to the
+  # diagnostics that do matter.
+  #
+  # So every new line must either be gone or be named. KAPT_NOISE is the whole allow-list, one
+  # entry long, and anything else fails and is printed.
+  #
+  # That entry: kapt reports the processor options it forwards as unrecognised, vibetags.root
+  # among them - an option AIGuardrailProcessor does declare in @SupportedOptions, and does
+  # receive, since it prints the resolved root from the same task. examples/kotlin, configured
+  # exactly as USAGE.md documents and built on Kotlin 2.4.10, does not produce it; this member,
+  # on Kotlin 2.3.10, does. Removing the javac-side configuration so that only the documented
+  # `kapt { arguments { ... } }` route remained did not change it either. That is as far as the
+  # evidence goes, so it is allow-listed as kapt bookkeeping and tracked as an open question
+  # rather than asserted to be harmless.
+  KAPT_NOISE="The following options were not recognized by any processor"
+  new_diags=$(comm -13 <(grep -hE "$DIAG_RE" "$dir/.corpus-ctrl.log" | sort -u)                        <(grep -hE "$DIAG_RE" "$dir/.corpus-vt.log" | sort -u)               | grep -vF "$KAPT_NOISE")
+  if [ -n "$new_diags" ]; then
+    echo "FAIL: $name raises diagnostics with VibeTags that it does not raise without it:" >&2
+    printf '%s\n' "$new_diags" | head -10 >&2
+    echo "      If a line here is annotation-processing machinery rather than VibeTags, say so" >&2
+    echo "      in the allow-list above with the evidence. Do not widen it silently." >&2
+    status=1
+  fi
+  # J3. File presence is the only opt-in (tier-1 invariant 1) and none of these repositories
+  # opted in. Nothing at all, not even a log: since #487 the log file is created on the first
+  # record rather than when the logger is configured.
+  if [ "$wrote" -ne 0 ]; then
+    echo "FAIL: $name had $wrote file(s) written into a project that never opted in:" >&2
+    find "$vt_root" -type f | head -10 >&2
+    status=1
+  fi
+
+  # -----------------------------------------------------------------------------------------
+  # Opt-in phase. Everything above proves VibeTags stays out of the way, which for these three
+  # languages is only half the question and not the interesting half: a processor that never
+  # ran also stays out of the way perfectly. What follows is the proof that the injection works
+  # at all - kapt over Kotlin stubs, joint compilation over Groovy stubs - and, for Scala, the
+  # proof that it does not.
+  # -----------------------------------------------------------------------------------------
+  mkdir -p "$optin/.claude/rules" "$optin/.gemini/rules"
+  : > "$optin/CLAUDE.md"
+  : > "$optin/GEMINI.md"
+  : > "$optin/.vibetags-locks"
+  # AGENTS.md is invariant 4's exception: written only as the sole AI config file, or when it
+  # already carries a marker pair. Created empty alongside CLAUDE.md and GEMINI.md it would be
+  # dropped from the active set silently, and the corpus would report Codex working while
+  # generating none of it. Seeding the pair is what a real consumer does.
+  printf '%s\n%s\n' '<!-- VIBETAGS-START -->' '<!-- VIBETAGS-END -->' > "$optin/AGENTS.md"
+
+  ( cd "$dir" && git checkout --quiet -- . 2>/dev/null )
+
+  showcase_pkg="vibetagscorpus"
+  showcase_dir="$srcdir/$showcase_pkg"
+  java_showcase_dir=""
+  mkdir -p "$showcase_dir"
+  case "$lang" in
+    kotlin)
+      sed "s/__PACKAGE__/$showcase_pkg/g" "$ROOT/corpus/showcase/CorpusShowcase.kt.tmpl" \
+        > "$showcase_dir/CorpusShowcase.kt"
+      declared=$(declared_markers "$ROOT/corpus/showcase/CorpusShowcase.kt.tmpl")
+      ;;
+    groovy)
+      sed "s/__PACKAGE__/$showcase_pkg/g" "$ROOT/corpus/showcase/CorpusShowcase.groovy.tmpl" \
+        > "$showcase_dir/CorpusShowcase.groovy"
+      declared=$(declared_markers "$ROOT/corpus/showcase/CorpusShowcase.groovy.tmpl")
+      ;;
+    scala)
+      # Both halves of one build. The Java one must generate everything; the Scala one must
+      # generate nothing, and that pair is the entire point of the Scala member: without the
+      # positive half, "nothing came from Scala" and "nothing came at all" look identical.
+      sed "s/__PACKAGE__/$showcase_pkg/g" "$ROOT/corpus/showcase/CorpusShowcase.scala.tmpl" \
+        > "$showcase_dir/CorpusShowcase.scala"
+      java_showcase_dir="$moddir/src/main/java/$showcase_pkg"
+      mkdir -p "$java_showcase_dir"
+      sed "s/__PACKAGE__/$showcase_pkg/g" "$ROOT/corpus/showcase/CorpusShowcase.java.tmpl" \
+        > "$java_showcase_dir/CorpusShowcase.java"
+      sed "s/__PACKAGE__/$showcase_pkg/g" "$ROOT/corpus/showcase/package-info.java.tmpl" \
+        > "$java_showcase_dir/package-info.java"
+      declared=$(declared_markers "$ROOT/corpus/showcase/CorpusShowcase.java.tmpl" \
+                                  "$ROOT/corpus/showcase/package-info.java.tmpl")
+      ;;
+    *)
+      echo "FAIL: $name declares an unknown language '$lang'." >&2
+      status=1
+      rm -rf "$showcase_dir"
+      continue
+      ;;
+  esac
+
+  VIBETAGS_ROOT="$(winpath "$optin")" \
+    gradle_run "$dir/.corpus-optin.log" "$task" --init-script "$(winpath "$INIT_SCRIPT")"
+  optin_exit=$?
+
+  claude_bytes=$(wc -c < "$optin/CLAUDE.md" | tr -d ' ')
+  agents_bytes=$(wc -c < "$optin/AGENTS.md" | tr -d ' ')
+  claude_rules=$(find "$optin/.claude/rules" -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
+  gemini_rules=$(find "$optin/.gemini/rules" -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
+  hits=$(generated_markers "$optin/CLAUDE.md" "$optin/GEMINI.md" "$optin/AGENTS.md" \
+                           "$optin/.claude/rules" "$optin/.gemini/rules")
+  excluded=$(excluded_markers "$lang")
+  expected=$(comm -23 <(printf '%s\n' "$declared" | grep . | sort -u)                       <(printf '%s\n' "$excluded" | grep . | sort -u))
+  n_declared=$(printf '%s\n' "$expected" | grep -c . || true)
+  n_hits=$(printf '%s\n' "$hits" | grep -c . || true)
+
+  printf "%-18s %-8s %-16s %-11s %-8s %s\n" \
+    "  |- opt-in" "" "exit=$optin_exit" "CLAUDE=$claude_bytes" \
+    "$claude_rules/$gemini_rules" "markers=$n_hits/$n_declared"
+
+  # J9b, taken before the sources go away. J9 below asserts that the annotated Scala produced no
+  # guardrails, and the cheapest way for that to be true is for scalac never to have seen the
+  # file at all - a source root that moved, a task that does not compile it, a showcase written
+  # somewhere the build ignores. Then J9 passes while proving nothing. Requiring a class file
+  # under the Scala output is what separates "scalac compiled it and offered nothing to a
+  # processor" from "scalac was never asked".
+  scala_classes=0
+  if [ "$lang" = scala ]; then
+    scala_classes=$(find "$moddir/build" -path "*classes/scala*" -name "CorpusShowcase*.class"                       2>/dev/null | wc -l | tr -d ' ')
+  fi
+
+  # Reverted before any assertion can `continue` out of the loop, so a failure never leaves
+  # third-party sources modified on disk.
+  rm -rf "$showcase_dir"
+  [ -n "$java_showcase_dir" ] && rm -rf "$java_showcase_dir"
+  ( cd "$dir" && git checkout --quiet -- . 2>/dev/null )
+
+  # J4. The annotated build still has to work. If it does not, nothing was generated and every
+  # assertion after this one would be reporting on an empty directory.
+  if [ "$optin_exit" -ne 0 ]; then
+    echo "FAIL: $name did not build once annotated, so nothing was generated to evaluate." >&2
+    grep -v "JAVA_TOOL_OPTIONS" "$dir/.corpus-optin.log" | tail -20 >&2
+    status=1
+    continue
+  fi
+
+  # J5. Every opted-in platform produces content, checked per platform rather than in aggregate:
+  # one renderer can be dropped from the registry and the other two will cover for it in a total.
+  for pf in CLAUDE.md GEMINI.md AGENTS.md; do
+    if [ ! -s "$optin/$pf" ]; then
+      echo "FAIL: $name opted into $pf and it came back empty." >&2
+      status=1
+    fi
+  done
+  # J5b. Codex needs its own check: AGENTS.md was seeded with a marker pair, so "not empty" is
+  # true before VibeTags runs at all. 46 bytes is the seed and nothing else.
+  if [ "$agents_bytes" -le 46 ]; then
+    echo "FAIL: $name produced an AGENTS.md of $agents_bytes bytes, which is the seeded marker" >&2
+    echo "      pair alone. Codex was dropped from the active set rather than written." >&2
+    status=1
+  fi
+  # J6. The marker pair is present in every aggregate: it is the whole of the promise that
+  # hand-authored content outside it survives.
+  for pf in CLAUDE.md GEMINI.md AGENTS.md; do
+    if ! grep -q "VIBETAGS-START" "$optin/$pf" 2>/dev/null; then
+      echo "FAIL: $name produced a $pf with no VIBETAGS-START marker." >&2
+      status=1
+    fi
+  done
+  # J6b. Both granular directories were written. An opted-in directory that stays empty looks
+  # exactly like "this project has no rules".
+  if [ "$claude_rules" -lt 1 ] || [ "$gemini_rules" -lt 1 ]; then
+    echo "FAIL: $name opted into granular rules and got $claude_rules Claude / $gemini_rules Gemini files." >&2
+    status=1
+  fi
+  # J6c. The tier split, which is invariant 6 checked through three compilers instead of one.
+  # With a granular directory opted in, the aggregate keeps the safety buckets inline and
+  # replaces everything else with a pointer: @AIPrivacy stays in CLAUDE.md, @AIContract must not.
+  safety=$(safety_marker "$lang")
+  if ! grep -q "$safety" "$optin/CLAUDE.md" 2>/dev/null; then
+    echo "FAIL: $name dropped a safety-tier guardrail ($safety) from the aggregate." >&2
+    echo "      Safety buckets stay inline even when the granular directory is opted in." >&2
+    status=1
+  fi
+  if grep -q "METHOD-CONTRACT" "$optin/CLAUDE.md" 2>/dev/null; then
+    echo "FAIL: $name kept a non-safety guardrail (@AIContract) inline in the aggregate." >&2
+    status=1
+  fi
+  if ! grep -rq "METHOD-CONTRACT" "$optin/.claude/rules" 2>/dev/null; then
+    echo "FAIL: $name moved @AIContract out of the aggregate but not into the rules directory." >&2
+    echo "      That guardrail now reaches nobody, which is worse than leaving it inline." >&2
+    status=1
+  fi
+  # J6d. The parameter level, which is the finest addressing VibeTags produces and the one most
+  # exposed to a stub generator: a parameter name that does not survive into the stub cannot be
+  # addressed at all, and neither kapt nor groovyc is obliged to keep it.
+  if ! grep -rq "PARAM-LOADBEARING" "$optin/.claude/rules" 2>/dev/null; then
+    echo "FAIL: $name lost the parameter-level guardrail (@AILoadBearing on a parameter)." >&2
+    status=1
+  fi
+  # J6f. Every marker the showcase declares must reach a generated file. Derived from the
+  # template rather than written down, so the bar rises with the showcase.
+  if [ "$n_hits" -lt "$n_declared" ]; then
+    echo "FAIL: $name rendered $n_hits of the $n_declared guardrails expected for $lang." >&2
+    echo "      Missing:" >&2
+    comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$hits") >&2
+    status=1
+  fi
+  # J6g. The other direction. A marker on the exclusion list is one this language is documented
+  # as unable to render, so its appearance means the toolchain changed under us and the
+  # documentation is now wrong in the generous direction - which nobody ever notices, because
+  # the run is green and more guardrails arrived than were asked for. Delete the exclusion and
+  # fix USAGE.md rather than leaving both to drift.
+  surprises=$(comm -12 <(printf '%s\n' "$excluded" | grep . | sort -u) <(printf '%s\n' "$hits"))
+  if [ -n "$surprises" ]; then
+    echo "FAIL: $name rendered guardrails that $lang is documented as unable to render:" >&2
+    printf '%s\n' "$surprises" >&2
+    echo "      Good news, and still a failure: remove the exclusion in excluded_markers()" >&2
+    echo "      and correct the limitation in USAGE.md." >&2
+    status=1
+  fi
+  # J8. No type-use annotation in any generated identity, in a path attribute, a lock entry or
+  # a filename. The Java corpus found this defect twice; these compilers reach ElementNaming by
+  # different routes and there is no reason to assume they agree.
+  leaked_paths=$(grep -c 'path="[^"]*@' "$optin/CLAUDE.md" "$optin/GEMINI.md" 2>/dev/null \
+                 | awk -F: '{s+=$2} END {print s+0}')
+  leaked_locks=$(grep -c '"element":"[^"]*@' "$optin/.vibetags-locks" 2>/dev/null || true)
+  leaked_names=$(find "$optin" -name "*@*" 2>/dev/null | wc -l | tr -d ' ')
+  leaked=$((leaked_paths + leaked_locks + leaked_names))
+  if [ "$leaked" -ne 0 ]; then
+    echo "FAIL: $name put a type-use annotation into an element identity" >&2
+    echo "      ($leaked_paths path attributes, $leaked_locks lock entries, $leaked_names filenames)." >&2
+    status=1
+  fi
+
+  # J9. Scala only, and the reason the Scala member is here at all. Every marker in the
+  # annotated .scala file must be absent from every generated file, because scalac never offered
+  # them to a processor. If this goes red, either scalac has gained JSR 269 support or VibeTags
+  # has found another way in - and USAGE.md's Scala row needs rewriting rather than this check
+  # relaxing. J6f above is the positive half, over the Java showcase in the same build.
+  if [ "$lang" = scala ]; then
+    seen=$(grep -rhoE "SCALA-INVISIBLE-[A-Z-]+" \
+             "$optin/CLAUDE.md" "$optin/GEMINI.md" "$optin/AGENTS.md" \
+             "$optin/.claude/rules" "$optin/.gemini/rules" 2>/dev/null | sort -u)
+    n_seen=$(printf '%s\n' "$seen" | grep -c . || true)
+    if [ "$scala_classes" -lt 1 ]; then
+      echo "FAIL: $name compiled no Scala showcase classes, so the check below would hold for" >&2
+      echo "      the wrong reason: scalac never saw the annotated file." >&2
+      echo "      Check module='$module' src='$src' and task='$task' in repos-jvm.tsv." >&2
+      status=1
+    fi
+    if [ "$n_seen" -ne 0 ]; then
+      echo "FAIL: $name generated $n_seen guardrail(s) from annotated Scala sources:" >&2
+      printf '%s\n' "$seen" >&2
+      echo "      USAGE.md says scalac has no JSR 269 support and annotated Scala is never seen." >&2
+      echo "      One of the two is now wrong. Do not relax this check to make the run green." >&2
+      status=1
+    fi
+  fi
+done < "$MANIFEST"
+
+if [ "$repos_run" -eq 0 ]; then
+  echo "FAIL: no repositories ran, so this proves nothing." >&2
+  exit 1
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "OK: $repos_run JVM-language repositories, control and treatment compared, opt-in read back."
+else
+  echo "FAILED: see the assertions above." >&2
+fi
+exit "$status"

--- a/corpus/showcase/CorpusShowcase.groovy.tmpl
+++ b/corpus/showcase/CorpusShowcase.groovy.tmpl
@@ -1,0 +1,156 @@
+package __PACKAGE__
+
+import se.deversity.vibetags.annotations.AIAudit
+import se.deversity.vibetags.annotations.AIBannedApi
+import se.deversity.vibetags.annotations.AIContext
+import se.deversity.vibetags.annotations.AIContract
+import se.deversity.vibetags.annotations.AICore
+import se.deversity.vibetags.annotations.AIGenerated
+import se.deversity.vibetags.annotations.AIIgnore
+import se.deversity.vibetags.annotations.AIImmutable
+import se.deversity.vibetags.annotations.AIInputSanitized
+import se.deversity.vibetags.annotations.AIKeepInSync
+import se.deversity.vibetags.annotations.AILoadBearing
+import se.deversity.vibetags.annotations.AILocked
+import se.deversity.vibetags.annotations.AIPerformance
+import se.deversity.vibetags.annotations.AIPrivacy
+import se.deversity.vibetags.annotations.AIPublicAPI
+import se.deversity.vibetags.annotations.AISecure
+import se.deversity.vibetags.annotations.AISecureLogging
+import se.deversity.vibetags.annotations.AITestDriven
+import se.deversity.vibetags.annotations.AIThreadSafe
+
+/**
+ * The Groovy twin of {@code CorpusShowcase.java}, compiled inside a third-party Groovy build by
+ * that project's own Gradle, through joint compilation.
+ *
+ * <p>Groovy reaches the processor by a different route from Kotlin and from Java. groovyc emits
+ * a Java stub per Groovy class and javac runs the processors over the stubs, which only happens
+ * when {@code groovyOptions.javaAnnotationProcessing} is switched on - and it is off by default
+ * in Gradle. A Groovy project that adds VibeTags and changes nothing else therefore generates
+ * nothing at all, silently. The init script switches it on, and the harness asserts output
+ * appeared, so the day that flag stops being honoured this goes red rather than quiet.
+ *
+ * <p><b>The fields below are here to fail.</b> groovyc's stub carries the class, its
+ * constructors, its methods and their parameters - and no fields whatsoever. Not renamed, not
+ * moved onto an accessor: absent. So every {@code FIELD}-targeted annotation is dropped before
+ * any processor is asked, {@code @AIPrivacy} among them, and that one is a safety-tier guardrail
+ * a Groovy author would reasonably expect to be the most reliable thing here.
+ *
+ * <p>Writing them {@code private} does not help, and that was the first guess: a Groovy field
+ * with no access modifier becomes a property, so the obvious theory was that the annotation had
+ * travelled onto a generated accessor. It has not. The stub was kept
+ * ({@code groovyOptions.keepStubs}) and read, and {@code billingEmail}, {@code authToken} and
+ * {@code tenantId} appear nowhere in it.
+ *
+ * <p>They stay in this file rather than being deleted, because a limitation nothing exercises is
+ * a limitation nobody notices has been fixed. {@code excluded_markers()} in
+ * corpus/run-corpus-jvm.sh names exactly these two, and the harness fails if they ever start
+ * being rendered - at which point the exclusion goes and USAGE.md's Groovy row gets rewritten.
+ *
+ * <p>Injected by corpus/run-corpus-jvm.sh and reverted with `git checkout -- .` afterwards.
+ */
+@AIContext(focus = "corpus groovy showcase: type level, non-safety, belongs in the granular tier",
+           avoids = "asserting anything about the third-party code around it")
+@AIPublicAPI
+class CorpusShowcase {
+
+    // ---- field level -------------------------------------------------------------------
+    //
+    // `private` is load-bearing: without it Groovy makes these properties, and a property is a
+    // getter and a setter around a synthetic field rather than the field an author annotated.
+
+    /** Safety tier: privacy stays inline in the aggregate. */
+    @AIPrivacy(reason = "corpus groovy showcase FIELD-PRIVACY: PII must never be logged")
+    private String billingEmail
+
+    /** Granular tier: a second field annotation that moves down. */
+    @AISecureLogging
+    private String authToken
+
+    /** Granular tier: a performance budget on a plain field. */
+    @AIPerformance(constraint = "corpus groovy showcase FIELD-PERFORMANCE: read on every request")
+    private long tenantId
+
+    // ---- constructor level -------------------------------------------------------------
+
+    @AILocked(reason = "corpus groovy showcase CONSTRUCTOR-LOCKED: initialisation order is load-bearing")
+    CorpusShowcase() {
+    }
+
+    @AIContract(reason = "corpus groovy showcase CONSTRUCTOR-CONTRACT: callers depend on this shape")
+    CorpusShowcase(String seed) {
+        this.billingEmail = seed
+    }
+
+    // ---- method level, safety tier -----------------------------------------------------
+
+    @AILocked(reason = "corpus groovy showcase METHOD-LOCKED: do not edit")
+    long invoiceNumber(long id) {
+        id
+    }
+
+    @AIAudit(checkFor = ["SQL injection", "path traversal"])
+    void audited(String query) {
+    }
+
+    @AISecure(aspect = "corpus groovy showcase METHOD-SECURE")
+    void secured() {
+    }
+
+    @AIIgnore(reason = "corpus groovy showcase METHOD-IGNORE: excluded from context")
+    void ignored() {
+    }
+
+    // ---- method level, granular tier, and the parameter level --------------------------
+
+    /**
+     * The parameter level is the finest addressing VibeTags produces. Under joint compilation it
+     * also depends on the stub keeping parameter names, which is the sort of thing that is true
+     * until a Groovy release makes it not.
+     */
+    @AIContract(reason = "corpus groovy showcase METHOD-CONTRACT: callers depend on this shape")
+    @AIPerformance(constraint = "corpus groovy showcase METHOD-PERFORMANCE: no allocation in the loop")
+    String render(
+            @AIInputSanitized([AIInputSanitized.SanitizerType.SQL_INJECTION,
+                               AIInputSanitized.SanitizerType.XSS]) String customerNote,
+            @AILoadBearing(invariant = "corpus groovy showcase PARAM-LOADBEARING: order matters here")
+            String other) {
+        customerNote + other
+    }
+
+    @AITestDriven(coverageGoal = 95)
+    void tested() {
+    }
+
+    @AIThreadSafe(note = "corpus groovy showcase METHOD-THREADSAFE")
+    void threadSafe() {
+    }
+
+    @AILoadBearing(invariant = "corpus groovy showcase METHOD-LOADBEARING: looks removable, is not")
+    void loadBearing() {
+    }
+
+    @AIKeepInSync(mirrors = ["corpus/showcase/CorpusShowcase.groovy.tmpl"])
+    void mirrored() {
+    }
+
+    @AIBannedApi(forbidden = ["java.util.Date"], useInstead = "java.time.Instant")
+    void bannedApis() {
+    }
+
+    @AIGenerated(from = "corpus/showcase/CorpusShowcase.groovy.tmpl")
+    void generated() {
+    }
+
+    // ---- nested type level -------------------------------------------------------------
+
+    /** A Groovy static nested class, so the element path matches the Java showcase's. */
+    @AIImmutable(note = "corpus groovy showcase NESTED-IMMUTABLE")
+    @AICore(sensitivity = "high", note = "corpus groovy showcase NESTED-CORE")
+    static final class Inner {
+        @AILocked(reason = "corpus groovy showcase NESTED-METHOD-LOCKED")
+        void innerMethod() {
+        }
+    }
+}

--- a/corpus/showcase/CorpusShowcase.kt.tmpl
+++ b/corpus/showcase/CorpusShowcase.kt.tmpl
@@ -1,0 +1,151 @@
+package __PACKAGE__
+
+import se.deversity.vibetags.annotations.AIAudit
+import se.deversity.vibetags.annotations.AIBannedApi
+import se.deversity.vibetags.annotations.AIContext
+import se.deversity.vibetags.annotations.AIContract
+import se.deversity.vibetags.annotations.AICore
+import se.deversity.vibetags.annotations.AIGenerated
+import se.deversity.vibetags.annotations.AIIgnore
+import se.deversity.vibetags.annotations.AIImmutable
+import se.deversity.vibetags.annotations.AIInputSanitized
+import se.deversity.vibetags.annotations.AIKeepInSync
+import se.deversity.vibetags.annotations.AILoadBearing
+import se.deversity.vibetags.annotations.AILocked
+import se.deversity.vibetags.annotations.AIPerformance
+import se.deversity.vibetags.annotations.AIPrivacy
+import se.deversity.vibetags.annotations.AIPublicAPI
+import se.deversity.vibetags.annotations.AISecure
+import se.deversity.vibetags.annotations.AISecureLogging
+import se.deversity.vibetags.annotations.AITestDriven
+import se.deversity.vibetags.annotations.AIThreadSafe
+
+/**
+ * The Kotlin twin of `CorpusShowcase.java`, compiled inside a third-party Kotlin build by that
+ * project's own Gradle, through kapt.
+ *
+ * Two things here are Kotlin's and not Java's, and both are the reason this file exists rather
+ * than being a translation exercise:
+ *
+ * **Use-site targets.** A Kotlin property is a getter, a setter and possibly a backing field, so
+ * an annotation written bare on a property does not necessarily land where a Java author would
+ * expect. Every `@AI*` annotation declares Java targets, and the ones that only accept `FIELD`
+ * are written `@field:` here on purpose. Getting this wrong does not fail the build - it moves
+ * the guardrail onto a different element, or drops it - which is exactly the failure a fixture
+ * written by somebody who knew the answer would never catch.
+ *
+ * **No package level.** Kotlin has no `package-info.kt`, so the package row of the Java showcase
+ * has no counterpart. That is a real limitation of the Kotlin route and is asserted as one:
+ * the harness does not look for a package guardrail here.
+ *
+ * Injected by corpus/run-corpus-jvm.sh and reverted with `git checkout -- .` afterwards.
+ */
+@AIContext(
+    focus = "corpus kotlin showcase: type level, non-safety, belongs in the granular tier",
+    avoids = "asserting anything about the third-party code around it",
+)
+@AIPublicAPI
+class CorpusShowcase {
+
+    // ---- field level -------------------------------------------------------------------
+    //
+    // @field: is load-bearing. @AIPrivacy targets FIELD only; written bare on a property Kotlin
+    // has no property target to fall back to for a Java annotation, and the result depends on
+    // the annotation's target set rather than on what the author meant.
+
+    /** Safety tier: privacy stays inline in the aggregate. */
+    @field:AIPrivacy(reason = "corpus kotlin showcase FIELD-PRIVACY: PII must never be logged")
+    private var billingEmail: String? = null
+
+    /** Granular tier: a second field annotation that moves down. */
+    @field:AISecureLogging
+    private var authToken: String? = null
+
+    /** Granular tier: a performance budget on a plain field. */
+    @field:AIPerformance(
+        constraint = "corpus kotlin showcase FIELD-PERFORMANCE: read on every request",
+    )
+    private var tenantId: Long = 0
+
+    // ---- constructor level -------------------------------------------------------------
+    //
+    // Annotating a Kotlin constructor requires the `constructor` keyword, which is why a
+    // secondary constructor is used for the second overload: two constructors that must be
+    // addressed by their own parameter lists, as in the Java showcase.
+
+    @AILocked(
+        reason = "corpus kotlin showcase CONSTRUCTOR-LOCKED: initialisation order is load-bearing",
+    )
+    constructor()
+
+    @AIContract(reason = "corpus kotlin showcase CONSTRUCTOR-CONTRACT: callers depend on this shape")
+    constructor(seed: String) {
+        this.billingEmail = seed
+    }
+
+    // ---- method level, safety tier -----------------------------------------------------
+
+    @AILocked(reason = "corpus kotlin showcase METHOD-LOCKED: do not edit")
+    fun invoiceNumber(id: Long): Long = id
+
+    @AIAudit(checkFor = ["SQL injection", "path traversal"])
+    fun audited(query: String) {
+        check(query.isNotEmpty() || true)
+    }
+
+    @AISecure(aspect = "corpus kotlin showcase METHOD-SECURE")
+    fun secured() = Unit
+
+    @AIIgnore(reason = "corpus kotlin showcase METHOD-IGNORE: excluded from context")
+    fun ignored() = Unit
+
+    // ---- method level, granular tier, and the parameter level --------------------------
+
+    /**
+     * The parameter level is the finest addressing VibeTags produces, and under kapt it is also
+     * the one most exposed to the stub generator: a parameter name that does not survive into
+     * the stub cannot be addressed at all.
+     */
+    @AIContract(reason = "corpus kotlin showcase METHOD-CONTRACT: callers depend on this shape")
+    @AIPerformance(constraint = "corpus kotlin showcase METHOD-PERFORMANCE: no allocation in the loop")
+    fun render(
+        @AIInputSanitized(
+            AIInputSanitized.SanitizerType.SQL_INJECTION,
+            AIInputSanitized.SanitizerType.XSS,
+        )
+        customerNote: String,
+        @AILoadBearing(invariant = "corpus kotlin showcase PARAM-LOADBEARING: order matters here")
+        other: String,
+    ): String = customerNote + other
+
+    @AITestDriven(coverageGoal = 95)
+    fun tested() = Unit
+
+    @AIThreadSafe(note = "corpus kotlin showcase METHOD-THREADSAFE")
+    fun threadSafe() = Unit
+
+    @AILoadBearing(invariant = "corpus kotlin showcase METHOD-LOADBEARING: looks removable, is not")
+    fun loadBearing() = Unit
+
+    @AIKeepInSync(mirrors = ["corpus/showcase/CorpusShowcase.kt.tmpl"])
+    fun mirrored() = Unit
+
+    @AIBannedApi(forbidden = ["java.util.Date"], useInstead = "java.time.Instant")
+    fun bannedApis() = Unit
+
+    @AIGenerated(from = "corpus/showcase/CorpusShowcase.kt.tmpl")
+    fun generated() = Unit
+
+    // ---- nested type level -------------------------------------------------------------
+
+    /**
+     * A Kotlin nested class is static unless declared `inner`, which matches the Java showcase's
+     * `static final class` and keeps the two element paths comparable.
+     */
+    @AIImmutable(note = "corpus kotlin showcase NESTED-IMMUTABLE")
+    @AICore(sensitivity = "high", note = "corpus kotlin showcase NESTED-CORE")
+    class Inner {
+        @AILocked(reason = "corpus kotlin showcase NESTED-METHOD-LOCKED")
+        fun innerMethod() = Unit
+    }
+}

--- a/corpus/showcase/CorpusShowcase.scala.tmpl
+++ b/corpus/showcase/CorpusShowcase.scala.tmpl
@@ -1,0 +1,68 @@
+package __PACKAGE__
+
+import se.deversity.vibetags.annotations.AIAudit
+import se.deversity.vibetags.annotations.AIContext
+import se.deversity.vibetags.annotations.AIContract
+import se.deversity.vibetags.annotations.AICore
+import se.deversity.vibetags.annotations.AILocked
+import se.deversity.vibetags.annotations.AIPrivacy
+import se.deversity.vibetags.annotations.AIPublicAPI
+import se.deversity.vibetags.annotations.AISecure
+
+/**
+ * The Scala half of the Scala corpus member, and the only showcase in the corpus that is
+ * asserted to produce **nothing**.
+ *
+ * scalac has no JSR 269 support. Java annotations are legal in Scala and compile without
+ * complaint, so a Scala author can write every annotation below, see a green build, and get no
+ * guardrails whatsoever. USAGE.md states that ("Scala | Java sources only | scalac has no JSR
+ * 269 support; annotated Scala classes compile but are never seen"), and until this file existed
+ * that sentence was prose nobody had run.
+ *
+ * The harness asserts the negative directly: none of the SCALA-INVISIBLE markers below may
+ * appear in any generated file, while the markers in the Java half of the same build must all
+ * appear. Both directions matter. If the negative assertion ever goes red, either scalac has
+ * gained annotation processing or VibeTags has found another way in - and either way the line
+ * in USAGE.md needs rewriting rather than the test relaxing.
+ *
+ * Injected by corpus/run-corpus-jvm.sh and reverted with `git checkout -- .` afterwards.
+ */
+@AIContext(focus = "corpus scala showcase SCALA-INVISIBLE-CONTEXT: must never be generated")
+@AIPublicAPI
+class CorpusShowcase {
+
+  @AIPrivacy(reason = "corpus scala showcase SCALA-INVISIBLE-PRIVACY: PII, and still not seen")
+  private var billingEmail: String = _
+
+  @AILocked(reason = "corpus scala showcase SCALA-INVISIBLE-LOCKED: do not edit")
+  def invoiceNumber(id: Long): Long = id
+
+  @AIAudit(checkFor = Array("SQL injection", "path traversal"))
+  def audited(query: String): Unit = ()
+
+  @AISecure(aspect = "corpus scala showcase SCALA-INVISIBLE-SECURE")
+  def secured(): Unit = ()
+
+  @AIContract(reason = "corpus scala showcase SCALA-INVISIBLE-CONTRACT: frozen shape")
+  def render(customerNote: String, other: String): String = customerNote + other
+}
+
+/**
+ * A Scala `object`, which has no Java counterpart at all. If anything ever did start reading
+ * Scala sources, this is the construct whose element path would have to be invented, so it is
+ * here to be found rather than discovered later.
+ */
+@AICore(sensitivity = "high", note = "corpus scala showcase SCALA-INVISIBLE-CORE")
+object CorpusShowcaseObject {
+  @AILocked(reason = "corpus scala showcase SCALA-INVISIBLE-OBJECT-LOCKED")
+  def helper(): Unit = ()
+}
+
+/** A case class and a trait, for the same reason. */
+@AIContext(focus = "corpus scala showcase SCALA-INVISIBLE-CASECLASS")
+case class CorpusShowcaseValue(id: Long, label: String)
+
+@AIContext(focus = "corpus scala showcase SCALA-INVISIBLE-TRAIT")
+trait CorpusShowcaseTrait {
+  def describe(): String
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **VibeTags is now tested against real Kotlin, Groovy and Scala, and the Groovy row of the
+  support matrix turned out to be wrong.** The third-party corpus added in the previous release
+  covers six Java libraries compiled by javac. That is the compiler JSR 269 belongs to, and it is
+  also the only one the project had ever been measured on outside its own examples. Kotlin reaches
+  the processor through kapt, Groovy only when joint compilation's `javaAnnotationProcessing` is
+  switched on, and Scala not at all. USAGE.md had stated all three for several releases; none had
+  been run against anybody else's code.
+
+  Three more repositories are now built on every CI run — [`kotlin-obd-api`][k], [`nf-boost`][g]
+  and [`splain`][s] — each twice, by its own Gradle wrapper, the only difference between the runs
+  being a Gradle init script. An init script is the supported way to add a plugin to a build you do
+  not own, so nothing edits a build file it did not write. Sixteen assertions, including the tier
+  split and the granular directories, checked through three compilers instead of one.
+
+  **What it found, in Groovy: every field-level annotation is silently dropped.** groovyc's Java
+  stubs carry the class, its constructors, its methods and their parameters — and no fields at all.
+  So `@AIPrivacy` on a Groovy field generates nothing. No file, no warning, no trace. It is one of
+  the six safety annotations and the natural way to mark a PII field, and until this ran the
+  documentation called that route "Full (joint compilation)".
+
+  The obvious explanation was wrong and is worth recording: a Groovy field with no access modifier
+  becomes a property, so the first theory was that the annotation had moved onto a generated
+  accessor. Keeping the stubs (`groovyOptions.keepStubs`) and reading one settled it — `billingEmail`,
+  `authToken` and `tenantId` appear nowhere in the stub. Nothing in VibeTags can fix that, so it is
+  documented instead, and pinned: the Groovy showcase annotates those fields on purpose and the
+  harness fails if they ever *start* being rendered, because a limitation nothing exercises is a
+  limitation nobody notices has been fixed.
+
+  Scala is asserted as a negative for the same reason, in both directions: annotated `.scala` must
+  generate nothing, the Java half of the same build must generate everything, and the Scala
+  showcase must have produced class files — otherwise "scalac generated nothing" and "scalac was
+  never asked" are the same green run.
+
+  Three further findings came out of choosing the members. Three of the eight Groovy repositories
+  surveyed compile perfectly well and break the moment stubs are generated, each on a different
+  stub defect. Two more fail because a Gradle toolchain pinned below 21 cannot load the processor,
+  with an error naming neither VibeTags nor the toolchain. And the harness's own diagnostic counter
+  was blind to javac's summary diagnostics, reporting `0` against `0` on a run that had raised a
+  warning the control had not. All of it is in [corpus/README.md][c].
+
+  [k]: https://github.com/eltonvs/kotlin-obd-api
+  [g]: https://github.com/bentsherman/nf-boost
+  [s]: https://github.com/tek/splain
+  [c]: ../corpus/README.md#the-other-three-jvm-languages
+
 - **A constructor can carry a guardrail.** No annotation declared `ElementType.CONSTRUCTOR`, so a
   constructor could not be guarded at all. That was odd rather than obviously wrong: `ElementNaming`
   has always rendered constructors, because javac hands them to the collector as enclosed elements

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -186,6 +186,35 @@ annotations in its rendering and VibeTags deliberately does not, which moves out
 consumer using jspecify or the Checker Framework. [corpus/README.md](../corpus/README.md) has
 the reasoning and the full repo table.
 
+### Job: `corpus-jvm`
+
+The same question in Kotlin, Groovy and Scala. `corpus/run-corpus-jvm.sh` clones three
+permissively licensed repositories at pinned SHAs and builds each **twice with its own Gradle
+wrapper**, the only difference being `corpus/inject-vibetags.init.gradle` — an init script,
+because that is the supported way to add a plugin to a build you do not own, and it means nothing
+here edits a build file it did not write.
+
+It is a separate job from `corpus` because none of these languages reaches the processor the way
+Java does: Kotlin only through kapt, Groovy only when joint compilation's `javaAnnotationProcessing`
+is switched on, Scala not at all. `--rerun-tasks` is passed on every invocation, because otherwise
+Gradle's up-to-date checks let the treatment skip compilation entirely and the whole comparison
+becomes a green run that compiled nothing.
+
+The Scala member asserts a negative and its own anti-vacuity guard: annotated `.scala` must
+generate nothing, the Java half of the same build must generate everything, and the Scala showcase
+must have produced class files — otherwise "scalac generated nothing" and "scalac was never asked"
+are the same result.
+
+It found that **Groovy silently drops every field-level annotation**: groovyc's stubs carry types,
+constructors, methods and parameters and no fields, so `@AIPrivacy` on a Groovy field generates
+nothing at all. USAGE.md called that route "Full (joint compilation)" until this job ran.
+[corpus/README.md](../corpus/README.md#the-other-three-jvm-languages) has the stub evidence, the
+other findings, and the eight-repository survey behind the choice of Groovy member.
+
+Two caches: the checkouts on the manifest and harness hashes, and `~/.gradle` on the manifest,
+because six Gradle builds otherwise re-download a distribution each and that is most of the job's
+wall clock.
+
 ### Job: `ecj-degradation`
 
 The one leg that does not run javac. `scripts/ecj-degradation-check.sh` compiles


### PR DESCRIPTION
Extends the third-party corpus to Kotlin, Groovy and Scala.

> **Stacked on #491.** The base branch is `fix/issues-487-490`, not `main`, because this builds
> directly on the opt-in phase and `check-platforms.py` that #491 adds to `corpus/`. Merge #491
> first; this PR's diff against `main` will then be just these commits.

## Why

`corpus/run-corpus.sh` covers six Java libraries compiled by javac. That is the compiler JSR 269
belongs to, and it was also the only one this project had ever been measured on outside its own
examples. The other three JVM languages reach the processor by different routes, and USAGE.md has
described all three for several releases without any of them being run against anybody else's code:

| Language | Route |
|---|---|
| Kotlin | kapt generates Java stubs and runs the processor over them; KSP does not run JSR 269 processors |
| Groovy | groovyc generates stubs the same way, but only when `javaAnnotationProcessing` is on, and it is off by default |
| Scala | scalac has no JSR 269 support at all |

## What this adds

Three repositories, built twice each by their own Gradle wrapper, the only difference between the
runs being `corpus/inject-vibetags.init.gradle`. An init script is the supported way to add a
plugin to a build you do not own, so nothing here edits a build file it did not write.

| Repo | Lang | Licence | Result |
|---|---|---|---|
| [`eltonvs/kotlin-obd-api`](https://github.com/eltonvs/kotlin-obd-api) | Kotlin | Apache-2.0 | 15/15 markers |
| [`bentsherman/nf-boost`](https://github.com/bentsherman/nf-boost) | Groovy | Apache-2.0 | 13/13, two documented exclusions |
| [`tek/splain`](https://github.com/tek/splain) | Scala | MIT | 17/17 from the Java half, 0 from the Scala half |

Sixteen assertions (J0-J9b), including Claude/Gemini/Codex opt-in, both granular directories and
the tier split, now checked through three compilers instead of one. Nothing is vendored.

## What it found

**Groovy silently drops every field-level annotation.** groovyc's stub carries the class, both
constructors, all twelve methods and both parameters of `render` with their annotations intact,
and no fields at all. So `@AIPrivacy` on a Groovy field generates nothing: no file, no warning, no
trace. It is one of the six safety annotations and the natural way to mark a PII field.

The first explanation was wrong, which is worth recording. A Groovy field with no access modifier
becomes a property, so the obvious theory was that the annotation had moved onto a generated
accessor. It had not. Keeping the stubs (`groovyOptions.keepStubs`) and reading one settles it -
`billingEmail`, `authToken` and `tenantId` appear nowhere in it.

Nothing in VibeTags can fix that, so USAGE.md's Groovy row changes from **"Full (joint
compilation)"** to **"Types and methods only"**, with the mechanism spelled out. And it is pinned
rather than just written down: the Groovy showcase annotates those fields on purpose,
`excluded_markers()` names the two markers, and **J6g fails if they ever start being rendered** -
because a limitation nothing exercises is a limitation nobody notices has been fixed.

**Most real Groovy projects cannot switch annotation processing on at all.** Eight were tried
before one could be used. Three compile perfectly well and break the moment stubs are generated,
each on a different stub defect (`'_' is a keyword`; `illegal combination of modifiers: public and
private`; `method does not override or implement a method from a supertype`). Two more fail
because a Gradle toolchain pinned below 21 cannot load the processor - `class file version 65.0` -
an error naming neither VibeTags nor the toolchain. Full table in `corpus/README.md`.

**And one in the harness, which is why J2 can be trusted.** The diagnostic counter required a
colon before the word (`: warning:`) and javac emits its summary diagnostics with no file prefix,
so a treatment run that raised a warning the control had not was counted `0` against `0`. A parity
check blind to a whole class of diagnostic is worse than none, because it reports as a pass.

## Design notes

- **J2 is line-based, not count-based.** Switching VibeTags on adds the kapt task graph to a Kotlin
  build and joint compilation to a Groovy one, and those emit diagnostics about the machinery
  rather than about VibeTags. Every new line must be absent or named; the allow-list has exactly
  one entry, carrying its evidence and the limits of that evidence.
- **J6f/J6g are a pair.** Where a language genuinely cannot render a guardrail the marker is named
  with the reason, and both directions are checked.
- **J9b exists so J9 cannot pass vacuously.** The cheapest way for "annotated Scala generated
  nothing" to be true is for scalac never to have seen the file.
- **`--rerun-tasks` on every invocation.** Otherwise Gradle's up-to-date checks let the treatment
  skip compilation and the comparison becomes a green run that compiled nothing.
- **The init script skips `buildSrc`.** splain's is Kotlin; without the guard the Scala member
  would run kapt over the build logic of a Scala project.

## Verification

- `corpus/run-corpus-jvm.sh`: green on all three members, exit 0.
- **J6g proved failing-first**: excluding `METHOD-LOCKED`, which does render, turned the run red
  with the intended message. Reverted afterwards.
- `mvn test -Pe2e`: **2403 tests, 0 failures**.
- `pre-commit`: gitleaks and the whitespace hooks passed. **checkstyle skipped, not passed** - no
  Docker daemon here; it also runs bound to `validate` in the Maven build.
- `corpus/run-corpus-jvm.sh` committed mode `100755`.

## Follow-ups

Filed as issues rather than left in this body.


- #493 - kapt reports `vibetags.root` as an unrecognised processor option. Allow-listed in J2 as
  unattributed, not as harmless; a second, different diagnostic still fails the check.
- #494 - can a Groovy consumer be warned that field-level guardrails are being dropped? VibeTags
  cannot see the annotation, so anything here has to be inferred from context. Three options
  weighed, including one that cuts against tier-1 invariant 1.
