### PR TITLE
docs: state what Kotlin, Groovy and Scala actually get, and unblock dependabot

### DIFF
--- a/.claude/skills/bump-dependencies/SKILL.md
+++ b/.claude/skills/bump-dependencies/SKILL.md
@@ -39,10 +39,10 @@ Edit the property in `vibetags-parent/pom.xml`. Then the places that cannot inhe
 
 | Pin | Also lives in |
 |-----|---------------|
-| `junit.version`, `junit.platform.version`, `mockito.version`, `archunit.version`, `async-test-lib.version`, `snakeyaml.version`, `logback.version`, `slf4j.version`, `jspecify.version` | `vibetags/build.gradle` (coordinates; `BuildVersionParityTest` enforces) |
-| `pmd.version` | `toolVersion` in `vibetags/build.gradle` and `vibetags-annotations/build.gradle` (enforced) |
+| `junit.version`, `junit.platform.version`, `mockito.version`, `archunit.version`, `async-test-lib.version`, `snakeyaml.version`, `logback.version`, `slf4j.version`, `jspecify.version` | nothing to edit. `vibetags/build.gradle` reads each one from the parent via `pomVersion(...)`; `BuildVersionParityTest` enforces that it keeps doing so |
+| `pmd.version` | nothing. Both Gradle builds derive it from the parent, and `BuildVersionParityTest` fails any file that reintroduces a literal |
 | `maven-compiler-plugin.version` | literals in `examples/basic/pom.xml`, `examples/multimodule/pom.xml`, `examples/multimodule-indexed/pom.xml`, `examples/all-tiers/pom.xml`, `tools/demo/pom.xml` (consumer poms; keep them in step) |
-| Gradle wrapper | `gradle/wrapper/gradle-wrapper.properties` in `vibetags`, `vibetags-annotations`, `example`, `examples/kotlin`, `examples/groovy`, `examples/scala`; the version named in `docs/DEPENDENCIES.md` |
+| Gradle wrapper | every `gradle-wrapper.properties` in the repository - ten of them, not the six this row used to list; enumerate with `git ls-files '*gradle-wrapper.properties'` rather than trusting the list - plus the version named in `docs/DEPENDENCIES.md` |
 | Kotlin | `examples/kotlin/build.gradle.kts` (`jvm` and `kapt`), the snippets in `README.md` and `examples/kotlin/README.md` |
 | Groovy, Scala | `examples/groovy/build.gradle`, `examples/scala/build.gradle` (Scala stays on the 2.13 line: the example is about Java-only support) |
 | pre-commit hook revs | `python -m pre_commit autoupdate`; the `checkstyle` hook runs in Docker, so unless Docker is available revert its rev and say so - an unverifiable bump is not a verified one |

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,11 +28,30 @@ updates:
     schedule:
       interval: daily
 
-  - package-ecosystem: maven
-    directory: /example
-    schedule:
-      interval: daily
-
+  # /vibetags is the only Maven directory that needs to be listed, and it reaches further than
+  # it looks. Every third-party version in this build is a <name.version> property in
+  # vibetags-parent/pom.xml (tier-1 invariant 14), and dependabot resolves the parent from the
+  # child: #470 was opened "in /vibetags" and its diff edits vibetags-parent/pom.xml. So one
+  # entry covers all 33 pins.
+  #
+  # This used to sit alongside `directory: /example`, which has never existed - the examples live
+  # under examples/, each with its own pom. That entry produced nothing at all, silently, which is
+  # the same failure the npm entry above carries a comment about. It is gone rather than
+  # redirected, and deliberately:
+  #
+  #   - examples/*/pom.xml and tools/demo/pom.xml pin se.deversity.vibetags artifacts at the
+  #     released version. That number is owned by scripts/set-version.sh, and
+  #     BuildVersionParityTest fails if it disagrees with <revision>. A dependabot PR moving it
+  #     would be red on arrival and could never merge.
+  #   - Their maven-compiler-plugin literals are mirrors of the parent property. Bumping the copy
+  #     without the original is the drift the mirror table in the bump-dependencies skill exists
+  #     to prevent.
+  #
+  # Both are release-managed rather than dependency-managed, so they belong to that skill and to
+  # set-version.sh, not here.
+  #
+  # load-tests/pom.xml is absent for a third reason: its <processor.version> is pinned
+  # independently so benchmarks can compare across releases, and force-bumping it is a bug.
   - package-ecosystem: maven
     directory: /vibetags
     schedule:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,8 @@ cd examples/basic && mvn clean compile     # consumer fixture; library must be i
 - [docs/PROCESSOR.md](docs/PROCESSOR.md) — processor options, write cache + fingerprint short-circuit, check mode, `.vibetags-locks`, SPI/Gradle incremental.
 - [docs/ANNOTATIONS.md](docs/ANNOTATIONS.md) — adding or changing an annotation: full table, semantics, validation warnings.
 - [docs/PLATFORMS.md](docs/PLATFORMS.md) — adding a platform, or a question about a specific output file.
+- [docs/JVM-LANGUAGES.md](docs/JVM-LANGUAGES.md) — Kotlin, Groovy, Scala and Clojure: what is
+  supported, what is silently lost, and how each rating is measured rather than claimed.
 - [docs/TESTS.md](docs/TESTS.md) — which test class covers what.
 - [docs/DEPENDENCIES.md](docs/DEPENDENCIES.md) — every third-party artifact, why it is here, what ships to consumers and what only runs the build.
 - [docs/LOAD-BEARING.md](docs/LOAD-BEARING.md) — processing flow, marker rules, the scoped-rules index, the internal class map, and the invariants in full.

--- a/USAGE.md
+++ b/USAGE.md
@@ -124,6 +124,11 @@ language's toolchain ever hand javac something carrying the annotations? Nothing
 itself is language-specific — each language below is a standalone example consumer plus this
 matrix, and adding one never touches the processor.
 
+> **Before adopting VibeTags in a Kotlin, Groovy or Scala project, read
+> [docs/JVM-LANGUAGES.md](docs/JVM-LANGUAGES.md).** It states the maturity of each route, what
+> each one silently drops, and how every claim is measured against third-party code on each pull
+> request. The summary below is the quick version; that page is where the limitations live.
+
 | Language | Support | Mechanism |
 |---|---|---|
 | Java | Full | javac runs the processor directly |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **[docs/JVM-LANGUAGES.md](JVM-LANGUAGES.md): what Kotlin, Groovy and Scala actually get.** The
+  support matrix in USAGE.md was three rows and a mechanism column, and one of the rows was wrong
+  for several releases. This page gives each language a stated maturity, the levels it silently
+  drops, the workaround, and the job that measures the claim on every pull request.
+
+  It also records the things a matrix row cannot: that Groovy loses every field-level annotation
+  including `@AIPrivacy`, with the stub evidence; that only two of eight surveyed Groovy projects
+  can switch stub processing on at all; that a Gradle toolchain pinned below 21 fails with an error
+  naming neither VibeTags nor the toolchain; and that Kotlin support rests entirely on kapt, which
+  JetBrains keeps current but has no plans to extend, while KSP defines its own processor interface
+  and cannot load a JSR 269 processor at all. A closing section states what is *not* known, so
+  silence is not mistaken for evidence.
+
 - **VibeTags is now tested against real Kotlin, Groovy and Scala, and the Groovy row of the
   support matrix turned out to be wrong.** The third-party corpus added in the previous release
   covers six Java libraries compiled by javac. That is the compiler JSR 269 belongs to, and it is
@@ -68,6 +81,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   objects by design. Both exclusions are named in `ConstructorLevelGuardrailTest` with the
   reasoning, so a later sweep that "completes" the set has to argue with it. Found by the
   third-party corpus, whose showcase failed to compile. (#488)
+
+### Changed
+
+- **A dependabot bump of `pmd.version` no longer turns the build red.** Every third-party version
+  is a property in `vibetags-parent/pom.xml`, and dependabot edits that file and nothing else,
+  because that is where the property lives. PMD's `toolVersion` was a hand-copied literal in
+  `vibetags/build.gradle` and `vibetags-annotations/build.gradle`, so `BuildVersionParityTest`
+  failed on every PMD bump and a human had to hand-fix the PR before it could merge, which is not
+  what an automated bump is for. Both files now derive the value from the parent.
+
+  `BuildVersionParityTest` was rewritten with it, and that half matters more than the fix: the old
+  check compared the literal against the parent, which finds nothing once there is no literal left,
+  so it would have started passing vacuously. It now asserts the *mechanism* - a quoted
+  `toolVersion` fails even when the number is correct, and a file applying PMD that never names
+  `pmd.version` fails too. Verified by simulating the exact dependabot edit: bumping `pmd.version`
+  in the parent alone passes with the fix and fails without it.
+
+- **Dependabot's `/example` Maven entry pointed at a directory that has never existed.** The
+  examples live under `examples/`, so that entry produced nothing, silently - the same failure the
+  npm entry in the same file already carries a comment about. Removed rather than redirected, with
+  the reason recorded: the example poms pin VibeTags artifacts at the released version, which
+  `scripts/set-version.sh` owns and `BuildVersionParityTest` enforces, so a dependabot PR moving
+  one would be red on arrival and could never merge. The remaining `/vibetags` entry reaches every
+  pin already, through the parent.
+
+- **`ecj.version` 3.44.0 to 3.46.0, and the Gradle wrapper 9.7.0 to 9.7.1** across all ten
+  `gradle-wrapper.properties` files. The ECJ pin had been invisible to `scripts/bump-dependencies.sh`
+  since it was introduced: the script's `PINS` table had no Maven Central path for it, so the report
+  exited 2 rather than reporting a stale version. Adding the path is what surfaced the update.
+  Verified by `scripts/ecj-degradation-check.sh` on 3.46.0: 9 locked entries under both compilers,
+  9 positions under javac and 0 under ECJ, and 147 lines of guardrail region byte-identical.
+
+  The mirror tables in `docs/DEPENDENCIES.md` and the `bump-dependencies` skill were both wrong
+  about the wrapper: they said three subprojects and six files respectively, against ten actual
+  files. Both now say to enumerate rather than remember.
 
 ### Fixed
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -106,7 +106,10 @@ so what consumers download is self-contained.
 - **GitHub Actions** are pinned to commit SHAs, not tags, with the human-readable version in a
   trailing comment. Dependabot proposes the bumps. Pinning is what the OSSF Scorecard
   Pinned-Dependencies check wants, and it is also the only form that cannot be moved under you.
-- **Gradle wrapper**, `gradle-9.7.0-bin.zip` in three subprojects. The checked-in
+- **Gradle wrapper**, `gradle-9.7.1-bin.zip` in ten `gradle-wrapper.properties` files: the two
+  published modules and the eight examples. This entry said "three subprojects" for several
+  releases while the count grew to ten, which is the kind of number worth counting rather than
+  remembering (`git ls-files '*gradle-wrapper.properties'`). The checked-in
   `gradle-wrapper.jar` files are validated against Gradle's published checksums by
   `.github/workflows/gradle-wrapper-validation.yml`, which must run on every push to main for
   Scorecard's Binary-Artifacts check to accept them.
@@ -119,13 +122,23 @@ so what consumers download is self-contained.
 build itself enforces:
 
 - The Gradle files cannot inherit from a Maven parent, so `vibetags/build.gradle`,
-  `vibetags-annotations/build.gradle` and `examples/basic/build.gradle` repeat the coordinates as literals.
+  `vibetags-annotations/build.gradle` and `examples/basic/build.gradle` **read** the parent's
+  properties rather than repeating them: `pomVersion('junit.version')` and the rest parse
+  `vibetags-parent/pom.xml` at configuration time.
 - The example poms are standalone on purpose, so a reader can lift one into their own project.
 
-`BuildVersionParityTest` fails the build when either copy drifts from the parent, when a managed pom
-grows a version literal, or when a Gradle module's PMD `toolVersion` disagrees. That last check
-exists because it had already happened: `vibetags-annotations` sat on PMD 7.24.0 while everything
-else was on 7.26.0, so the two modules were analysed by different rule sets.
+`BuildVersionParityTest` fails the build when a copy drifts from the parent, when a managed pom
+grows a version literal, and when a Gradle module applying PMD does not derive its `toolVersion`
+from `pmd.version`.
+
+That last check used to compare the literal against the parent instead, which reads the same and
+is weaker. It exists because the drift had already happened - `vibetags-annotations` sat on PMD
+7.24.0 while everything else was on 7.26.0, so two modules were analysed by different rule sets -
+but comparing the literal made every automated bump fail. Dependabot edits `vibetags-parent/pom.xml`
+and nothing else, because that is where the property lives, so each PMD bump arrived as a red PR
+needing a hand-fix before it could merge. Deriving the value removes the copy the check was
+policing; asserting the *mechanism* is what stops the check passing vacuously once there is no
+literal left to compare.
 
 To bump the VibeTags release version itself, use `scripts/set-version.sh <version>` and then run
 that test.

--- a/docs/JVM-LANGUAGES.md
+++ b/docs/JVM-LANGUAGES.md
@@ -1,0 +1,283 @@
+# JVM language support: maturity and limitations
+
+VibeTags is a JSR 269 annotation processor, so one question decides everything on this page:
+
+> Does the language's toolchain ever hand **javac** a declaration carrying the annotation?
+
+Nothing in VibeTags is language-specific. There is no Kotlin code path and no Groovy renderer. A
+language is supported to exactly the extent that its compiler produces something javac sees, and
+the differences below are differences between those toolchains, not between features anyone chose
+to build.
+
+This page states each rating and, more importantly, **how it is checked**. Every claim here was
+measured against a third-party repository on a pinned commit, by the `JVM-Language Corpus (Kotlin,
+Groovy, Scala)` job that runs on every pull request. Before that job existed, this page's contents
+were prose that nobody had run, and one of the claims was wrong for several releases.
+
+## The ratings
+
+| Rating | Means |
+|---|---|
+| **Supported** | Every level VibeTags addresses is rendered. Verified on code nobody wrote for VibeTags. |
+| **Supported, one level lost** | Most levels render; a named level does not, for a reason outside VibeTags' control. |
+| **Partial by construction** | Only part of the build ever reaches the processor. |
+| **Not possible** | No path even in principle. |
+
+| Language | Rating | What reaches the processor | Verified by |
+|---|---|---|---|
+| Java | **Supported** | javac runs the processor directly | `corpus/run-corpus.sh`, six libraries, 15,683 members |
+| Kotlin | **Supported, one level lost** (package) | kapt generates Java stubs and runs the processor over them | `kotlin-obd-api`, 15 of 15 guardrails rendered |
+| Groovy | **Supported, one level lost** (field) | groovyc stubs, but only with `javaAnnotationProcessing` on | `nf-boost`, 13 of 13 expected, 2 field guardrails absent |
+| Scala | **Partial by construction** | the Java sources of a mixed module; never `.scala` | `splain`, 17 from the Java half, 0 from the Scala half |
+| Clojure | **Not possible** | nothing | n/a |
+
+---
+
+## Java
+
+The reference implementation, and the only one with no caveat. Every level VibeTags addresses
+renders: package, type, nested type, field, constructor, method, parameter.
+
+Measured continuously over six libraries at pinned commits, roughly 495 files and 15,683 members,
+none of which were written with VibeTags in mind. See [corpus/README.md](../corpus/README.md).
+
+---
+
+## Kotlin
+
+**Rating: supported, one level lost.**
+
+Every `@AI*` annotation is a plain Java annotation with `SOURCE` retention, so it applies to Kotlin
+declarations unchanged. kapt generates a Java stub per Kotlin class and runs JSR 269 processors
+over the stubs.
+
+### What was measured
+
+15 of 15 guardrails the showcase declares reached the generated files, across **type, nested type,
+field, constructor, method and parameter**. `@AIPrivacy` on a Kotlin property renders as
+`vibetagscorpus.CorpusShowcase.billingEmail`, in the safety bucket, inline in the Tier-1 aggregate
+where it belongs. Claude, Gemini and Codex all produced output, and both granular rule directories
+were written.
+
+### What is lost, and why
+
+- **The package level.** Kotlin has no `package-info.kt`, so there is no compilation unit for a
+  package annotation to live on. Thirteen annotations accept `ElementType.PACKAGE` and none of them
+  can be used from Kotlin. There is no workaround; put the guardrail on the types instead.
+- **Method-body-scoped annotations.** Stubs carry no method bodies, so an annotation on a local
+  declaration inside a function is never seen. Class-level and function-level annotations, which is
+  the normal usage, work fully.
+- **Source positions describe the stub.** The `.vibetags-locks` report's line ranges would point
+  into the generated stub rather than the `.kt` file, so do not opt a pure-Kotlin module into the
+  locks report.
+
+### Use-site targets are load-bearing
+
+A Kotlin property is a getter, a setter and possibly a backing field. An annotation written bare on
+a property does not necessarily land where a Java author would expect, and getting it wrong does
+not fail the build: it moves the guardrail onto a different element, or drops it. Annotations
+declaring only `ElementType.FIELD` should be written with the `@field:` target:
+
+```kotlin
+@field:AIPrivacy(reason = "Billing email identifies a natural person; never log it")
+private var billingEmail: String? = null
+```
+
+### The strategic risk, stated plainly
+
+Kotlin support rests entirely on kapt, and **kapt is in maintenance mode**: JetBrains keeps it
+current with new Kotlin and Java releases but has no plans to add features, and recommends KSP for
+annotation processing ([kapt](https://kotlinlang.org/docs/kapt.html),
+[KSP overview](https://kotlinlang.org/docs/ksp-overview.html),
+[migration guide](https://kotlinlang.org/docs/ksp-kapt-migration.html)).
+
+KSP is not a route for VibeTags as it stands. KSP defines its own processor interface
+(`SymbolProcessor`) rather than implementing `javax.annotation.processing.Processor`, so a JSR 269
+processor is not loadable by it. A Kotlin project that has migrated fully to KSP cannot run
+VibeTags at all.
+
+This is the largest single exposure in the matrix. Kotlin support does not degrade gradually if
+kapt is ever withdrawn; it goes from "one level lost" to nothing, and the only in-principle fix is
+a separate KSP processor reading the same annotations. Nothing about that is imminent, and no
+deprecation has been announced. It is written down here because the alternative is finding out
+from a release note.
+
+---
+
+## Groovy
+
+**Rating: supported, one level lost.**
+
+groovyc emits a Java stub per Groovy class and javac runs the processors over the stubs, the same
+shape as kapt. The switch is off by default in Gradle, so a Groovy project that adds VibeTags and
+changes nothing else generates **nothing at all, silently**:
+
+```groovy
+tasks.withType(GroovyCompile).configureEach {
+    groovyOptions.javaAnnotationProcessing = true
+    options.annotationProcessorPath = configurations.annotationProcessor
+    options.compilerArgs << "-Avibetags.root=${projectDir.absolutePath}"
+}
+```
+
+### Field-level annotations are dropped
+
+This is the limitation worth reading twice, because it is silent and it affects a safety
+annotation.
+
+groovyc's stub carries the class, its constructors, its methods and their parameters, with every
+annotation intact, and **no fields whatsoever**. So `@AIPrivacy`, `@AISecureLogging`,
+`@AIPerformance` and every other `ElementType.FIELD` annotation on a Groovy field reaches no
+processor and generates nothing. There is no warning, because nothing in the compilation ever sees
+the annotation.
+
+`@AIPrivacy` is one of the six safety annotations that stay inline in the Tier-1 aggregate,
+precisely so they reach an agent that never opens the file. In Groovy, marking a PII field does
+nothing, and the build stays green.
+
+The obvious explanation is wrong, which is worth recording. A Groovy field with no access modifier
+becomes a property, so the natural theory is that the annotation moved onto a generated accessor.
+It did not. Keeping the stubs (`groovyOptions.keepStubs`) and reading one settles it:
+
+```java
+@AIContext(...) @AIPublicAPI() public class CorpusShowcase
+@AILocked(reason="...CONSTRUCTOR-LOCKED...") public CorpusShowcase
+@AILocked(reason="...METHOD-LOCKED...") public long invoiceNumber(long id) { return (long)0;}
+@AIContract(...) public String render(@AIInputSanitized(...) String customerNote, ...)
+```
+
+The three annotated fields appear nowhere in it. Declaring them `private` does not help: that only
+stops Groovy making them properties, and the stub omits them either way.
+
+**What to do instead:** put the guardrail on the accessor or on the enclosing type, or keep the
+rule in the hand-authored region outside the `VIBETAGS-START`/`END` markers.
+
+This is pinned rather than merely written down. The Groovy showcase in the corpus annotates fields
+on purpose, the harness expects those two guardrails to be missing, and it **fails if they ever
+start appearing** - at which point this section gets rewritten instead of quietly aging.
+
+### Most Groovy projects cannot switch stub processing on at all
+
+The levels above describe what happens once it works. Whether it works is a separate question, and
+for real Groovy code the answer is often no. Eight Groovy repositories were surveyed before one
+could be used as a corpus member:
+
+| Repository | Outcome once `javaAnnotationProcessing` is on |
+|---|---|
+| `jenkinsci/JenkinsPipelineUnit` | stub rejected: `'_' is a keyword, and may not be used as an identifier` |
+| `int128/gradle-ssh-plugin` | stub rejected: `illegal combination of modifiers: public and private` |
+| `longwa/build-test-data` | stub rejected: `method does not override or implement a method from a supertype` |
+| `jk1/Gradle-License-Report` | toolchain pinned to Java 17: `class file version 65.0` |
+| `allegro/axion-release-plugin` | toolchain pinned to Java 17: same |
+| `jwagenleitner/groovy-wslite` | wrapper too old: `Could not determine java version from '21.0.9'` |
+| `gpc/grails-postgresql-extensions` | compiles |
+| `bentsherman/nf-boost` | compiles |
+
+Three of the eight compile perfectly well on their own and break the moment stubs are generated,
+each on a different stub defect. That is a property of groovyc's stub generator, not of VibeTags,
+and a user hitting it sees a compile error in a file they did not write, under
+`build/tmp/compileGroovy/groovy-java-stubs`.
+
+**Try it on a branch before committing to it.** If the stubs compile, Groovy support is real; if
+they do not, no amount of VibeTags configuration will help.
+
+---
+
+## Scala
+
+**Rating: partial by construction.**
+
+scalac has no JSR 269 support of any kind. Java annotations are legal in Scala and compile without
+complaint, so an author can annotate a Scala class, see a green build, and get no guardrails at
+all. Only the Java sources of a mixed module reach the processor, compiled by javac as normal.
+
+### Both directions are measured
+
+Asserting the negative matters as much as the positive here, and the corpus does both in one build:
+
+- the **Java** half must generate everything: 17 of 17 guardrails, including the package level.
+- the **Scala** half is annotated at every level it can be, and every one of those markers must be
+  absent from every generated file.
+- the Scala showcase must have produced class files. Without that third check, "scalac generated
+  nothing" and "scalac was never asked" are the same green run.
+
+If the negative ever fails, either scalac has gained annotation processing or VibeTags has found
+another way in, and this section needs rewriting rather than the test relaxing.
+
+### What to do instead
+
+Put guardrails on thin annotated Java types next to the Scala they protect; javac compiles
+`src/main/java` normally in a mixed module. For rules that have no Java surface, the hand-authored
+region outside the `VIBETAGS-START`/`END` markers is the right home, and it survives regeneration.
+
+---
+
+## Clojure
+
+**Rating: not possible.** There is no javac in the pipeline, and Clojure's metadata annotations emit
+only `CLASS` or `RUNTIME` retention into bytecode. `SOURCE` retention cannot be expressed at all, so
+the annotations cannot even be written. Same fallback as Scala: annotated Java types, or
+hand-authored rules outside the markers.
+
+---
+
+## One trap that applies to every language
+
+**The compiling JDK must be 21 or newer, and a Gradle toolchain overrides the JDK you launched
+with.** This:
+
+```groovy
+java { toolchain { languageVersion = JavaLanguageVersion.of(17) } }
+```
+
+runs javac from a JDK 17, which cannot load the processor:
+
+```
+class file version 65.0, this version of the Java Runtime only recognizes class file versions up to 61.0
+```
+
+The message names neither VibeTags nor the toolchain, so it reads like a corrupt jar. Two of the
+Groovy projects above fail exactly this way. Gradle plugins and libraries pin older toolchains for
+consumer compatibility far more often than application code does, so it is worth checking first.
+
+---
+
+## How these ratings are kept honest
+
+Each row of the first table is a test, not a belief:
+
+| Job | What it runs |
+|---|---|
+| `Third-Party Corpus` | `corpus/run-corpus.sh` - six Java libraries, twice each, with and without VibeTags |
+| `JVM-Language Corpus (Kotlin, Groovy, Scala)` | `corpus/run-corpus-jvm.sh` - three repositories built twice by their own Gradle wrapper |
+
+Both compare a control build against a treatment build, so "it compiled" is never the assertion.
+Sixteen assertions cover the JVM-language leg, including the tier split, both granular directories
+and the parameter level. Two of them exist specifically to keep this page true:
+
+- **the expected set is derived from the showcase**, so a level that stops rendering fails rather
+  than being absorbed by a margin someone left in;
+- **the exclusions are checked in the other direction too**, so a limitation that quietly gets
+  fixed fails the build and forces this page to be corrected. A documentation error in the generous
+  direction is the one nobody ever notices, because the run is green and more guardrails arrived
+  than were asked for.
+
+Full detail, including the assertion table:
+[corpus/README.md](../corpus/README.md#the-other-three-jvm-languages).
+
+## What is not known
+
+Stated so that nobody mistakes silence for evidence:
+
+- **Kotlin is verified on one Kotlin version.** The corpus member is on Kotlin 2.3.10 and
+  `examples/kotlin` on 2.4.10. Nothing here sweeps a range of Kotlin releases.
+- **One kapt diagnostic is unattributed.** kapt reports `vibetags.root` as an unrecognised
+  processor option even though `AIGuardrailProcessor` declares it in `@SupportedOptions` and
+  demonstrably receives it. It appears on 2.3.10 and not on 2.4.10. Tracked as an open question,
+  not asserted to be harmless.
+- **Groovy is verified on one project.** `nf-boost` compiles its stubs; the survey above shows how
+  much that varies. There is no claim about Groovy versions or about Grails.
+- **Scala is verified on one Gradle-built project.** Gradle-built Scala is rare; sbt is far more
+  common and is not exercised anywhere. Nothing here says what happens under sbt, only that scalac
+  itself offers nothing to a processor, which is true regardless of build tool.
+- **Android is not covered at all.** No corpus member uses the Android Gradle plugin.

--- a/examples/basic/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/basic/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/examples/gradle-composite/app/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gradle-composite/app/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/examples/gradle-flat/app/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gradle-flat/app/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/examples/gradle-multimodule/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gradle-multimodule/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/examples/gradle-shared-buildfile/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gradle-shared-buildfile/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/examples/groovy/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/groovy/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/examples/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/examples/scala/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/scala/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/scripts/bump-dependencies.sh
+++ b/scripts/bump-dependencies.sh
@@ -53,6 +53,7 @@ nullaway.version                        com/uber/nullaway/nullaway
 cyclonedx-maven-plugin.version          org/cyclonedx/cyclonedx-maven-plugin
 central-publishing-maven-plugin.version org/sonatype/central/central-publishing-maven-plugin
 maven-gpg-plugin.version                org/apache/maven/plugins/maven-gpg-plugin
+ecj.version                             org/eclipse/jdt/ecj
 "
 
 prop() { sed -n "s:.*<$1>\(.*\)</$1>.*:\1:p" "$PARENT" | head -n1; }

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -88,9 +88,27 @@ jar {
     }
 }
 
+// The one shared version this module needs, read from the same place Maven reads it. Kept
+// deliberately smaller than vibetags/build.gradle's helper: this module has exactly one pin to
+// resolve, and a literal here is what turned every dependabot PMD bump into a red
+// BuildVersionParityTest.
+def pmdVersionFromParent = {
+    def pom = file("${projectDir}/../vibetags-parent/pom.xml")
+    if (!pom.exists()) {
+        throw new GradleException("vibetags-parent/pom.xml is missing, so there is nothing to read "
+            + 'pmd.version from. Shared versions live in the parent, never as a literal here.')
+    }
+    def m = (pom.text =~ /<pmd\.version>([^<]+)<\/pmd\.version>/)
+    if (!m) {
+        throw new GradleException('vibetags-parent/pom.xml <properties> does not define '
+            + '<pmd.version>. Add it there rather than hard-coding a number in build.gradle.')
+    }
+    m[0][1].trim()
+}()
+
 pmd {
     consoleOutput = true
-    toolVersion = "7.26.0"
+    toolVersion = pmdVersionFromParent
     ignoreFailures = false
     ruleSetFiles = files("${projectDir}/../pmd-ruleset.xml")
 }

--- a/vibetags-annotations/gradle/wrapper/gradle-wrapper.properties
+++ b/vibetags-annotations/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -96,7 +96,7 @@
              the documented claim that the processor degrades rather than fails under a compiler
              with no Tree API (docs/PROCESSOR.md, USAGE.md). scripts/ecj-degradation-check.sh
              reads this property so the version has one home, like every other pin here. -->
-        <ecj.version>3.44.0</ecj.version>
+        <ecj.version>3.46.0</ecj.version>
 
         <!-- Build plugins -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -189,7 +189,10 @@ jacocoTestReport {
 
 pmd {
     consoleOutput = true
-    toolVersion = "7.26.0"
+    // Derived, never a literal. A literal here is a mirror of pmd.version in the parent, and
+    // dependabot bumps the parent alone - so every PMD bump arrived as a red
+    // BuildVersionParityTest that a human had to hand-fix before the PR could merge.
+    toolVersion = pomVersion('pmd.version')
     ignoreFailures = false
     ruleSetFiles = files("${projectDir}/../pmd-ruleset.xml")
 }

--- a/vibetags/gradle/wrapper/gradle-wrapper.properties
+++ b/vibetags/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/BuildVersionParityTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/BuildVersionParityTest.java
@@ -62,6 +62,10 @@ class BuildVersionParityTest {
         "examples/kotlin/build.gradle.kts", "examples/groovy/build.gradle",
         "examples/scala/build.gradle");
 
+    private static final char EQUALS = '=';
+    private static final char SINGLE_QUOTE = '\'';
+    private static final char DOUBLE_QUOTE = '"';
+
     /** Directory names whose contents are build output or tool cache, never sources. */
     private static final Set<String> NON_SOURCE_DIRS =
         Set.of(".git", ".gradle", "build", "target", "node_modules");
@@ -158,27 +162,73 @@ class BuildVersionParityTest {
      * vibetags/build.gradle were on 7.26.0, which means the two modules were analysed by different
      * rule sets and a rule added between those releases ran on one module only.
      */
+    /**
+     * PMD's {@code toolVersion} must be <em>derived</em> from {@code pmd.version} in the parent,
+     * never copied.
+     *
+     * <p>This used to compare the literal against the parent, which is a weaker rule that reads
+     * the same. The difference shows up when dependabot bumps {@code pmd.version}: it edits the
+     * parent pom and nothing else, because that is where the property lives, and every Gradle
+     * file holding a copy of the old number then failed this test. Each PMD bump therefore
+     * arrived as a red PR that a human had to hand-fix before it could merge, which is not what
+     * an automated bump is for.
+     *
+     * <p>So the assertion is now about the mechanism rather than the value. A literal fails even
+     * if it happens to be correct today, and a file that never mentions {@code pmd.version} fails
+     * even if it has no literal - otherwise deleting the derivation would leave nothing to match
+     * and this test would pass on a file it no longer checks.
+     */
     @Test
-    void gradlePmdToolVersionsMatchTheParent() {
-        String expected = properties().get("pmd.version");
-        Pattern toolVersion = Pattern.compile("^\\s*toolVersion\\s*=\\s*['\"]([^'\"]+)['\"]",
-            Pattern.MULTILINE);
+    void gradlePmdToolVersionIsDerivedFromTheParentRatherThanCopied() {
         List<String> problems = new ArrayList<>();
+        int checked = 0;
 
         for (String file : gradleFiles()) {
-            Matcher m = toolVersion.matcher(read(repoRoot().resolve(file)));
-            while (m.find()) {
-                if (!expected.equals(m.group(1))) {
-                    problems.add(file + ": PMD toolVersion is " + m.group(1)
-                        + " but vibetags-parent declares pmd.version " + expected);
+            String text = read(repoRoot().resolve(file));
+            if (!text.contains("pmd {")) {
+                continue;
+            }
+            checked++;
+            for (String line : text.lines().toList()) {
+                String trimmed = line.trim();
+                int assignment = trimmed.indexOf(EQUALS);
+                if (!trimmed.startsWith("toolVersion") || assignment < 0) {
+                    continue;
+                }
+                if (isQuoted(trimmed.substring(assignment + 1).trim())) {
+                    problems.add(file + ": PMD toolVersion is a literal (" + trimmed
+                        + "). Read pmd.version from vibetags-parent instead, so that a bump"
+                        + " of the parent cannot leave this file behind.");
                 }
             }
+            if (!text.contains("pmd.version")) {
+                problems.add(file + ": applies the pmd plugin but never names pmd.version,"
+                    + " so nothing ties its analyser to the version the rest of the build"
+                    + " uses.");
+            }
         }
+
+        assertTrue(checked >= 2,
+            "Expected at least two Gradle modules applying PMD; found " + checked
+                + ". A walk that stops finding them passes this test while checking"
+                + " nothing.");
         assertTrue(problems.isEmpty(),
-            "A Gradle module analysed by a different PMD than the rest of the build:\n  "
-                + String.join("\n  ", problems));
+            "A Gradle module that a dependabot bump of pmd.version would leave behind: "
+                + String.join("; ", problems));
     }
 
+    /**
+     * Whether the right-hand side of a {@code toolVersion} assignment is a quoted number.
+     *
+     * <p>Only the start of the value is looked at, and that is the whole point: the first
+     * version of this asked whether the <em>line</em> contained a quote, which rejected
+     * {@code toolVersion = pomVersion('pmd.version')} - the very form it exists to require.
+     * A derived value may quote a property name; a copied one opens with the quote.
+     */
+    private static boolean isQuoted(String value) {
+        return !value.isEmpty()
+            && (value.charAt(0) == SINGLE_QUOTE || value.charAt(0) == DOUBLE_QUOTE);
+    }
     @Test
     void managedPomsDeclareNoVersionOfTheirOwn() {
         List<String> problems = new ArrayList<>();


### PR DESCRIPTION
Two commits: an honest support document for the three non-Java JVM languages, and the dependency
work that makes a dependabot bump stop turning the build red.

> **Stacked on #492.** Base is `test/corpus-jvm-languages` so the diff here is just these two
> commits. Merge #491, then #492, and GitHub will retarget this one automatically.

## 1. `docs/JVM-LANGUAGES.md`

The support matrix in USAGE.md was three rows and a mechanism column, and one row was wrong for
several releases: Groovy was described as **"Full (joint compilation)"** while silently dropping
every field-level annotation. A table row cannot carry a limitation like that, so this adds a page
that can.

| Language | Rating | Measured |
|---|---|---|
| Java | **Supported** | six libraries, 15,683 members |
| Kotlin | **Supported, one level lost** (package) | 15 of 15 guardrails |
| Groovy | **Supported, one level lost** (field) | 13 of 13 expected, 2 field guardrails absent |
| Scala | **Partial by construction** | 17 from the Java half, 0 from the Scala half |
| Clojure | **Not possible** | — |

The rating vocabulary is defined in the page, so "supported" is not doing vague work.

What the page records that a matrix row could not:

- **Groovy drops `@AIPrivacy` with no warning**, with the generated stub printed so a reader can
  see the fields are simply absent. It also records that the obvious explanation — the annotation
  moving onto a generated accessor — is wrong, and how that was settled (`groovyOptions.keepStubs`).
- **Only two of eight surveyed Groovy projects can switch stub processing on at all**, with the
  exact error for each. That is a bigger practical limit than the missing level.
- **A Gradle toolchain pinned below 21** fails with `class file version 65.0`, naming neither
  VibeTags nor the toolchain.
- **Kotlin's exposure.** Support rests entirely on kapt, which JetBrains keeps current but has no
  plans to extend, recommending KSP. KSP defines `SymbolProcessor` rather than implementing
  `javax.annotation.processing.Processor`, so a project fully migrated to KSP cannot run VibeTags
  at all. Checked against kotlinlang.org rather than asserted from memory, and cited. The page says
  plainly that nothing is imminent and no deprecation is announced.

A closing **"What is not known"** section states the limits of the evidence — one Kotlin version
each side, one Groovy project, one Gradle-built Scala project with sbt untested, Android not
covered, and the unattributed kapt option warning — so silence is not read as evidence.

Linked from `CLAUDE.md`'s reference index and the head of USAGE.md's JVM-languages section, so
anyone about to adopt Kotlin or Groovy support meets the limitations before the snippet.

## 2. Dependency and dependabot work

- **A dependabot bump of `pmd.version` no longer turns the build red.** Dependabot edits
  `vibetags-parent/pom.xml` and nothing else, because that is where the property lives. PMD's
  `toolVersion` was a hand-copied literal in two `build.gradle` files, so `BuildVersionParityTest`
  failed on every PMD bump and a human had to hand-fix the PR first. Both now derive it.

  The test was rewritten with it, and that half matters more: the old check compared the literal
  against the parent, which finds nothing once no literal is left, so it would have **started
  passing vacuously**. It now asserts the mechanism — a quoted `toolVersion` fails even when the
  number is correct, and a file applying PMD that never names `pmd.version` fails too.

- **Dependabot's `/example` entry pointed at a directory that has never existed**, so it produced
  nothing, silently — the same failure the npm entry in the same file carries a comment about.
  Removed rather than redirected: the example poms pin VibeTags artifacts at the released version,
  owned by `scripts/set-version.sh` and enforced by `BuildVersionParityTest`, so a dependabot PR
  moving one would be red on arrival. `/vibetags` already reaches every pin through the parent.

- **`ecj.version` 3.44.0 → 3.46.0** and the **Gradle wrapper 9.7.0 → 9.7.1** across all ten wrapper
  files. The ECJ pin had been invisible to `scripts/bump-dependencies.sh` since it was introduced —
  no Maven Central path in its `PINS` table, so the report exited 2 rather than reporting a stale
  version. The mirror tables in `docs/DEPENDENCIES.md` and the `bump-dependencies` skill were both
  wrong about the wrapper (three subprojects, six files, against ten actual) and now say to
  enumerate rather than remember.

## Verification

- `mvn clean install -Pe2e`: **2403 tests, 0 failures**.
- **The dependabot scenario simulated both ways**: bumping `pmd.version` in the parent alone passes
  with the fix and fails without it.
- `scripts/ecj-degradation-check.sh` on ECJ 3.46.0: 9 locked entries under both compilers, 9
  positions under javac and 0 under ECJ, 147 lines of guardrail region byte-identical.
- Gradle builds of `vibetags` and `vibetags-annotations` green on wrapper 9.7.1 and the derived PMD pin.
- Every factual claim in the new document checked against the code: 13 annotations accept
  `ElementType.PACKAGE`, six corpus repos, 15,683 members, all annotations `SOURCE`, job name
  matches `build.yml`. All relative links resolve.
- `pre-commit`: gitleaks and the whitespace hooks passed. **checkstyle skipped, not passed** — no
  Docker daemon here; it also runs bound to `validate` in the Maven build.

## Follow-up

- #493 — the unattributed kapt `vibetags.root` warning, now also named in the new document's
  "What is not known".
- #494 — whether a Groovy consumer can be warned that field guardrails are dropped.
