### PR TITLE
Re-land the JVM corpus and language docs that a stacked merge stranded

### DIFF
--- a/.claude/skills/bump-dependencies/SKILL.md
+++ b/.claude/skills/bump-dependencies/SKILL.md
@@ -39,10 +39,10 @@ Edit the property in `vibetags-parent/pom.xml`. Then the places that cannot inhe
 
 | Pin | Also lives in |
 |-----|---------------|
-| `junit.version`, `junit.platform.version`, `mockito.version`, `archunit.version`, `async-test-lib.version`, `snakeyaml.version`, `logback.version`, `slf4j.version`, `jspecify.version` | `vibetags/build.gradle` (coordinates; `BuildVersionParityTest` enforces) |
-| `pmd.version` | `toolVersion` in `vibetags/build.gradle` and `vibetags-annotations/build.gradle` (enforced) |
+| `junit.version`, `junit.platform.version`, `mockito.version`, `archunit.version`, `async-test-lib.version`, `snakeyaml.version`, `logback.version`, `slf4j.version`, `jspecify.version` | nothing to edit. `vibetags/build.gradle` reads each one from the parent via `pomVersion(...)`; `BuildVersionParityTest` enforces that it keeps doing so |
+| `pmd.version` | nothing. Both Gradle builds derive it from the parent, and `BuildVersionParityTest` fails any file that reintroduces a literal |
 | `maven-compiler-plugin.version` | literals in `examples/basic/pom.xml`, `examples/multimodule/pom.xml`, `examples/multimodule-indexed/pom.xml`, `examples/all-tiers/pom.xml`, `tools/demo/pom.xml` (consumer poms; keep them in step) |
-| Gradle wrapper | `gradle/wrapper/gradle-wrapper.properties` in `vibetags`, `vibetags-annotations`, `example`, `examples/kotlin`, `examples/groovy`, `examples/scala`; the version named in `docs/DEPENDENCIES.md` |
+| Gradle wrapper | every `gradle-wrapper.properties` in the repository - ten of them, not the six this row used to list; enumerate with `git ls-files '*gradle-wrapper.properties'` rather than trusting the list - plus the version named in `docs/DEPENDENCIES.md` |
 | Kotlin | `examples/kotlin/build.gradle.kts` (`jvm` and `kapt`), the snippets in `README.md` and `examples/kotlin/README.md` |
 | Groovy, Scala | `examples/groovy/build.gradle`, `examples/scala/build.gradle` (Scala stays on the 2.13 line: the example is about Java-only support) |
 | pre-commit hook revs | `python -m pre_commit autoupdate`; the `checkstyle` hook runs in Docker, so unless Docker is available revert its rev and say so - an unverifiable bump is not a verified one |

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,11 +28,30 @@ updates:
     schedule:
       interval: daily
 
-  - package-ecosystem: maven
-    directory: /example
-    schedule:
-      interval: daily
-
+  # /vibetags is the only Maven directory that needs to be listed, and it reaches further than
+  # it looks. Every third-party version in this build is a <name.version> property in
+  # vibetags-parent/pom.xml (tier-1 invariant 14), and dependabot resolves the parent from the
+  # child: #470 was opened "in /vibetags" and its diff edits vibetags-parent/pom.xml. So one
+  # entry covers all 33 pins.
+  #
+  # This used to sit alongside `directory: /example`, which has never existed - the examples live
+  # under examples/, each with its own pom. That entry produced nothing at all, silently, which is
+  # the same failure the npm entry above carries a comment about. It is gone rather than
+  # redirected, and deliberately:
+  #
+  #   - examples/*/pom.xml and tools/demo/pom.xml pin se.deversity.vibetags artifacts at the
+  #     released version. That number is owned by scripts/set-version.sh, and
+  #     BuildVersionParityTest fails if it disagrees with <revision>. A dependabot PR moving it
+  #     would be red on arrival and could never merge.
+  #   - Their maven-compiler-plugin literals are mirrors of the parent property. Bumping the copy
+  #     without the original is the drift the mirror table in the bump-dependencies skill exists
+  #     to prevent.
+  #
+  # Both are release-managed rather than dependency-managed, so they belong to that skill and to
+  # set-version.sh, not here.
+  #
+  # load-tests/pom.xml is absent for a third reason: its <processor.version> is pinned
+  # independently so benchmarks can compare across releases, and force-bumping it is a bug.
   - package-ecosystem: maven
     directory: /vibetags
     schedule:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1272,6 +1272,64 @@ jobs:
       - name: Run VibeTags over the corpus and compare against the control
         run: corpus/run-corpus.sh
 
+  # The same question in the three other JVM languages people ship, and none of them reaches the
+  # processor the way Java does: Kotlin only through kapt, Groovy only when joint compilation's
+  # javaAnnotationProcessing is switched on, and Scala not at all. USAGE.md has stated all three
+  # for several releases; this is the leg that runs them. Each repository is built twice by its
+  # own Gradle wrapper and the only difference is corpus/inject-vibetags.init.gradle. The Scala
+  # member asserts a negative on purpose: annotated Scala must generate nothing, while the Java
+  # half of the same build must generate everything. corpus/README.md has the rest.
+  corpus-jvm:
+    name: JVM-Language Corpus (Kotlin, Groovy, Scala)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      # Keyed on the manifest, the harness and the init script, so a pin bump or a change to how
+      # the injection works fetches afresh. The repositories are pinned to commits, so a hit is
+      # always the right source. Nothing derived is trusted from a hit: the processor classpath
+      # is resolved every run, because a classpath written by a failing run is indistinguishable
+      # from a good one once it is on disk.
+      - name: Cache the JVM-language corpus checkouts
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: target/corpus-jvm
+          key: corpus-jvm-${{ hashFiles('corpus/repos-jvm.tsv', 'corpus/run-corpus-jvm.sh', 'corpus/inject-vibetags.init.gradle') }}
+
+      # Six Gradle builds run here, each with --rerun-tasks. Without a warm Gradle cache every
+      # one of them re-downloads a distribution and a dependency graph, which is most of this
+      # job's wall clock and none of what it is measuring.
+      - name: Cache the Gradle distributions and dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: corpus-jvm-gradle-${{ hashFiles('corpus/repos-jvm.tsv') }}
+          restore-keys: corpus-jvm-gradle-
+
+      - name: Install VibeTags Annotations and Processor (Maven)
+        run: |
+          cd vibetags-annotations
+          mvn install -B -q -DskipTests
+          cd ../vibetags
+          mvn install -B -q -DskipTests
+
+      - name: Run VibeTags over Kotlin, Groovy and Scala and compare against the control
+        run: corpus/run-corpus-jvm.sh
+
   # The one leg that does not run javac. docs/PROCESSOR.md and USAGE.md both promise that
   # VibeTags degrades - loses @AILocked positions, keeps every guardrail - under a compiler
   # with no Tree API, and nothing verified either sentence. The paths behind them are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,8 @@ cd examples/basic && mvn clean compile     # consumer fixture; library must be i
 - [docs/PROCESSOR.md](docs/PROCESSOR.md) — processor options, write cache + fingerprint short-circuit, check mode, `.vibetags-locks`, SPI/Gradle incremental.
 - [docs/ANNOTATIONS.md](docs/ANNOTATIONS.md) — adding or changing an annotation: full table, semantics, validation warnings.
 - [docs/PLATFORMS.md](docs/PLATFORMS.md) — adding a platform, or a question about a specific output file.
+- [docs/JVM-LANGUAGES.md](docs/JVM-LANGUAGES.md) — Kotlin, Groovy, Scala and Clojure: what is
+  supported, what is silently lost, and how each rating is measured rather than claimed.
 - [docs/TESTS.md](docs/TESTS.md) — which test class covers what.
 - [docs/DEPENDENCIES.md](docs/DEPENDENCIES.md) — every third-party artifact, why it is here, what ships to consumers and what only runs the build.
 - [docs/LOAD-BEARING.md](docs/LOAD-BEARING.md) — processing flow, marker rules, the scoped-rules index, the internal class map, and the invariants in full.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,9 @@ cd examples/basic && mvn clean compile     # consumer fixture; library must be i
 - Per-element guardrails: the generated block below indexes `.claude/rules/`, loaded on demand
   by glob. Whether the rules in this file actually bind an agent is measured, not assumed:
   [evals/README.md](evals/README.md).
+- Third-party corpus: `corpus/run-corpus.sh` (Java, javac) and `corpus/run-corpus-jvm.sh`
+  (Kotlin, Groovy, Scala, each built by its own Gradle). Both run in CI on every PR;
+  [corpus/README.md](corpus/README.md) says what each asserts and what they have found.
 - Run `pre-commit run --all-files` after `git add`, before committing.
 
 ## Reference docs (read on demand)

--- a/USAGE.md
+++ b/USAGE.md
@@ -128,7 +128,7 @@ matrix, and adding one never touches the processor.
 |---|---|---|
 | Java | Full | javac runs the processor directly |
 | Kotlin | Full (kapt) | kapt generates Java stubs and runs JSR 269 processors over them |
-| Groovy | Full (joint compilation) | groovyc generates Java stubs; `javaAnnotationProcessing = true` runs processors over them |
+| Groovy | Types and methods only (joint compilation) | groovyc generates Java stubs; `javaAnnotationProcessing = true` runs processors over them. The stubs carry no fields, so **field-level annotations are dropped** — see below |
 | Scala | Java sources only | scalac has no JSR 269 support; annotated Scala classes compile but are never seen |
 | Clojure | Not possible | no javac in the pipeline, and Clojure metadata annotations emit only CLASS/RUNTIME retention into bytecode — `SOURCE` annotations cannot be expressed at all |
 
@@ -149,9 +149,36 @@ tasks.withType(GroovyCompile).configureEach {
 }
 ```
 
-The stub caveats are the same as kapt's: no method bodies (body-scoped annotations are
-invisible) and stub-relative source positions. Working consumer:
-[`examples/groovy/`](examples/groovy/README.md).
+The stub caveats are the same as kapt's — no method bodies, so body-scoped annotations are
+invisible, and stub-relative source positions — plus two that are Groovy's alone. Both were
+found by running VibeTags over third-party Groovy rather than over this repository's own
+example ([corpus/README.md](corpus/README.md)).
+
+- **Field-level annotations are dropped.** groovyc's stub carries the class, its constructors,
+  its methods and their parameters, and no fields at all. Not renamed, not moved onto a
+  generated accessor: absent. So `@AIPrivacy`, `@AISecureLogging`, `@AIPerformance` on a field,
+  and anything else targeting `ElementType.FIELD`, never reach the processor and generate
+  nothing. There is no warning, because nothing in the compilation ever sees the annotation.
+
+  `@AIPrivacy` is the one that stings: it is a safety-tier guardrail, it is the natural way to
+  mark a PII field, and in Groovy it silently does nothing. Declaring the field `private` does
+  not help — that only stops Groovy turning it into a property, and the stub omits it either
+  way. Put the guardrail on the accessor or the enclosing type instead, or keep the rule in the
+  hand-authored region outside the markers.
+
+  `corpus/run-corpus-jvm.sh` pins this: the Groovy showcase annotates fields on purpose, the
+  harness expects those two markers to be missing, and it fails if they ever start appearing —
+  so the day groovyc emits fields, this section gets rewritten instead of quietly aging.
+
+- **The compiling JDK must be 21 or newer, and a Gradle toolchain overrides the JDK you
+  launched with.** `java { toolchain { languageVersion = JavaLanguageVersion.of(17) } }` runs
+  javac from a JDK 17, which cannot load the processor: `class file version 65.0, this version
+  of the Java Runtime only recognizes class file versions up to 61.0`. The error names no
+  VibeTags file and does not mention the toolchain, so it reads like a corrupt jar. Two of the
+  Groovy projects the corpus surveyed fail this way. It applies to every language, but Groovy
+  and Kotlin Gradle plugins pin an older toolchain far more often than Java projects do.
+
+Working consumer: [`examples/groovy/`](examples/groovy/README.md).
 
 **Scala**: put guardrails on thin annotated Java types next to the Scala code they protect —
 javac compiles `src/main/java` normally in a mixed module. An `@AI*` annotation directly on

--- a/USAGE.md
+++ b/USAGE.md
@@ -124,6 +124,11 @@ language's toolchain ever hand javac something carrying the annotations? Nothing
 itself is language-specific — each language below is a standalone example consumer plus this
 matrix, and adding one never touches the processor.
 
+> **Before adopting VibeTags in a Kotlin, Groovy or Scala project, read
+> [docs/JVM-LANGUAGES.md](docs/JVM-LANGUAGES.md).** It states the maturity of each route, what
+> each one silently drops, and how every claim is measured against third-party code on each pull
+> request. The summary below is the quick version; that page is where the limitations live.
+
 | Language | Support | Mechanism |
 |---|---|---|
 | Java | Full | javac runs the processor directly |

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -1,8 +1,12 @@
 # The third-party corpus
 
-Six real Java libraries, pinned to commits, compiled twice on every CI run: once without
-VibeTags and once with it. Nothing is vendored. The sources are cloned at build time into
-`target/corpus` and never committed, so no third-party code enters this repository.
+Nine real libraries, pinned to commits, compiled twice on every CI run: once without VibeTags and
+once with it. Six are Java, compiled by javac, and are what the first half of this document is
+about. The other three are Kotlin, Groovy and Scala, built by their own Gradle wrappers, and have
+[a harness and a section of their own](#the-other-three-jvm-languages).
+
+Nothing is vendored. The sources are cloned at build time into `target/corpus` and
+`target/corpus-jvm` and never committed, so no third-party code enters this repository.
 
 ```bash
 corpus/run-corpus.sh               # all of it
@@ -243,7 +247,189 @@ Chosen for variety rather than volume. The construct counts were measured, not e
 
 Roughly 495 files and 15,683 members in total.
 
-## Adding a repo
+## The other three JVM languages
+
+Everything above is Java, compiled by javac, because that is the compiler JSR 269 belongs to.
+`corpus/run-corpus-jvm.sh` asks the same questions of Kotlin, Groovy and Scala, and it is a
+separate harness rather than three more rows in `repos.tsv` because none of them reaches the
+processor the way Java does.
+
+```bash
+corpus/run-corpus-jvm.sh                  # all of it
+corpus/run-corpus-jvm.sh kotlin-obd-api   # one repo
+```
+
+| Language | Route to the processor |
+|---|---|
+| Kotlin | kapt generates Java stubs and runs the processor over them. KSP does not run JSR 269 processors, so kapt is the only route |
+| Groovy | groovyc generates stubs the same way, but only when `javaAnnotationProcessing` is on, and it is off by default in Gradle |
+| Scala | scalac has no JSR 269 support at all. Only the Java half of a mixed build reaches the processor |
+
+USAGE.md has said all three for several releases. Until this harness existed, none of them had
+been run against code outside this repository.
+
+### How VibeTags gets into a build nobody wrote for it
+
+Each repository is built twice by its own Gradle wrapper, and the only difference between the two
+runs is `corpus/inject-vibetags.init.gradle`:
+
+```
+control    ./gradlew <task>
+treatment  ./gradlew <task> --init-script corpus/inject-vibetags.init.gradle
+```
+
+A Gradle init script is the supported way to add a plugin or a dependency to a build you do not
+own, so nothing here edits a `build.gradle` it did not write. It is switched on by the presence of
+`VIBETAGS_ROOT` in the environment, which is how the control runs the same command line without it.
+
+Two details in that file are load-bearing, and both are there because the first version got them
+wrong:
+
+- **It skips `buildSrc` and included builds.** They are not the build under test — they compile
+  the target project's own build logic, often in another language. splain's `buildSrc` is Kotlin,
+  so without the guard the Scala member would have run kapt over the build logic of a Scala
+  project.
+- **On Kotlin projects it configures kapt only, never javac.** That is how `examples/kotlin` and
+  USAGE.md configure it. Doing both put `-Avibetags.root` on kapt's javac command line as a raw
+  flag as well as into kapt's option map.
+
+`--rerun-tasks` is also not optional. Gradle's up-to-date checks would let the treatment skip
+compilation entirely, because the control had just compiled the same sources from the same inputs,
+and a treatment that never ran a compiler passes every assertion below while testing nothing.
+
+### What is asserted
+
+| # | Assertion | What it protects |
+|---|---|---|
+| J0 | The control build succeeds | Everything else is relative to it; a repository that cannot build passes exit parity trivially, both sides failing identically |
+| J1 | The treatment exits exactly as the control did | Adding VibeTags to somebody's build must not fail it |
+| J2 | No new compiler diagnostic, line by line, against a one-entry allow-list | A processor that turns a clean build noisy has broken the same promise, more quietly |
+| J3 | Nothing written into a project that never opted in | File presence is the only opt-in (tier-1 invariant 1) |
+| J4 | The annotated build still succeeds | Otherwise nothing was generated and J5 onward report on an empty directory |
+| J5 | Every opted-in platform file has content, checked per platform | One renderer can be dropped and the other two cover for it in any total |
+| J5b | `AGENTS.md` grew beyond the seeded marker pair | Codex being dropped from the active set looks identical to Codex working |
+| J6 | Every aggregate carries a `VIBETAGS-START` pair | The markers are the whole promise that hand-authored content survives |
+| J6b | Both granular directories were written | An opted-in directory that stays empty looks exactly like "this project has no rules" |
+| J6c | The tier split: a safety guardrail inline, `@AIContract` not inline but present in the rules directory | Invariant 6, checked through three compilers instead of one |
+| J6d | The parameter level survived | The level most exposed to a stub generator: a parameter name that does not survive into the stub cannot be addressed |
+| J6f | Every marker the showcase declares, minus the language's documented exclusions, reached a generated file | A change that stopped rendering half the surface would still pass every assertion that names one guardrail |
+| J6g | **No marker on the exclusion list appeared** | A limitation that quietly gets fixed leaves the documentation wrong in the generous direction, which nobody notices because the run is green |
+| J8 | No type-use annotation in any generated identity | These compilers reach `ElementNaming` by different routes; there is no reason to assume they agree |
+| J9 | Scala only: no marker from the annotated `.scala` file appears anywhere | USAGE.md's Scala row, turned into a test |
+| J9b | Scala only: the Scala showcase produced class files | Without it, "scalac generated nothing" and "scalac was never asked" are the same green run |
+
+J2 differs from the Java corpus's assertion 2 on purpose. There, javac runs either way and the
+only difference is a `-processor` flag, so "no new diagnostics" is a fair comparison. Here it is
+not: switching VibeTags on adds the kapt task graph to a Kotlin build and joint compilation to a
+Groovy one, and those emit diagnostics about the machinery rather than about VibeTags. Counting
+them fails for the wrong reason; raising a threshold to make them pass blinds the check. So every
+new line must either be absent or be named in the allow-list, which has exactly one entry.
+
+J6f and J6g are a pair, and the pair is the point. Anywhere a language genuinely cannot render a
+guardrail, that marker is named in `excluded_markers()` with the evidence, and both directions are
+then checked: it must not go missing from the expected set, and it must not appear from the
+excluded one.
+
+### The members
+
+| Repo | Lang | Licence | Why this one |
+|---|---|---|---|
+| [`eltonvs/kotlin-obd-api`](https://github.com/eltonvs/kotlin-obd-api) | Kotlin | Apache-2.0 | A plain `kotlin("jvm")` library — not Android, not multiplatform — so kapt applies exactly as USAGE.md documents |
+| [`bentsherman/nf-boost`](https://github.com/bentsherman/nf-boost) | Groovy | Apache-2.0 | A Groovy library whose classes groovyc can turn into valid Java stubs, which most of the candidates could not |
+| [`tek/splain`](https://github.com/tek/splain) | Scala | MIT | One of very few Gradle-built Scala projects on a JDK 21 wrapper; `:core:classes` runs `compileJava` and `compileScala`, which is what makes the two-sided Scala assertion possible |
+
+The Scala member carries two showcases in one build: a Java one that must generate everything, and
+a Scala one that must generate nothing. Both halves are needed. Without the positive half, "nothing
+came from Scala" and "nothing came at all" are the same result.
+
+### What it found
+
+**Groovy drops every field-level annotation, silently.**
+
+This is the finding that justifies the harness. `@AIPrivacy` on a Groovy field generates nothing —
+no file, no warning, no trace. It is one of the six safety annotations, it is the natural way to
+mark a PII field, and until this ran, USAGE.md called the Groovy route "Full (joint compilation)".
+
+The first guess was wrong, which is worth recording: a Groovy field with no access modifier
+becomes a property, so the obvious theory was that the annotation had moved onto a generated
+accessor. It had not. Keeping the stubs (`groovyOptions.keepStubs`) and reading one settles it —
+the stub has the class, both constructors, all twelve methods and both parameters of `render`,
+each with its annotations intact, and no fields whatsoever:
+
+```java
+@AIContext(...) @AIPublicAPI() public class CorpusShowcase
+@AILocked(reason="...CONSTRUCTOR-LOCKED...") public CorpusShowcase
+@AILocked(reason="...METHOD-LOCKED...") public long invoiceNumber(long id) { return (long)0;}
+@AIContract(...) public String render(@AIInputSanitized(...) String customerNote, ...)
+```
+
+`billingEmail`, `authToken` and `tenantId` appear nowhere in it. The annotations are not lost by
+VibeTags; they never reach any processor. Nothing in VibeTags can fix that, so it is documented
+instead — and pinned, because a limitation nothing exercises is a limitation nobody notices has
+been fixed. The Groovy showcase annotates those fields on purpose, `excluded_markers()` names the
+two markers, and J6g fails the day they start appearing.
+
+**Most real Groovy projects cannot switch annotation processing on at all.**
+
+Eight Groovy repositories were tried before one could be used, and the failures were not
+incidental:
+
+| Repository | Outcome once `javaAnnotationProcessing` is on |
+|---|---|
+| `jenkinsci/JenkinsPipelineUnit` | stub rejected: `'_' is a keyword, and may not be used as an identifier` |
+| `int128/gradle-ssh-plugin` | stub rejected: `illegal combination of modifiers: public and private` |
+| `longwa/build-test-data` | stub rejected: `method does not override or implement a method from a supertype` |
+| `jk1/Gradle-License-Report` | toolchain pinned to Java 17: `class file version 65.0` |
+| `allegro/axion-release-plugin` | toolchain pinned to Java 17: same |
+| `jwagenleitner/groovy-wslite` | wrapper too old: `Could not determine java version from '21.0.9'` |
+| `gpc/grails-postgresql-extensions` | **compiles** |
+| `bentsherman/nf-boost` | **compiles** — the member |
+
+Three of the eight compile perfectly well on their own and break the moment stubs are generated,
+each for a different reason. That is a property of groovyc's stub generator, not of VibeTags, and
+a Groovy user hitting it sees a compile error in a file they did not write, in a directory named
+`build/tmp/compileGroovy/groovy-java-stubs`. Worth knowing before recommending the switch.
+
+**A Gradle toolchain below 21 fails in a way that names nothing useful.**
+
+`java { toolchain { languageVersion = JavaLanguageVersion.of(17) } }` runs javac from a JDK 17,
+which cannot load the processor. README has always said "Java 21 or higher"; what it did not say
+is that a toolchain pin overrides the JDK you launched Gradle with, so a developer on JDK 21 gets
+`class file version 65.0` and no mention of VibeTags or of toolchains. Now in USAGE.md.
+
+**kapt reports `vibetags.root` as unrecognised.**
+
+`warning: The following options were not recognized by any processor: '[vibetags.root,
+kapt.kotlin.generated]'` — for an option `AIGuardrailProcessor` declares in `@SupportedOptions`
+and demonstrably receives, since it prints the resolved root from the same task. `examples/kotlin`
+on Kotlin 2.4.10 does not produce it; this member on Kotlin 2.3.10 does. Removing the javac-side
+configuration so only the documented `kapt { arguments { … } }` route remained did not change it.
+
+That is as far as the evidence goes, so it is allow-listed as kapt bookkeeping with the evidence
+written next to it, and tracked as an open question rather than asserted to be harmless.
+
+**And one in the harness, which is the reason J2 can be trusted at all.**
+
+The diagnostic counter could not see the diagnostic it existed for. It required a colon before the
+word — `: warning:` — and javac emits its summary diagnostics with no file prefix at all. So the
+kapt warning above was raised by the treatment, absent from the control, and counted `0` against
+`0`. A parity check blind to an entire class of diagnostic is worse than no parity check, because
+it is reported as a pass.
+
+### Adding a member
+
+1. It must build on JDK 21 with its own wrapper, at the SHA you pin, **and** with annotation
+   processing switched on. Those are two different tests for Groovy, and the second is the one
+   that eliminates most candidates.
+2. Prefer a library over a build plugin. Plugins pin old toolchains for consumer compatibility,
+   which is what disqualified two Groovy candidates outright.
+3. Add a row to `repos-jvm.tsv` with the SHA, never a branch, and say in `why` what it covers that
+   the others do not.
+4. If it cannot render some level, name the markers in `excluded_markers()` **with the evidence**,
+   and write the limitation in USAGE.md in the same change. An exclusion without a reason is how a
+   real defect gets absorbed into the expected set.
+
+## Adding a Java repo
 
 1. Pick something small, permissively licensed, and *different* from what is already there. A
    seventh repo that looks like `commons-codec` adds runtime and no coverage.

--- a/corpus/inject-vibetags.init.gradle
+++ b/corpus/inject-vibetags.init.gradle
@@ -1,0 +1,113 @@
+// Injects VibeTags into a Gradle build that has never heard of it.
+//
+// Passed to a third-party clone as `--init-script corpus/inject-vibetags.init.gradle`. An init
+// script is the one supported way to add a plugin or a dependency to a build you do not own, so
+// the corpus never edits a `build.gradle` it did not write. The clone's own build file is the
+// control; this file is the entire difference between the control run and the treatment run.
+//
+// Configured entirely through the environment, because an init script cannot take arguments:
+//
+//   VIBETAGS_JARS   path-separated processor jar + its runtime classpath
+//   VIBETAGS_ANN    the annotations jar, added to compileOnly so an injected showcase resolves
+//   VIBETAGS_ROOT   where the processor writes; unset means "do not inject at all"
+//
+// Three languages, three different routes to the same JSR 269 processor, and the differences
+// are the whole reason the JVM-language corpus exists:
+//
+//   Java     javac runs the processor directly.
+//   Kotlin   kapt generates Java stubs and runs the processor over them. KSP does not run
+//            JSR 269 processors, so kapt is the only route (USAGE.md, "Kotlin (kapt)").
+//   Groovy   groovyc generates stubs the same way, but only when javaAnnotationProcessing is
+//            switched on, which is off by default in Gradle.
+//   Scala    scalac has no JSR 269 support at all. Nothing here reaches a .scala source, and
+//            the corpus asserts that rather than papering over it.
+
+def jars = System.getenv('VIBETAGS_JARS')
+def annJar = System.getenv('VIBETAGS_ANN')
+def vtRoot = System.getenv('VIBETAGS_ROOT')
+
+if (vtRoot == null || vtRoot.isEmpty() || jars == null || jars.isEmpty()) {
+    // The control run uses the same command line minus the environment, so a missing variable
+    // has to mean "do nothing" rather than "fail". A treatment run that silently did nothing
+    // would be indistinguishable from a passing one, which is why run-corpus-jvm.sh verifies
+    // the processor actually ran instead of trusting this file.
+    return
+}
+
+// buildSrc and any included build gets this init script too, and it is not the build under
+// test: it compiles the target project's own build logic, often in a different language and
+// against the Gradle API. Injecting an annotation processor there would change whether the
+// build script compiles, which is a failure of the harness rather than a finding about VibeTags.
+// splain's buildSrc is Kotlin, so without this guard the Scala member would run kapt over the
+// build logic of a Scala project.
+if (gradle.parent != null) {
+    return
+}
+
+def procFiles = jars.split(java.io.File.pathSeparator).findAll { !it.isEmpty() }
+def rootArg = "-Avibetags.root=${vtRoot}".toString()
+
+gradle.allprojects { project ->
+    project.plugins.withId('java-base') {
+        if (annJar != null && !annJar.isEmpty()) {
+            // The injected showcase imports se.deversity.vibetags.annotations.*. Every @AI*
+            // annotation is RetentionPolicy.SOURCE, so compileOnly is the correct scope and
+            // nothing reaches the class files or the published artifacts.
+            project.configurations.matching { it.name == 'compileOnly' }.configureEach { cfg ->
+                project.dependencies.add(cfg.name, project.files(annJar))
+            }
+        }
+    }
+
+    // Java, and the Java half of a Scala or mixed build.
+    //
+    // Skipped entirely for Kotlin projects, and that is not a shortcut. kapt owns annotation
+    // processing there, exactly as examples/kotlin and USAGE.md configure it: processor on the
+    // kapt path, root passed through `kapt { arguments { ... } }`, nothing on the javac path.
+    // Configuring both routes at once is what the first version of this file did, and it put
+    // `-Avibetags.root` on kapt's javac command line as a raw flag as well as into kapt's own
+    // option map. javac then reported it as unclaimed - "warning: The following options were not
+    // recognized by any processor: '[vibetags.root, kapt.kotlin.generated]'" - a warning the
+    // control build could not have, which failed diagnostic parity for a defect in the harness
+    // rather than in the product. examples/kotlin, built the documented way, never showed it.
+    project.tasks.withType(org.gradle.api.tasks.compile.JavaCompile).configureEach { t ->
+        if (project.pluginManager.hasPlugin('org.jetbrains.kotlin.jvm')) {
+            return
+        }
+        // Appended, never assigned. Several corpus members run annotation processors of their
+        // own; replacing the path would disable them, and a treatment run that quietly dropped
+        // the project's own processor is not a measurement of non-interference, it is a
+        // different build.
+        def existing = t.options.annotationProcessorPath
+        t.options.annotationProcessorPath =
+            existing == null ? project.files(procFiles) : existing.plus(project.files(procFiles))
+        t.options.compilerArgs.add(rootArg)
+    }
+
+    // Groovy. javaAnnotationProcessing is off by default in Gradle, which is why a Groovy
+    // project that adds VibeTags and changes nothing else sees no output at all.
+    project.plugins.withId('groovy') {
+        project.tasks.withType(org.gradle.api.tasks.compile.GroovyCompile).configureEach { t ->
+            t.groovyOptions.javaAnnotationProcessing = true
+            def existing = t.options.annotationProcessorPath
+            t.options.annotationProcessorPath =
+                existing == null ? project.files(procFiles) : existing.plus(project.files(procFiles))
+            t.options.compilerArgs.add(rootArg)
+        }
+    }
+
+    // Kotlin. The kapt plugin ships inside kotlin-gradle-plugin, which is already on the
+    // buildscript classpath of any project applying kotlin("jvm"), so it can be applied by id
+    // from here without adding anything to the init classpath and without having to guess the
+    // project's Kotlin version.
+    project.pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
+        project.pluginManager.apply('org.jetbrains.kotlin.kapt')
+        procFiles.each { jar -> project.dependencies.add('kapt', project.files(jar)) }
+        // kapt compiles generated stubs in a worker directory, so the JVM working directory is
+        // not the project directory and the root must be passed explicitly. This is the same
+        // instruction USAGE.md gives a real Kotlin consumer.
+        project.extensions.getByName('kapt').arguments {
+            arg('vibetags.root', vtRoot)
+        }
+    }
+}

--- a/corpus/repos-jvm.tsv
+++ b/corpus/repos-jvm.tsv
@@ -1,0 +1,29 @@
+# The JVM-language corpus: real Kotlin, Groovy and Scala that nobody wrote to suit VibeTags.
+#
+# Separate from repos.tsv because these are not compiled by javac. Each repository is built by
+# its own Gradle wrapper, twice, and the only difference between the two runs is
+# corpus/inject-vibetags.init.gradle. An init script is the supported way to add a plugin or a
+# dependency to a build you do not own, so nothing here edits a build file it did not write.
+#
+# Tab-separated. Lines starting with '#' are comments. Columns:
+#   name      directory name under the corpus cache
+#   url       clone URL
+#   sha       pinned commit. Never a branch: an upstream push must not be able to turn this
+#             repository's CI red for a reason nobody here changed.
+#   lang      kotlin | groovy | scala. Picks the showcase template and the assertions.
+#   module    Gradle project directory holding the source set; "." for a single-module build
+#   src       source root, relative to module
+#   task      compile task to run. Not `build`: tests and linters are the project's business,
+#             and a repository whose checkstyle dislikes an injected showcase would be reporting
+#             its own opinion rather than anything about VibeTags.
+#   licence   SPDX id, checked before adding. Nothing is vendored.
+#   why       what this repository contributes that the others do not
+#
+# Each entry was control-compiled on JDK 21 at its pinned SHA before being added. A member whose
+# own build does not work makes every assertion below it vacuous, which is the lesson assertion 0
+# in the Java corpus was written from.
+#
+#name	url	sha	lang	module	src	task	licence	why
+kotlin-obd-api	https://github.com/eltonvs/kotlin-obd-api.git	30014eb6e8cd35334ba8f7ea627500f6b1942ff5	kotlin	.	src/main/kotlin	compileKotlin	Apache-2.0	Plain kotlin("jvm") library, no Android and no multiplatform, so kapt applies the way USAGE.md documents it
+groovy-nf-boost	https://github.com/bentsherman/nf-boost.git	92ba0a18ad9808649c54d56c7af33a50b0efc098	groovy	.	src/main/groovy	compileGroovy	Apache-2.0	A Groovy library whose classes groovyc can turn into valid Java stubs, which four of the seven Groovy projects tried could not; see corpus/README.md
+scala-splain	https://github.com/tek/splain.git	60c92b5e6422738087a1ed65c70e41a9ebefbc27	scala	core	src/main/scala	:core:classes	MIT	One of very few Gradle-built Scala projects on a JDK 21 wrapper; :core:classes runs compileJava and compileScala, which is what makes the two-sided Scala assertion possible

--- a/corpus/run-corpus-jvm.sh
+++ b/corpus/run-corpus-jvm.sh
@@ -1,0 +1,488 @@
+#!/usr/bin/env bash
+# Runs VibeTags over real third-party Kotlin, Groovy and Scala, built by their own Gradle.
+#
+# corpus/run-corpus.sh answers "does VibeTags survive code nobody wrote for it". It answers it in
+# Java, with javac, because that is the compiler JSR 269 belongs to. This script asks the same
+# question of the three other JVM languages people actually ship, and none of them reaches the
+# processor the way Java does:
+#
+#   Kotlin   kapt generates Java stubs and runs the processor over them. KSP does not run JSR 269
+#            processors at all, so kapt is the only route.
+#   Groovy   groovyc generates stubs the same way, but only when javaAnnotationProcessing is on,
+#            and it is off by default in Gradle. A Groovy project that adds VibeTags and changes
+#            nothing else generates nothing, silently.
+#   Scala    scalac has no JSR 269 support whatsoever. Annotated Scala compiles cleanly and is
+#            never seen. Only the Java half of a mixed build reaches the processor.
+#
+# USAGE.md has said all three for several releases. Until this script none of them had been run
+# against code outside this repository. The Scala one is asserted as a negative on purpose: the
+# Scala showcase is annotated at every level it can be, and every marker must be absent.
+#
+# Each repository is built twice by its own wrapper, and the only difference between the two runs
+# is corpus/inject-vibetags.init.gradle:
+#
+#   control    ./gradlew <task>
+#   treatment  ./gradlew <task> --init-script corpus/inject-vibetags.init.gradle
+#
+# Usage:
+#   corpus/run-corpus-jvm.sh [name ...]     # all repos, or just the named ones
+#
+# Env:
+#   VIBETAGS_CORPUS_DIR   cache location (default: <repo>/target/corpus-jvm)
+#   VIBETAGS_GRADLE_ARGS  extra flags for every Gradle invocation
+#
+# Requires vibetags-annotations and vibetags installed (see CLAUDE.md "Build and test").
+set -u
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+CACHE="${VIBETAGS_CORPUS_DIR:-$ROOT/target/corpus-jvm}"
+MANIFEST="$ROOT/corpus/repos-jvm.tsv"
+INIT_SCRIPT="$ROOT/corpus/inject-vibetags.init.gradle"
+GRADLE_ARGS="${VIBETAGS_GRADLE_ARGS:---console=plain}"
+
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) SEP=";" ; winpath() { cygpath -w "$1"; } ;;
+  *)                    SEP=":" ; winpath() { printf "%s" "$1"; } ;;
+esac
+
+VERSION=$(sed -n "s|.*<revision>\(.*\)</revision>.*|\1|p" "$ROOT/vibetags-parent/pom.xml")
+PROC_JAR="$ROOT/vibetags/target/vibetags-processor-$VERSION.jar"
+if [ ! -f "$PROC_JAR" ]; then
+  echo "FAIL: $PROC_JAR not found. Run 'mvn install' in vibetags/ first." >&2
+  exit 1
+fi
+ANN_JAR=$(ls "$HOME"/.m2/repository/se/deversity/vibetags/vibetags-annotations/"$VERSION"/vibetags-annotations-"$VERSION".jar 2>/dev/null | head -1)
+if [ ! -f "$ANN_JAR" ]; then
+  echo "FAIL: vibetags-annotations $VERSION is not in the local repository." >&2
+  echo "      The showcase cannot compile without it; run 'mvn install' in vibetags-annotations/." >&2
+  exit 1
+fi
+
+mkdir -p "$CACHE"
+# Regenerated every run, never restored from a cache. A classpath resolved by a run that failed
+# is indistinguishable from a good one once it is on disk, and the Java corpus has already been
+# burned by exactly that (corpus/README.md, "a third, in the harness rather than the product").
+mvn -q -f "$ROOT/vibetags/pom.xml" dependency:build-classpath \
+    -Dmdep.includeScope=runtime -Dmdep.regenerateFile=true \
+    "-Dmdep.outputFile=$CACHE/vibetags.cp" >/dev/null 2>&1
+if [ ! -s "$CACHE/vibetags.cp" ]; then
+  echo "FAIL: could not resolve the processor's runtime classpath." >&2
+  exit 1
+fi
+export VIBETAGS_JARS="$(winpath "$PROC_JAR")$SEP$(cat "$CACHE/vibetags.cp")"
+export VIBETAGS_ANN="$(winpath "$ANN_JAR")"
+
+fetch_repo() {
+  name="$1"; url="$2"; sha="$3"
+  dir="$CACHE/$name"
+  if [ -f "$dir/.corpus-sha" ] && [ "$(cat "$dir/.corpus-sha")" = "$sha" ]; then
+    return 0
+  fi
+  rm -rf "$dir"
+  mkdir -p "$dir"
+  ( cd "$dir" \
+    && git init --quiet \
+    && git remote add origin "$url" \
+    && git fetch --quiet --depth 1 origin "$sha" \
+    && git checkout --quiet FETCH_HEAD ) || return 1
+  printf '%s' "$sha" > "$dir/.corpus-sha"
+}
+
+DIAG_RE="^(w|e): |^(warning|error):|: (error|warning):|^\[(warn|error)\]"
+
+# Counts compiler diagnostics across four compilers' formats. javac and groovyc say
+# "warning:"/"error:", kotlinc prefixes "w:"/"e:", scalac and Zinc bracket them. Gradle's own
+# deprecation notices are excluded: they are identical on both sides, and counting them would
+# add noise to a comparison meant to isolate one variable.
+#
+# The `^(warning|error):` arm is not decoration. javac emits its summary diagnostics with no
+# file prefix at all - "warning: The following options were not recognized by any processor" is
+# the one that matters here - and the first version of this pattern required a colon before the
+# word. It counted 0 against 0 on a treatment run that had in fact raised a warning the control
+# had not, which is a diagnostic-parity check that cannot see the diagnostic it exists for.
+diagnostics() {
+  grep -cE "$DIAG_RE" "$1" 2>/dev/null || true
+}
+
+# Every marker a showcase declares. The floor is not a hand-written number here: it is derived
+# from the template, so growing a showcase raises the bar automatically and a level that stops
+# rendering cannot be absorbed by a margin somebody once left in.
+declared_markers() {
+  grep -ohE "(PACKAGE|FIELD|METHOD|PARAM|NESTED|CONSTRUCTOR)-[A-Z]+" "$@" 2>/dev/null | sort -u
+}
+generated_markers() {
+  grep -rhoE "(PACKAGE|FIELD|METHOD|PARAM|NESTED|CONSTRUCTOR)-[A-Z]+" "$@" 2>/dev/null | sort -u
+}
+
+# Markers a language is known not to be able to render, with the reason. Checked in both
+# directions: one of these appearing is as much a finding as a normal marker going missing,
+# because it means the toolchain changed and the documentation is now wrong the other way.
+#
+# groovy: groovyc's Java stubs carry types, constructors, methods and parameters - and no fields
+# at all. Verified by keeping the stubs (groovyOptions.keepStubs) and reading one: billingEmail,
+# authToken and tenantId are simply not in it. So every FIELD-targeted annotation is dropped
+# before any processor sees it, @AIPrivacy included, which is a safety-tier guardrail. USAGE.md
+# called this route "Full (joint compilation)" until this corpus ran.
+excluded_markers() {
+  case "$1" in
+    groovy) printf '%s\n' "FIELD-PERFORMANCE" "FIELD-PRIVACY" ;;
+    *)      : ;;
+  esac
+}
+
+# The safety-tier marker J6c looks for inline in the aggregate. @AIPrivacy on a field is the
+# sharpest version of that question and is used wherever fields survive; Groovy has to fall back
+# to @AILocked on a method, for the reason above.
+safety_marker() {
+  case "$1" in
+    groovy) printf '%s' "METHOD-LOCKED" ;;
+    *)      printf '%s' "FIELD-PRIVACY" ;;
+  esac
+}
+
+status=0
+repos_run=0
+printf "%-18s %-8s %-16s %-11s %-8s %s\n" REPO LANG "EXIT ctrl/vt" "DIAGS c/v" WROTE NOTE
+
+while IFS=$'\t' read -r name url sha lang module src task licence why; do
+  case "$name" in ''|'#'*) continue ;; esac
+  if [ "$#" -gt 0 ]; then
+    case " $* " in *" $name "*) ;; *) continue ;; esac
+  fi
+
+  if ! fetch_repo "$name" "$url" "$sha"; then
+    echo "FAIL: could not fetch $name at $sha" >&2
+    status=1
+    continue
+  fi
+
+  dir="$CACHE/$name"
+  moddir="$dir/$module"
+  srcdir="$moddir/$src"
+  if [ ! -d "$srcdir" ]; then
+    echo "FAIL: $name has no source root at $module/$src (pinned SHA moved it?)" >&2
+    status=1
+    continue
+  fi
+  if [ ! -f "$dir/gradlew" ]; then
+    echo "FAIL: $name has no Gradle wrapper, so there is no build to inject into." >&2
+    status=1
+    continue
+  fi
+  chmod +x "$dir/gradlew" 2>/dev/null || true
+
+  vt_root="$dir/.corpus-vibetags-root"
+  optin="$dir/.corpus-optin-root"
+  rm -rf "$vt_root" "$optin"
+  mkdir -p "$vt_root"
+
+  # --rerun-tasks is not optional. Gradle's up-to-date checks would let the treatment run skip
+  # compilation entirely, because the control had just compiled the same sources from the same
+  # inputs. A treatment that never ran a compiler passes every assertion below while testing
+  # nothing, which is the same shape of vacuous pass assertion 0 exists for in the Java corpus.
+  gradle_run() {
+    logfile="$1"; shift
+    ( cd "$dir" && ./gradlew $GRADLE_ARGS --rerun-tasks "$@" ) > "$logfile" 2>&1
+  }
+
+  # Control: the project's own build, untouched. VIBETAGS_ROOT is what switches the init script
+  # on, so the control runs with it unset rather than with a different command line.
+  ( unset VIBETAGS_ROOT; gradle_run "$dir/.corpus-ctrl.log" "$task" )
+  ctrl_exit=$?
+
+  VIBETAGS_ROOT="$(winpath "$vt_root")" \
+    gradle_run "$dir/.corpus-vt.log" "$task" --init-script "$(winpath "$INIT_SCRIPT")"
+  vt_exit=$?
+
+  ctrl_diag=$(diagnostics "$dir/.corpus-ctrl.log")
+  vt_diag=$(diagnostics "$dir/.corpus-vt.log")
+  wrote=$(find "$vt_root" -type f 2>/dev/null | wc -l | tr -d ' ')
+
+  printf "%-18s %-8s %-16s %-11s %-8s %s\n" \
+    "$name" "$lang" "$ctrl_exit/$vt_exit" "$ctrl_diag/$vt_diag" "$wrote" ""
+
+  repos_run=$((repos_run + 1))
+
+  # J0. The control has to build. Every assertion here is relative to it, so a repository that
+  # cannot build on its own passes exit parity and diagnostic parity trivially, both sides
+  # failing identically, and proves nothing.
+  if [ "$ctrl_exit" -ne 0 ]; then
+    echo "FAIL: $name does not build on its own, so nothing below it means anything." >&2
+    echo "      Fix the corpus member - pinned SHA, module path, task or JDK - not the code." >&2
+    grep -v "JAVA_TOOL_OPTIONS" "$dir/.corpus-ctrl.log" | tail -15 >&2
+    status=1
+    continue
+  fi
+  # J1. Adding VibeTags to somebody's build must not change whether it succeeds.
+  if [ "$ctrl_exit" -ne "$vt_exit" ]; then
+    echo "FAIL: $name exits $vt_exit with VibeTags and $ctrl_exit without it." >&2
+    grep -v "JAVA_TOOL_OPTIONS" "$dir/.corpus-vt.log" | tail -20 >&2
+    status=1
+  fi
+  # J2. A processor that turns a clean build noisy has broken the same promise, more quietly.
+  #
+  # Compared line by line rather than by count, and that is a deliberate departure from the Java
+  # corpus. There, javac runs either way and the only difference is a -processor flag, so "no new
+  # diagnostics" is a fair test. Here it is not: switching VibeTags on adds the kapt task graph to
+  # a Kotlin build and joint compilation to a Groovy one, and those emit diagnostics of their own
+  # about the annotation-processing machinery rather than about VibeTags. Counting them makes the
+  # check fail for the wrong reason, and raising a threshold to make it pass would blind it to the
+  # diagnostics that do matter.
+  #
+  # So every new line must either be gone or be named. KAPT_NOISE is the whole allow-list, one
+  # entry long, and anything else fails and is printed.
+  #
+  # That entry: kapt reports the processor options it forwards as unrecognised, vibetags.root
+  # among them - an option AIGuardrailProcessor does declare in @SupportedOptions, and does
+  # receive, since it prints the resolved root from the same task. examples/kotlin, configured
+  # exactly as USAGE.md documents and built on Kotlin 2.4.10, does not produce it; this member,
+  # on Kotlin 2.3.10, does. Removing the javac-side configuration so that only the documented
+  # `kapt { arguments { ... } }` route remained did not change it either. That is as far as the
+  # evidence goes, so it is allow-listed as kapt bookkeeping and tracked as an open question
+  # rather than asserted to be harmless.
+  KAPT_NOISE="The following options were not recognized by any processor"
+  new_diags=$(comm -13 <(grep -hE "$DIAG_RE" "$dir/.corpus-ctrl.log" | sort -u)                        <(grep -hE "$DIAG_RE" "$dir/.corpus-vt.log" | sort -u)               | grep -vF "$KAPT_NOISE")
+  if [ -n "$new_diags" ]; then
+    echo "FAIL: $name raises diagnostics with VibeTags that it does not raise without it:" >&2
+    printf '%s\n' "$new_diags" | head -10 >&2
+    echo "      If a line here is annotation-processing machinery rather than VibeTags, say so" >&2
+    echo "      in the allow-list above with the evidence. Do not widen it silently." >&2
+    status=1
+  fi
+  # J3. File presence is the only opt-in (tier-1 invariant 1) and none of these repositories
+  # opted in. Nothing at all, not even a log: since #487 the log file is created on the first
+  # record rather than when the logger is configured.
+  if [ "$wrote" -ne 0 ]; then
+    echo "FAIL: $name had $wrote file(s) written into a project that never opted in:" >&2
+    find "$vt_root" -type f | head -10 >&2
+    status=1
+  fi
+
+  # -----------------------------------------------------------------------------------------
+  # Opt-in phase. Everything above proves VibeTags stays out of the way, which for these three
+  # languages is only half the question and not the interesting half: a processor that never
+  # ran also stays out of the way perfectly. What follows is the proof that the injection works
+  # at all - kapt over Kotlin stubs, joint compilation over Groovy stubs - and, for Scala, the
+  # proof that it does not.
+  # -----------------------------------------------------------------------------------------
+  mkdir -p "$optin/.claude/rules" "$optin/.gemini/rules"
+  : > "$optin/CLAUDE.md"
+  : > "$optin/GEMINI.md"
+  : > "$optin/.vibetags-locks"
+  # AGENTS.md is invariant 4's exception: written only as the sole AI config file, or when it
+  # already carries a marker pair. Created empty alongside CLAUDE.md and GEMINI.md it would be
+  # dropped from the active set silently, and the corpus would report Codex working while
+  # generating none of it. Seeding the pair is what a real consumer does.
+  printf '%s\n%s\n' '<!-- VIBETAGS-START -->' '<!-- VIBETAGS-END -->' > "$optin/AGENTS.md"
+
+  ( cd "$dir" && git checkout --quiet -- . 2>/dev/null )
+
+  showcase_pkg="vibetagscorpus"
+  showcase_dir="$srcdir/$showcase_pkg"
+  java_showcase_dir=""
+  mkdir -p "$showcase_dir"
+  case "$lang" in
+    kotlin)
+      sed "s/__PACKAGE__/$showcase_pkg/g" "$ROOT/corpus/showcase/CorpusShowcase.kt.tmpl" \
+        > "$showcase_dir/CorpusShowcase.kt"
+      declared=$(declared_markers "$ROOT/corpus/showcase/CorpusShowcase.kt.tmpl")
+      ;;
+    groovy)
+      sed "s/__PACKAGE__/$showcase_pkg/g" "$ROOT/corpus/showcase/CorpusShowcase.groovy.tmpl" \
+        > "$showcase_dir/CorpusShowcase.groovy"
+      declared=$(declared_markers "$ROOT/corpus/showcase/CorpusShowcase.groovy.tmpl")
+      ;;
+    scala)
+      # Both halves of one build. The Java one must generate everything; the Scala one must
+      # generate nothing, and that pair is the entire point of the Scala member: without the
+      # positive half, "nothing came from Scala" and "nothing came at all" look identical.
+      sed "s/__PACKAGE__/$showcase_pkg/g" "$ROOT/corpus/showcase/CorpusShowcase.scala.tmpl" \
+        > "$showcase_dir/CorpusShowcase.scala"
+      java_showcase_dir="$moddir/src/main/java/$showcase_pkg"
+      mkdir -p "$java_showcase_dir"
+      sed "s/__PACKAGE__/$showcase_pkg/g" "$ROOT/corpus/showcase/CorpusShowcase.java.tmpl" \
+        > "$java_showcase_dir/CorpusShowcase.java"
+      sed "s/__PACKAGE__/$showcase_pkg/g" "$ROOT/corpus/showcase/package-info.java.tmpl" \
+        > "$java_showcase_dir/package-info.java"
+      declared=$(declared_markers "$ROOT/corpus/showcase/CorpusShowcase.java.tmpl" \
+                                  "$ROOT/corpus/showcase/package-info.java.tmpl")
+      ;;
+    *)
+      echo "FAIL: $name declares an unknown language '$lang'." >&2
+      status=1
+      rm -rf "$showcase_dir"
+      continue
+      ;;
+  esac
+
+  VIBETAGS_ROOT="$(winpath "$optin")" \
+    gradle_run "$dir/.corpus-optin.log" "$task" --init-script "$(winpath "$INIT_SCRIPT")"
+  optin_exit=$?
+
+  claude_bytes=$(wc -c < "$optin/CLAUDE.md" | tr -d ' ')
+  agents_bytes=$(wc -c < "$optin/AGENTS.md" | tr -d ' ')
+  claude_rules=$(find "$optin/.claude/rules" -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
+  gemini_rules=$(find "$optin/.gemini/rules" -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
+  hits=$(generated_markers "$optin/CLAUDE.md" "$optin/GEMINI.md" "$optin/AGENTS.md" \
+                           "$optin/.claude/rules" "$optin/.gemini/rules")
+  excluded=$(excluded_markers "$lang")
+  expected=$(comm -23 <(printf '%s\n' "$declared" | grep . | sort -u)                       <(printf '%s\n' "$excluded" | grep . | sort -u))
+  n_declared=$(printf '%s\n' "$expected" | grep -c . || true)
+  n_hits=$(printf '%s\n' "$hits" | grep -c . || true)
+
+  printf "%-18s %-8s %-16s %-11s %-8s %s\n" \
+    "  |- opt-in" "" "exit=$optin_exit" "CLAUDE=$claude_bytes" \
+    "$claude_rules/$gemini_rules" "markers=$n_hits/$n_declared"
+
+  # J9b, taken before the sources go away. J9 below asserts that the annotated Scala produced no
+  # guardrails, and the cheapest way for that to be true is for scalac never to have seen the
+  # file at all - a source root that moved, a task that does not compile it, a showcase written
+  # somewhere the build ignores. Then J9 passes while proving nothing. Requiring a class file
+  # under the Scala output is what separates "scalac compiled it and offered nothing to a
+  # processor" from "scalac was never asked".
+  scala_classes=0
+  if [ "$lang" = scala ]; then
+    scala_classes=$(find "$moddir/build" -path "*classes/scala*" -name "CorpusShowcase*.class"                       2>/dev/null | wc -l | tr -d ' ')
+  fi
+
+  # Reverted before any assertion can `continue` out of the loop, so a failure never leaves
+  # third-party sources modified on disk.
+  rm -rf "$showcase_dir"
+  [ -n "$java_showcase_dir" ] && rm -rf "$java_showcase_dir"
+  ( cd "$dir" && git checkout --quiet -- . 2>/dev/null )
+
+  # J4. The annotated build still has to work. If it does not, nothing was generated and every
+  # assertion after this one would be reporting on an empty directory.
+  if [ "$optin_exit" -ne 0 ]; then
+    echo "FAIL: $name did not build once annotated, so nothing was generated to evaluate." >&2
+    grep -v "JAVA_TOOL_OPTIONS" "$dir/.corpus-optin.log" | tail -20 >&2
+    status=1
+    continue
+  fi
+
+  # J5. Every opted-in platform produces content, checked per platform rather than in aggregate:
+  # one renderer can be dropped from the registry and the other two will cover for it in a total.
+  for pf in CLAUDE.md GEMINI.md AGENTS.md; do
+    if [ ! -s "$optin/$pf" ]; then
+      echo "FAIL: $name opted into $pf and it came back empty." >&2
+      status=1
+    fi
+  done
+  # J5b. Codex needs its own check: AGENTS.md was seeded with a marker pair, so "not empty" is
+  # true before VibeTags runs at all. 46 bytes is the seed and nothing else.
+  if [ "$agents_bytes" -le 46 ]; then
+    echo "FAIL: $name produced an AGENTS.md of $agents_bytes bytes, which is the seeded marker" >&2
+    echo "      pair alone. Codex was dropped from the active set rather than written." >&2
+    status=1
+  fi
+  # J6. The marker pair is present in every aggregate: it is the whole of the promise that
+  # hand-authored content outside it survives.
+  for pf in CLAUDE.md GEMINI.md AGENTS.md; do
+    if ! grep -q "VIBETAGS-START" "$optin/$pf" 2>/dev/null; then
+      echo "FAIL: $name produced a $pf with no VIBETAGS-START marker." >&2
+      status=1
+    fi
+  done
+  # J6b. Both granular directories were written. An opted-in directory that stays empty looks
+  # exactly like "this project has no rules".
+  if [ "$claude_rules" -lt 1 ] || [ "$gemini_rules" -lt 1 ]; then
+    echo "FAIL: $name opted into granular rules and got $claude_rules Claude / $gemini_rules Gemini files." >&2
+    status=1
+  fi
+  # J6c. The tier split, which is invariant 6 checked through three compilers instead of one.
+  # With a granular directory opted in, the aggregate keeps the safety buckets inline and
+  # replaces everything else with a pointer: @AIPrivacy stays in CLAUDE.md, @AIContract must not.
+  safety=$(safety_marker "$lang")
+  if ! grep -q "$safety" "$optin/CLAUDE.md" 2>/dev/null; then
+    echo "FAIL: $name dropped a safety-tier guardrail ($safety) from the aggregate." >&2
+    echo "      Safety buckets stay inline even when the granular directory is opted in." >&2
+    status=1
+  fi
+  if grep -q "METHOD-CONTRACT" "$optin/CLAUDE.md" 2>/dev/null; then
+    echo "FAIL: $name kept a non-safety guardrail (@AIContract) inline in the aggregate." >&2
+    status=1
+  fi
+  if ! grep -rq "METHOD-CONTRACT" "$optin/.claude/rules" 2>/dev/null; then
+    echo "FAIL: $name moved @AIContract out of the aggregate but not into the rules directory." >&2
+    echo "      That guardrail now reaches nobody, which is worse than leaving it inline." >&2
+    status=1
+  fi
+  # J6d. The parameter level, which is the finest addressing VibeTags produces and the one most
+  # exposed to a stub generator: a parameter name that does not survive into the stub cannot be
+  # addressed at all, and neither kapt nor groovyc is obliged to keep it.
+  if ! grep -rq "PARAM-LOADBEARING" "$optin/.claude/rules" 2>/dev/null; then
+    echo "FAIL: $name lost the parameter-level guardrail (@AILoadBearing on a parameter)." >&2
+    status=1
+  fi
+  # J6f. Every marker the showcase declares must reach a generated file. Derived from the
+  # template rather than written down, so the bar rises with the showcase.
+  if [ "$n_hits" -lt "$n_declared" ]; then
+    echo "FAIL: $name rendered $n_hits of the $n_declared guardrails expected for $lang." >&2
+    echo "      Missing:" >&2
+    comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$hits") >&2
+    status=1
+  fi
+  # J6g. The other direction. A marker on the exclusion list is one this language is documented
+  # as unable to render, so its appearance means the toolchain changed under us and the
+  # documentation is now wrong in the generous direction - which nobody ever notices, because
+  # the run is green and more guardrails arrived than were asked for. Delete the exclusion and
+  # fix USAGE.md rather than leaving both to drift.
+  surprises=$(comm -12 <(printf '%s\n' "$excluded" | grep . | sort -u) <(printf '%s\n' "$hits"))
+  if [ -n "$surprises" ]; then
+    echo "FAIL: $name rendered guardrails that $lang is documented as unable to render:" >&2
+    printf '%s\n' "$surprises" >&2
+    echo "      Good news, and still a failure: remove the exclusion in excluded_markers()" >&2
+    echo "      and correct the limitation in USAGE.md." >&2
+    status=1
+  fi
+  # J8. No type-use annotation in any generated identity, in a path attribute, a lock entry or
+  # a filename. The Java corpus found this defect twice; these compilers reach ElementNaming by
+  # different routes and there is no reason to assume they agree.
+  leaked_paths=$(grep -c 'path="[^"]*@' "$optin/CLAUDE.md" "$optin/GEMINI.md" 2>/dev/null \
+                 | awk -F: '{s+=$2} END {print s+0}')
+  leaked_locks=$(grep -c '"element":"[^"]*@' "$optin/.vibetags-locks" 2>/dev/null || true)
+  leaked_names=$(find "$optin" -name "*@*" 2>/dev/null | wc -l | tr -d ' ')
+  leaked=$((leaked_paths + leaked_locks + leaked_names))
+  if [ "$leaked" -ne 0 ]; then
+    echo "FAIL: $name put a type-use annotation into an element identity" >&2
+    echo "      ($leaked_paths path attributes, $leaked_locks lock entries, $leaked_names filenames)." >&2
+    status=1
+  fi
+
+  # J9. Scala only, and the reason the Scala member is here at all. Every marker in the
+  # annotated .scala file must be absent from every generated file, because scalac never offered
+  # them to a processor. If this goes red, either scalac has gained JSR 269 support or VibeTags
+  # has found another way in - and USAGE.md's Scala row needs rewriting rather than this check
+  # relaxing. J6f above is the positive half, over the Java showcase in the same build.
+  if [ "$lang" = scala ]; then
+    seen=$(grep -rhoE "SCALA-INVISIBLE-[A-Z-]+" \
+             "$optin/CLAUDE.md" "$optin/GEMINI.md" "$optin/AGENTS.md" \
+             "$optin/.claude/rules" "$optin/.gemini/rules" 2>/dev/null | sort -u)
+    n_seen=$(printf '%s\n' "$seen" | grep -c . || true)
+    if [ "$scala_classes" -lt 1 ]; then
+      echo "FAIL: $name compiled no Scala showcase classes, so the check below would hold for" >&2
+      echo "      the wrong reason: scalac never saw the annotated file." >&2
+      echo "      Check module='$module' src='$src' and task='$task' in repos-jvm.tsv." >&2
+      status=1
+    fi
+    if [ "$n_seen" -ne 0 ]; then
+      echo "FAIL: $name generated $n_seen guardrail(s) from annotated Scala sources:" >&2
+      printf '%s\n' "$seen" >&2
+      echo "      USAGE.md says scalac has no JSR 269 support and annotated Scala is never seen." >&2
+      echo "      One of the two is now wrong. Do not relax this check to make the run green." >&2
+      status=1
+    fi
+  fi
+done < "$MANIFEST"
+
+if [ "$repos_run" -eq 0 ]; then
+  echo "FAIL: no repositories ran, so this proves nothing." >&2
+  exit 1
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "OK: $repos_run JVM-language repositories, control and treatment compared, opt-in read back."
+else
+  echo "FAILED: see the assertions above." >&2
+fi
+exit "$status"

--- a/corpus/showcase/CorpusShowcase.groovy.tmpl
+++ b/corpus/showcase/CorpusShowcase.groovy.tmpl
@@ -1,0 +1,156 @@
+package __PACKAGE__
+
+import se.deversity.vibetags.annotations.AIAudit
+import se.deversity.vibetags.annotations.AIBannedApi
+import se.deversity.vibetags.annotations.AIContext
+import se.deversity.vibetags.annotations.AIContract
+import se.deversity.vibetags.annotations.AICore
+import se.deversity.vibetags.annotations.AIGenerated
+import se.deversity.vibetags.annotations.AIIgnore
+import se.deversity.vibetags.annotations.AIImmutable
+import se.deversity.vibetags.annotations.AIInputSanitized
+import se.deversity.vibetags.annotations.AIKeepInSync
+import se.deversity.vibetags.annotations.AILoadBearing
+import se.deversity.vibetags.annotations.AILocked
+import se.deversity.vibetags.annotations.AIPerformance
+import se.deversity.vibetags.annotations.AIPrivacy
+import se.deversity.vibetags.annotations.AIPublicAPI
+import se.deversity.vibetags.annotations.AISecure
+import se.deversity.vibetags.annotations.AISecureLogging
+import se.deversity.vibetags.annotations.AITestDriven
+import se.deversity.vibetags.annotations.AIThreadSafe
+
+/**
+ * The Groovy twin of {@code CorpusShowcase.java}, compiled inside a third-party Groovy build by
+ * that project's own Gradle, through joint compilation.
+ *
+ * <p>Groovy reaches the processor by a different route from Kotlin and from Java. groovyc emits
+ * a Java stub per Groovy class and javac runs the processors over the stubs, which only happens
+ * when {@code groovyOptions.javaAnnotationProcessing} is switched on - and it is off by default
+ * in Gradle. A Groovy project that adds VibeTags and changes nothing else therefore generates
+ * nothing at all, silently. The init script switches it on, and the harness asserts output
+ * appeared, so the day that flag stops being honoured this goes red rather than quiet.
+ *
+ * <p><b>The fields below are here to fail.</b> groovyc's stub carries the class, its
+ * constructors, its methods and their parameters - and no fields whatsoever. Not renamed, not
+ * moved onto an accessor: absent. So every {@code FIELD}-targeted annotation is dropped before
+ * any processor is asked, {@code @AIPrivacy} among them, and that one is a safety-tier guardrail
+ * a Groovy author would reasonably expect to be the most reliable thing here.
+ *
+ * <p>Writing them {@code private} does not help, and that was the first guess: a Groovy field
+ * with no access modifier becomes a property, so the obvious theory was that the annotation had
+ * travelled onto a generated accessor. It has not. The stub was kept
+ * ({@code groovyOptions.keepStubs}) and read, and {@code billingEmail}, {@code authToken} and
+ * {@code tenantId} appear nowhere in it.
+ *
+ * <p>They stay in this file rather than being deleted, because a limitation nothing exercises is
+ * a limitation nobody notices has been fixed. {@code excluded_markers()} in
+ * corpus/run-corpus-jvm.sh names exactly these two, and the harness fails if they ever start
+ * being rendered - at which point the exclusion goes and USAGE.md's Groovy row gets rewritten.
+ *
+ * <p>Injected by corpus/run-corpus-jvm.sh and reverted with `git checkout -- .` afterwards.
+ */
+@AIContext(focus = "corpus groovy showcase: type level, non-safety, belongs in the granular tier",
+           avoids = "asserting anything about the third-party code around it")
+@AIPublicAPI
+class CorpusShowcase {
+
+    // ---- field level -------------------------------------------------------------------
+    //
+    // `private` is load-bearing: without it Groovy makes these properties, and a property is a
+    // getter and a setter around a synthetic field rather than the field an author annotated.
+
+    /** Safety tier: privacy stays inline in the aggregate. */
+    @AIPrivacy(reason = "corpus groovy showcase FIELD-PRIVACY: PII must never be logged")
+    private String billingEmail
+
+    /** Granular tier: a second field annotation that moves down. */
+    @AISecureLogging
+    private String authToken
+
+    /** Granular tier: a performance budget on a plain field. */
+    @AIPerformance(constraint = "corpus groovy showcase FIELD-PERFORMANCE: read on every request")
+    private long tenantId
+
+    // ---- constructor level -------------------------------------------------------------
+
+    @AILocked(reason = "corpus groovy showcase CONSTRUCTOR-LOCKED: initialisation order is load-bearing")
+    CorpusShowcase() {
+    }
+
+    @AIContract(reason = "corpus groovy showcase CONSTRUCTOR-CONTRACT: callers depend on this shape")
+    CorpusShowcase(String seed) {
+        this.billingEmail = seed
+    }
+
+    // ---- method level, safety tier -----------------------------------------------------
+
+    @AILocked(reason = "corpus groovy showcase METHOD-LOCKED: do not edit")
+    long invoiceNumber(long id) {
+        id
+    }
+
+    @AIAudit(checkFor = ["SQL injection", "path traversal"])
+    void audited(String query) {
+    }
+
+    @AISecure(aspect = "corpus groovy showcase METHOD-SECURE")
+    void secured() {
+    }
+
+    @AIIgnore(reason = "corpus groovy showcase METHOD-IGNORE: excluded from context")
+    void ignored() {
+    }
+
+    // ---- method level, granular tier, and the parameter level --------------------------
+
+    /**
+     * The parameter level is the finest addressing VibeTags produces. Under joint compilation it
+     * also depends on the stub keeping parameter names, which is the sort of thing that is true
+     * until a Groovy release makes it not.
+     */
+    @AIContract(reason = "corpus groovy showcase METHOD-CONTRACT: callers depend on this shape")
+    @AIPerformance(constraint = "corpus groovy showcase METHOD-PERFORMANCE: no allocation in the loop")
+    String render(
+            @AIInputSanitized([AIInputSanitized.SanitizerType.SQL_INJECTION,
+                               AIInputSanitized.SanitizerType.XSS]) String customerNote,
+            @AILoadBearing(invariant = "corpus groovy showcase PARAM-LOADBEARING: order matters here")
+            String other) {
+        customerNote + other
+    }
+
+    @AITestDriven(coverageGoal = 95)
+    void tested() {
+    }
+
+    @AIThreadSafe(note = "corpus groovy showcase METHOD-THREADSAFE")
+    void threadSafe() {
+    }
+
+    @AILoadBearing(invariant = "corpus groovy showcase METHOD-LOADBEARING: looks removable, is not")
+    void loadBearing() {
+    }
+
+    @AIKeepInSync(mirrors = ["corpus/showcase/CorpusShowcase.groovy.tmpl"])
+    void mirrored() {
+    }
+
+    @AIBannedApi(forbidden = ["java.util.Date"], useInstead = "java.time.Instant")
+    void bannedApis() {
+    }
+
+    @AIGenerated(from = "corpus/showcase/CorpusShowcase.groovy.tmpl")
+    void generated() {
+    }
+
+    // ---- nested type level -------------------------------------------------------------
+
+    /** A Groovy static nested class, so the element path matches the Java showcase's. */
+    @AIImmutable(note = "corpus groovy showcase NESTED-IMMUTABLE")
+    @AICore(sensitivity = "high", note = "corpus groovy showcase NESTED-CORE")
+    static final class Inner {
+        @AILocked(reason = "corpus groovy showcase NESTED-METHOD-LOCKED")
+        void innerMethod() {
+        }
+    }
+}

--- a/corpus/showcase/CorpusShowcase.kt.tmpl
+++ b/corpus/showcase/CorpusShowcase.kt.tmpl
@@ -1,0 +1,151 @@
+package __PACKAGE__
+
+import se.deversity.vibetags.annotations.AIAudit
+import se.deversity.vibetags.annotations.AIBannedApi
+import se.deversity.vibetags.annotations.AIContext
+import se.deversity.vibetags.annotations.AIContract
+import se.deversity.vibetags.annotations.AICore
+import se.deversity.vibetags.annotations.AIGenerated
+import se.deversity.vibetags.annotations.AIIgnore
+import se.deversity.vibetags.annotations.AIImmutable
+import se.deversity.vibetags.annotations.AIInputSanitized
+import se.deversity.vibetags.annotations.AIKeepInSync
+import se.deversity.vibetags.annotations.AILoadBearing
+import se.deversity.vibetags.annotations.AILocked
+import se.deversity.vibetags.annotations.AIPerformance
+import se.deversity.vibetags.annotations.AIPrivacy
+import se.deversity.vibetags.annotations.AIPublicAPI
+import se.deversity.vibetags.annotations.AISecure
+import se.deversity.vibetags.annotations.AISecureLogging
+import se.deversity.vibetags.annotations.AITestDriven
+import se.deversity.vibetags.annotations.AIThreadSafe
+
+/**
+ * The Kotlin twin of `CorpusShowcase.java`, compiled inside a third-party Kotlin build by that
+ * project's own Gradle, through kapt.
+ *
+ * Two things here are Kotlin's and not Java's, and both are the reason this file exists rather
+ * than being a translation exercise:
+ *
+ * **Use-site targets.** A Kotlin property is a getter, a setter and possibly a backing field, so
+ * an annotation written bare on a property does not necessarily land where a Java author would
+ * expect. Every `@AI*` annotation declares Java targets, and the ones that only accept `FIELD`
+ * are written `@field:` here on purpose. Getting this wrong does not fail the build - it moves
+ * the guardrail onto a different element, or drops it - which is exactly the failure a fixture
+ * written by somebody who knew the answer would never catch.
+ *
+ * **No package level.** Kotlin has no `package-info.kt`, so the package row of the Java showcase
+ * has no counterpart. That is a real limitation of the Kotlin route and is asserted as one:
+ * the harness does not look for a package guardrail here.
+ *
+ * Injected by corpus/run-corpus-jvm.sh and reverted with `git checkout -- .` afterwards.
+ */
+@AIContext(
+    focus = "corpus kotlin showcase: type level, non-safety, belongs in the granular tier",
+    avoids = "asserting anything about the third-party code around it",
+)
+@AIPublicAPI
+class CorpusShowcase {
+
+    // ---- field level -------------------------------------------------------------------
+    //
+    // @field: is load-bearing. @AIPrivacy targets FIELD only; written bare on a property Kotlin
+    // has no property target to fall back to for a Java annotation, and the result depends on
+    // the annotation's target set rather than on what the author meant.
+
+    /** Safety tier: privacy stays inline in the aggregate. */
+    @field:AIPrivacy(reason = "corpus kotlin showcase FIELD-PRIVACY: PII must never be logged")
+    private var billingEmail: String? = null
+
+    /** Granular tier: a second field annotation that moves down. */
+    @field:AISecureLogging
+    private var authToken: String? = null
+
+    /** Granular tier: a performance budget on a plain field. */
+    @field:AIPerformance(
+        constraint = "corpus kotlin showcase FIELD-PERFORMANCE: read on every request",
+    )
+    private var tenantId: Long = 0
+
+    // ---- constructor level -------------------------------------------------------------
+    //
+    // Annotating a Kotlin constructor requires the `constructor` keyword, which is why a
+    // secondary constructor is used for the second overload: two constructors that must be
+    // addressed by their own parameter lists, as in the Java showcase.
+
+    @AILocked(
+        reason = "corpus kotlin showcase CONSTRUCTOR-LOCKED: initialisation order is load-bearing",
+    )
+    constructor()
+
+    @AIContract(reason = "corpus kotlin showcase CONSTRUCTOR-CONTRACT: callers depend on this shape")
+    constructor(seed: String) {
+        this.billingEmail = seed
+    }
+
+    // ---- method level, safety tier -----------------------------------------------------
+
+    @AILocked(reason = "corpus kotlin showcase METHOD-LOCKED: do not edit")
+    fun invoiceNumber(id: Long): Long = id
+
+    @AIAudit(checkFor = ["SQL injection", "path traversal"])
+    fun audited(query: String) {
+        check(query.isNotEmpty() || true)
+    }
+
+    @AISecure(aspect = "corpus kotlin showcase METHOD-SECURE")
+    fun secured() = Unit
+
+    @AIIgnore(reason = "corpus kotlin showcase METHOD-IGNORE: excluded from context")
+    fun ignored() = Unit
+
+    // ---- method level, granular tier, and the parameter level --------------------------
+
+    /**
+     * The parameter level is the finest addressing VibeTags produces, and under kapt it is also
+     * the one most exposed to the stub generator: a parameter name that does not survive into
+     * the stub cannot be addressed at all.
+     */
+    @AIContract(reason = "corpus kotlin showcase METHOD-CONTRACT: callers depend on this shape")
+    @AIPerformance(constraint = "corpus kotlin showcase METHOD-PERFORMANCE: no allocation in the loop")
+    fun render(
+        @AIInputSanitized(
+            AIInputSanitized.SanitizerType.SQL_INJECTION,
+            AIInputSanitized.SanitizerType.XSS,
+        )
+        customerNote: String,
+        @AILoadBearing(invariant = "corpus kotlin showcase PARAM-LOADBEARING: order matters here")
+        other: String,
+    ): String = customerNote + other
+
+    @AITestDriven(coverageGoal = 95)
+    fun tested() = Unit
+
+    @AIThreadSafe(note = "corpus kotlin showcase METHOD-THREADSAFE")
+    fun threadSafe() = Unit
+
+    @AILoadBearing(invariant = "corpus kotlin showcase METHOD-LOADBEARING: looks removable, is not")
+    fun loadBearing() = Unit
+
+    @AIKeepInSync(mirrors = ["corpus/showcase/CorpusShowcase.kt.tmpl"])
+    fun mirrored() = Unit
+
+    @AIBannedApi(forbidden = ["java.util.Date"], useInstead = "java.time.Instant")
+    fun bannedApis() = Unit
+
+    @AIGenerated(from = "corpus/showcase/CorpusShowcase.kt.tmpl")
+    fun generated() = Unit
+
+    // ---- nested type level -------------------------------------------------------------
+
+    /**
+     * A Kotlin nested class is static unless declared `inner`, which matches the Java showcase's
+     * `static final class` and keeps the two element paths comparable.
+     */
+    @AIImmutable(note = "corpus kotlin showcase NESTED-IMMUTABLE")
+    @AICore(sensitivity = "high", note = "corpus kotlin showcase NESTED-CORE")
+    class Inner {
+        @AILocked(reason = "corpus kotlin showcase NESTED-METHOD-LOCKED")
+        fun innerMethod() = Unit
+    }
+}

--- a/corpus/showcase/CorpusShowcase.scala.tmpl
+++ b/corpus/showcase/CorpusShowcase.scala.tmpl
@@ -1,0 +1,68 @@
+package __PACKAGE__
+
+import se.deversity.vibetags.annotations.AIAudit
+import se.deversity.vibetags.annotations.AIContext
+import se.deversity.vibetags.annotations.AIContract
+import se.deversity.vibetags.annotations.AICore
+import se.deversity.vibetags.annotations.AILocked
+import se.deversity.vibetags.annotations.AIPrivacy
+import se.deversity.vibetags.annotations.AIPublicAPI
+import se.deversity.vibetags.annotations.AISecure
+
+/**
+ * The Scala half of the Scala corpus member, and the only showcase in the corpus that is
+ * asserted to produce **nothing**.
+ *
+ * scalac has no JSR 269 support. Java annotations are legal in Scala and compile without
+ * complaint, so a Scala author can write every annotation below, see a green build, and get no
+ * guardrails whatsoever. USAGE.md states that ("Scala | Java sources only | scalac has no JSR
+ * 269 support; annotated Scala classes compile but are never seen"), and until this file existed
+ * that sentence was prose nobody had run.
+ *
+ * The harness asserts the negative directly: none of the SCALA-INVISIBLE markers below may
+ * appear in any generated file, while the markers in the Java half of the same build must all
+ * appear. Both directions matter. If the negative assertion ever goes red, either scalac has
+ * gained annotation processing or VibeTags has found another way in - and either way the line
+ * in USAGE.md needs rewriting rather than the test relaxing.
+ *
+ * Injected by corpus/run-corpus-jvm.sh and reverted with `git checkout -- .` afterwards.
+ */
+@AIContext(focus = "corpus scala showcase SCALA-INVISIBLE-CONTEXT: must never be generated")
+@AIPublicAPI
+class CorpusShowcase {
+
+  @AIPrivacy(reason = "corpus scala showcase SCALA-INVISIBLE-PRIVACY: PII, and still not seen")
+  private var billingEmail: String = _
+
+  @AILocked(reason = "corpus scala showcase SCALA-INVISIBLE-LOCKED: do not edit")
+  def invoiceNumber(id: Long): Long = id
+
+  @AIAudit(checkFor = Array("SQL injection", "path traversal"))
+  def audited(query: String): Unit = ()
+
+  @AISecure(aspect = "corpus scala showcase SCALA-INVISIBLE-SECURE")
+  def secured(): Unit = ()
+
+  @AIContract(reason = "corpus scala showcase SCALA-INVISIBLE-CONTRACT: frozen shape")
+  def render(customerNote: String, other: String): String = customerNote + other
+}
+
+/**
+ * A Scala `object`, which has no Java counterpart at all. If anything ever did start reading
+ * Scala sources, this is the construct whose element path would have to be invented, so it is
+ * here to be found rather than discovered later.
+ */
+@AICore(sensitivity = "high", note = "corpus scala showcase SCALA-INVISIBLE-CORE")
+object CorpusShowcaseObject {
+  @AILocked(reason = "corpus scala showcase SCALA-INVISIBLE-OBJECT-LOCKED")
+  def helper(): Unit = ()
+}
+
+/** A case class and a trait, for the same reason. */
+@AIContext(focus = "corpus scala showcase SCALA-INVISIBLE-CASECLASS")
+case class CorpusShowcaseValue(id: Long, label: String)
+
+@AIContext(focus = "corpus scala showcase SCALA-INVISIBLE-TRAIT")
+trait CorpusShowcaseTrait {
+  def describe(): String
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **[docs/JVM-LANGUAGES.md](JVM-LANGUAGES.md): what Kotlin, Groovy and Scala actually get.** The
+  support matrix in USAGE.md was three rows and a mechanism column, and one of the rows was wrong
+  for several releases. This page gives each language a stated maturity, the levels it silently
+  drops, the workaround, and the job that measures the claim on every pull request.
+
+  It also records the things a matrix row cannot: that Groovy loses every field-level annotation
+  including `@AIPrivacy`, with the stub evidence; that only two of eight surveyed Groovy projects
+  can switch stub processing on at all; that a Gradle toolchain pinned below 21 fails with an error
+  naming neither VibeTags nor the toolchain; and that Kotlin support rests entirely on kapt, which
+  JetBrains keeps current but has no plans to extend, while KSP defines its own processor interface
+  and cannot load a JSR 269 processor at all. A closing section states what is *not* known, so
+  silence is not mistaken for evidence.
+
 - **VibeTags is now tested against real Kotlin, Groovy and Scala, and the Groovy row of the
   support matrix turned out to be wrong.** The third-party corpus added in the previous release
   covers six Java libraries compiled by javac. That is the compiler JSR 269 belongs to, and it is
@@ -68,6 +81,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   objects by design. Both exclusions are named in `ConstructorLevelGuardrailTest` with the
   reasoning, so a later sweep that "completes" the set has to argue with it. Found by the
   third-party corpus, whose showcase failed to compile. (#488)
+
+### Changed
+
+- **A dependabot bump of `pmd.version` no longer turns the build red.** Every third-party version
+  is a property in `vibetags-parent/pom.xml`, and dependabot edits that file and nothing else,
+  because that is where the property lives. PMD's `toolVersion` was a hand-copied literal in
+  `vibetags/build.gradle` and `vibetags-annotations/build.gradle`, so `BuildVersionParityTest`
+  failed on every PMD bump and a human had to hand-fix the PR before it could merge, which is not
+  what an automated bump is for. Both files now derive the value from the parent.
+
+  `BuildVersionParityTest` was rewritten with it, and that half matters more than the fix: the old
+  check compared the literal against the parent, which finds nothing once there is no literal left,
+  so it would have started passing vacuously. It now asserts the *mechanism* - a quoted
+  `toolVersion` fails even when the number is correct, and a file applying PMD that never names
+  `pmd.version` fails too. Verified by simulating the exact dependabot edit: bumping `pmd.version`
+  in the parent alone passes with the fix and fails without it.
+
+- **Dependabot's `/example` Maven entry pointed at a directory that has never existed.** The
+  examples live under `examples/`, so that entry produced nothing, silently - the same failure the
+  npm entry in the same file already carries a comment about. Removed rather than redirected, with
+  the reason recorded: the example poms pin VibeTags artifacts at the released version, which
+  `scripts/set-version.sh` owns and `BuildVersionParityTest` enforces, so a dependabot PR moving
+  one would be red on arrival and could never merge. The remaining `/vibetags` entry reaches every
+  pin already, through the parent.
+
+- **`ecj.version` 3.44.0 to 3.46.0, and the Gradle wrapper 9.7.0 to 9.7.1** across all ten
+  `gradle-wrapper.properties` files. The ECJ pin had been invisible to `scripts/bump-dependencies.sh`
+  since it was introduced: the script's `PINS` table had no Maven Central path for it, so the report
+  exited 2 rather than reporting a stale version. Adding the path is what surfaced the update.
+  Verified by `scripts/ecj-degradation-check.sh` on 3.46.0: 9 locked entries under both compilers,
+  9 positions under javac and 0 under ECJ, and 147 lines of guardrail region byte-identical.
+
+  The mirror tables in `docs/DEPENDENCIES.md` and the `bump-dependencies` skill were both wrong
+  about the wrapper: they said three subprojects and six files respectively, against ten actual
+  files. Both now say to enumerate rather than remember.
 
 ### Fixed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **VibeTags is now tested against real Kotlin, Groovy and Scala, and the Groovy row of the
+  support matrix turned out to be wrong.** The third-party corpus added in the previous release
+  covers six Java libraries compiled by javac. That is the compiler JSR 269 belongs to, and it is
+  also the only one the project had ever been measured on outside its own examples. Kotlin reaches
+  the processor through kapt, Groovy only when joint compilation's `javaAnnotationProcessing` is
+  switched on, and Scala not at all. USAGE.md had stated all three for several releases; none had
+  been run against anybody else's code.
+
+  Three more repositories are now built on every CI run — [`kotlin-obd-api`][k], [`nf-boost`][g]
+  and [`splain`][s] — each twice, by its own Gradle wrapper, the only difference between the runs
+  being a Gradle init script. An init script is the supported way to add a plugin to a build you do
+  not own, so nothing edits a build file it did not write. Sixteen assertions, including the tier
+  split and the granular directories, checked through three compilers instead of one.
+
+  **What it found, in Groovy: every field-level annotation is silently dropped.** groovyc's Java
+  stubs carry the class, its constructors, its methods and their parameters — and no fields at all.
+  So `@AIPrivacy` on a Groovy field generates nothing. No file, no warning, no trace. It is one of
+  the six safety annotations and the natural way to mark a PII field, and until this ran the
+  documentation called that route "Full (joint compilation)".
+
+  The obvious explanation was wrong and is worth recording: a Groovy field with no access modifier
+  becomes a property, so the first theory was that the annotation had moved onto a generated
+  accessor. Keeping the stubs (`groovyOptions.keepStubs`) and reading one settled it — `billingEmail`,
+  `authToken` and `tenantId` appear nowhere in the stub. Nothing in VibeTags can fix that, so it is
+  documented instead, and pinned: the Groovy showcase annotates those fields on purpose and the
+  harness fails if they ever *start* being rendered, because a limitation nothing exercises is a
+  limitation nobody notices has been fixed.
+
+  Scala is asserted as a negative for the same reason, in both directions: annotated `.scala` must
+  generate nothing, the Java half of the same build must generate everything, and the Scala
+  showcase must have produced class files — otherwise "scalac generated nothing" and "scalac was
+  never asked" are the same green run.
+
+  Three further findings came out of choosing the members. Three of the eight Groovy repositories
+  surveyed compile perfectly well and break the moment stubs are generated, each on a different
+  stub defect. Two more fail because a Gradle toolchain pinned below 21 cannot load the processor,
+  with an error naming neither VibeTags nor the toolchain. And the harness's own diagnostic counter
+  was blind to javac's summary diagnostics, reporting `0` against `0` on a run that had raised a
+  warning the control had not. All of it is in [corpus/README.md][c].
+
+  [k]: https://github.com/eltonvs/kotlin-obd-api
+  [g]: https://github.com/bentsherman/nf-boost
+  [s]: https://github.com/tek/splain
+  [c]: ../corpus/README.md#the-other-three-jvm-languages
+
 - **A constructor can carry a guardrail.** No annotation declared `ElementType.CONSTRUCTOR`, so a
   constructor could not be guarded at all. That was odd rather than obviously wrong: `ElementNaming`
   has always rendered constructors, because javac hands them to the collector as enclosed elements

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -106,7 +106,10 @@ so what consumers download is self-contained.
 - **GitHub Actions** are pinned to commit SHAs, not tags, with the human-readable version in a
   trailing comment. Dependabot proposes the bumps. Pinning is what the OSSF Scorecard
   Pinned-Dependencies check wants, and it is also the only form that cannot be moved under you.
-- **Gradle wrapper**, `gradle-9.7.0-bin.zip` in three subprojects. The checked-in
+- **Gradle wrapper**, `gradle-9.7.1-bin.zip` in ten `gradle-wrapper.properties` files: the two
+  published modules and the eight examples. This entry said "three subprojects" for several
+  releases while the count grew to ten, which is the kind of number worth counting rather than
+  remembering (`git ls-files '*gradle-wrapper.properties'`). The checked-in
   `gradle-wrapper.jar` files are validated against Gradle's published checksums by
   `.github/workflows/gradle-wrapper-validation.yml`, which must run on every push to main for
   Scorecard's Binary-Artifacts check to accept them.
@@ -119,13 +122,23 @@ so what consumers download is self-contained.
 build itself enforces:
 
 - The Gradle files cannot inherit from a Maven parent, so `vibetags/build.gradle`,
-  `vibetags-annotations/build.gradle` and `examples/basic/build.gradle` repeat the coordinates as literals.
+  `vibetags-annotations/build.gradle` and `examples/basic/build.gradle` **read** the parent's
+  properties rather than repeating them: `pomVersion('junit.version')` and the rest parse
+  `vibetags-parent/pom.xml` at configuration time.
 - The example poms are standalone on purpose, so a reader can lift one into their own project.
 
-`BuildVersionParityTest` fails the build when either copy drifts from the parent, when a managed pom
-grows a version literal, or when a Gradle module's PMD `toolVersion` disagrees. That last check
-exists because it had already happened: `vibetags-annotations` sat on PMD 7.24.0 while everything
-else was on 7.26.0, so the two modules were analysed by different rule sets.
+`BuildVersionParityTest` fails the build when a copy drifts from the parent, when a managed pom
+grows a version literal, and when a Gradle module applying PMD does not derive its `toolVersion`
+from `pmd.version`.
+
+That last check used to compare the literal against the parent instead, which reads the same and
+is weaker. It exists because the drift had already happened - `vibetags-annotations` sat on PMD
+7.24.0 while everything else was on 7.26.0, so two modules were analysed by different rule sets -
+but comparing the literal made every automated bump fail. Dependabot edits `vibetags-parent/pom.xml`
+and nothing else, because that is where the property lives, so each PMD bump arrived as a red PR
+needing a hand-fix before it could merge. Deriving the value removes the copy the check was
+policing; asserting the *mechanism* is what stops the check passing vacuously once there is no
+literal left to compare.
 
 To bump the VibeTags release version itself, use `scripts/set-version.sh <version>` and then run
 that test.

--- a/docs/JVM-LANGUAGES.md
+++ b/docs/JVM-LANGUAGES.md
@@ -1,0 +1,283 @@
+# JVM language support: maturity and limitations
+
+VibeTags is a JSR 269 annotation processor, so one question decides everything on this page:
+
+> Does the language's toolchain ever hand **javac** a declaration carrying the annotation?
+
+Nothing in VibeTags is language-specific. There is no Kotlin code path and no Groovy renderer. A
+language is supported to exactly the extent that its compiler produces something javac sees, and
+the differences below are differences between those toolchains, not between features anyone chose
+to build.
+
+This page states each rating and, more importantly, **how it is checked**. Every claim here was
+measured against a third-party repository on a pinned commit, by the `JVM-Language Corpus (Kotlin,
+Groovy, Scala)` job that runs on every pull request. Before that job existed, this page's contents
+were prose that nobody had run, and one of the claims was wrong for several releases.
+
+## The ratings
+
+| Rating | Means |
+|---|---|
+| **Supported** | Every level VibeTags addresses is rendered. Verified on code nobody wrote for VibeTags. |
+| **Supported, one level lost** | Most levels render; a named level does not, for a reason outside VibeTags' control. |
+| **Partial by construction** | Only part of the build ever reaches the processor. |
+| **Not possible** | No path even in principle. |
+
+| Language | Rating | What reaches the processor | Verified by |
+|---|---|---|---|
+| Java | **Supported** | javac runs the processor directly | `corpus/run-corpus.sh`, six libraries, 15,683 members |
+| Kotlin | **Supported, one level lost** (package) | kapt generates Java stubs and runs the processor over them | `kotlin-obd-api`, 15 of 15 guardrails rendered |
+| Groovy | **Supported, one level lost** (field) | groovyc stubs, but only with `javaAnnotationProcessing` on | `nf-boost`, 13 of 13 expected, 2 field guardrails absent |
+| Scala | **Partial by construction** | the Java sources of a mixed module; never `.scala` | `splain`, 17 from the Java half, 0 from the Scala half |
+| Clojure | **Not possible** | nothing | n/a |
+
+---
+
+## Java
+
+The reference implementation, and the only one with no caveat. Every level VibeTags addresses
+renders: package, type, nested type, field, constructor, method, parameter.
+
+Measured continuously over six libraries at pinned commits, roughly 495 files and 15,683 members,
+none of which were written with VibeTags in mind. See [corpus/README.md](../corpus/README.md).
+
+---
+
+## Kotlin
+
+**Rating: supported, one level lost.**
+
+Every `@AI*` annotation is a plain Java annotation with `SOURCE` retention, so it applies to Kotlin
+declarations unchanged. kapt generates a Java stub per Kotlin class and runs JSR 269 processors
+over the stubs.
+
+### What was measured
+
+15 of 15 guardrails the showcase declares reached the generated files, across **type, nested type,
+field, constructor, method and parameter**. `@AIPrivacy` on a Kotlin property renders as
+`vibetagscorpus.CorpusShowcase.billingEmail`, in the safety bucket, inline in the Tier-1 aggregate
+where it belongs. Claude, Gemini and Codex all produced output, and both granular rule directories
+were written.
+
+### What is lost, and why
+
+- **The package level.** Kotlin has no `package-info.kt`, so there is no compilation unit for a
+  package annotation to live on. Thirteen annotations accept `ElementType.PACKAGE` and none of them
+  can be used from Kotlin. There is no workaround; put the guardrail on the types instead.
+- **Method-body-scoped annotations.** Stubs carry no method bodies, so an annotation on a local
+  declaration inside a function is never seen. Class-level and function-level annotations, which is
+  the normal usage, work fully.
+- **Source positions describe the stub.** The `.vibetags-locks` report's line ranges would point
+  into the generated stub rather than the `.kt` file, so do not opt a pure-Kotlin module into the
+  locks report.
+
+### Use-site targets are load-bearing
+
+A Kotlin property is a getter, a setter and possibly a backing field. An annotation written bare on
+a property does not necessarily land where a Java author would expect, and getting it wrong does
+not fail the build: it moves the guardrail onto a different element, or drops it. Annotations
+declaring only `ElementType.FIELD` should be written with the `@field:` target:
+
+```kotlin
+@field:AIPrivacy(reason = "Billing email identifies a natural person; never log it")
+private var billingEmail: String? = null
+```
+
+### The strategic risk, stated plainly
+
+Kotlin support rests entirely on kapt, and **kapt is in maintenance mode**: JetBrains keeps it
+current with new Kotlin and Java releases but has no plans to add features, and recommends KSP for
+annotation processing ([kapt](https://kotlinlang.org/docs/kapt.html),
+[KSP overview](https://kotlinlang.org/docs/ksp-overview.html),
+[migration guide](https://kotlinlang.org/docs/ksp-kapt-migration.html)).
+
+KSP is not a route for VibeTags as it stands. KSP defines its own processor interface
+(`SymbolProcessor`) rather than implementing `javax.annotation.processing.Processor`, so a JSR 269
+processor is not loadable by it. A Kotlin project that has migrated fully to KSP cannot run
+VibeTags at all.
+
+This is the largest single exposure in the matrix. Kotlin support does not degrade gradually if
+kapt is ever withdrawn; it goes from "one level lost" to nothing, and the only in-principle fix is
+a separate KSP processor reading the same annotations. Nothing about that is imminent, and no
+deprecation has been announced. It is written down here because the alternative is finding out
+from a release note.
+
+---
+
+## Groovy
+
+**Rating: supported, one level lost.**
+
+groovyc emits a Java stub per Groovy class and javac runs the processors over the stubs, the same
+shape as kapt. The switch is off by default in Gradle, so a Groovy project that adds VibeTags and
+changes nothing else generates **nothing at all, silently**:
+
+```groovy
+tasks.withType(GroovyCompile).configureEach {
+    groovyOptions.javaAnnotationProcessing = true
+    options.annotationProcessorPath = configurations.annotationProcessor
+    options.compilerArgs << "-Avibetags.root=${projectDir.absolutePath}"
+}
+```
+
+### Field-level annotations are dropped
+
+This is the limitation worth reading twice, because it is silent and it affects a safety
+annotation.
+
+groovyc's stub carries the class, its constructors, its methods and their parameters, with every
+annotation intact, and **no fields whatsoever**. So `@AIPrivacy`, `@AISecureLogging`,
+`@AIPerformance` and every other `ElementType.FIELD` annotation on a Groovy field reaches no
+processor and generates nothing. There is no warning, because nothing in the compilation ever sees
+the annotation.
+
+`@AIPrivacy` is one of the six safety annotations that stay inline in the Tier-1 aggregate,
+precisely so they reach an agent that never opens the file. In Groovy, marking a PII field does
+nothing, and the build stays green.
+
+The obvious explanation is wrong, which is worth recording. A Groovy field with no access modifier
+becomes a property, so the natural theory is that the annotation moved onto a generated accessor.
+It did not. Keeping the stubs (`groovyOptions.keepStubs`) and reading one settles it:
+
+```java
+@AIContext(...) @AIPublicAPI() public class CorpusShowcase
+@AILocked(reason="...CONSTRUCTOR-LOCKED...") public CorpusShowcase
+@AILocked(reason="...METHOD-LOCKED...") public long invoiceNumber(long id) { return (long)0;}
+@AIContract(...) public String render(@AIInputSanitized(...) String customerNote, ...)
+```
+
+The three annotated fields appear nowhere in it. Declaring them `private` does not help: that only
+stops Groovy making them properties, and the stub omits them either way.
+
+**What to do instead:** put the guardrail on the accessor or on the enclosing type, or keep the
+rule in the hand-authored region outside the `VIBETAGS-START`/`END` markers.
+
+This is pinned rather than merely written down. The Groovy showcase in the corpus annotates fields
+on purpose, the harness expects those two guardrails to be missing, and it **fails if they ever
+start appearing** - at which point this section gets rewritten instead of quietly aging.
+
+### Most Groovy projects cannot switch stub processing on at all
+
+The levels above describe what happens once it works. Whether it works is a separate question, and
+for real Groovy code the answer is often no. Eight Groovy repositories were surveyed before one
+could be used as a corpus member:
+
+| Repository | Outcome once `javaAnnotationProcessing` is on |
+|---|---|
+| `jenkinsci/JenkinsPipelineUnit` | stub rejected: `'_' is a keyword, and may not be used as an identifier` |
+| `int128/gradle-ssh-plugin` | stub rejected: `illegal combination of modifiers: public and private` |
+| `longwa/build-test-data` | stub rejected: `method does not override or implement a method from a supertype` |
+| `jk1/Gradle-License-Report` | toolchain pinned to Java 17: `class file version 65.0` |
+| `allegro/axion-release-plugin` | toolchain pinned to Java 17: same |
+| `jwagenleitner/groovy-wslite` | wrapper too old: `Could not determine java version from '21.0.9'` |
+| `gpc/grails-postgresql-extensions` | compiles |
+| `bentsherman/nf-boost` | compiles |
+
+Three of the eight compile perfectly well on their own and break the moment stubs are generated,
+each on a different stub defect. That is a property of groovyc's stub generator, not of VibeTags,
+and a user hitting it sees a compile error in a file they did not write, under
+`build/tmp/compileGroovy/groovy-java-stubs`.
+
+**Try it on a branch before committing to it.** If the stubs compile, Groovy support is real; if
+they do not, no amount of VibeTags configuration will help.
+
+---
+
+## Scala
+
+**Rating: partial by construction.**
+
+scalac has no JSR 269 support of any kind. Java annotations are legal in Scala and compile without
+complaint, so an author can annotate a Scala class, see a green build, and get no guardrails at
+all. Only the Java sources of a mixed module reach the processor, compiled by javac as normal.
+
+### Both directions are measured
+
+Asserting the negative matters as much as the positive here, and the corpus does both in one build:
+
+- the **Java** half must generate everything: 17 of 17 guardrails, including the package level.
+- the **Scala** half is annotated at every level it can be, and every one of those markers must be
+  absent from every generated file.
+- the Scala showcase must have produced class files. Without that third check, "scalac generated
+  nothing" and "scalac was never asked" are the same green run.
+
+If the negative ever fails, either scalac has gained annotation processing or VibeTags has found
+another way in, and this section needs rewriting rather than the test relaxing.
+
+### What to do instead
+
+Put guardrails on thin annotated Java types next to the Scala they protect; javac compiles
+`src/main/java` normally in a mixed module. For rules that have no Java surface, the hand-authored
+region outside the `VIBETAGS-START`/`END` markers is the right home, and it survives regeneration.
+
+---
+
+## Clojure
+
+**Rating: not possible.** There is no javac in the pipeline, and Clojure's metadata annotations emit
+only `CLASS` or `RUNTIME` retention into bytecode. `SOURCE` retention cannot be expressed at all, so
+the annotations cannot even be written. Same fallback as Scala: annotated Java types, or
+hand-authored rules outside the markers.
+
+---
+
+## One trap that applies to every language
+
+**The compiling JDK must be 21 or newer, and a Gradle toolchain overrides the JDK you launched
+with.** This:
+
+```groovy
+java { toolchain { languageVersion = JavaLanguageVersion.of(17) } }
+```
+
+runs javac from a JDK 17, which cannot load the processor:
+
+```
+class file version 65.0, this version of the Java Runtime only recognizes class file versions up to 61.0
+```
+
+The message names neither VibeTags nor the toolchain, so it reads like a corrupt jar. Two of the
+Groovy projects above fail exactly this way. Gradle plugins and libraries pin older toolchains for
+consumer compatibility far more often than application code does, so it is worth checking first.
+
+---
+
+## How these ratings are kept honest
+
+Each row of the first table is a test, not a belief:
+
+| Job | What it runs |
+|---|---|
+| `Third-Party Corpus` | `corpus/run-corpus.sh` - six Java libraries, twice each, with and without VibeTags |
+| `JVM-Language Corpus (Kotlin, Groovy, Scala)` | `corpus/run-corpus-jvm.sh` - three repositories built twice by their own Gradle wrapper |
+
+Both compare a control build against a treatment build, so "it compiled" is never the assertion.
+Sixteen assertions cover the JVM-language leg, including the tier split, both granular directories
+and the parameter level. Two of them exist specifically to keep this page true:
+
+- **the expected set is derived from the showcase**, so a level that stops rendering fails rather
+  than being absorbed by a margin someone left in;
+- **the exclusions are checked in the other direction too**, so a limitation that quietly gets
+  fixed fails the build and forces this page to be corrected. A documentation error in the generous
+  direction is the one nobody ever notices, because the run is green and more guardrails arrived
+  than were asked for.
+
+Full detail, including the assertion table:
+[corpus/README.md](../corpus/README.md#the-other-three-jvm-languages).
+
+## What is not known
+
+Stated so that nobody mistakes silence for evidence:
+
+- **Kotlin is verified on one Kotlin version.** The corpus member is on Kotlin 2.3.10 and
+  `examples/kotlin` on 2.4.10. Nothing here sweeps a range of Kotlin releases.
+- **One kapt diagnostic is unattributed.** kapt reports `vibetags.root` as an unrecognised
+  processor option even though `AIGuardrailProcessor` declares it in `@SupportedOptions` and
+  demonstrably receives it. It appears on 2.3.10 and not on 2.4.10. Tracked as an open question,
+  not asserted to be harmless.
+- **Groovy is verified on one project.** `nf-boost` compiles its stubs; the survey above shows how
+  much that varies. There is no claim about Groovy versions or about Grails.
+- **Scala is verified on one Gradle-built project.** Gradle-built Scala is rare; sbt is far more
+  common and is not exercised anywhere. Nothing here says what happens under sbt, only that scalac
+  itself offers nothing to a processor, which is true regardless of build tool.
+- **Android is not covered at all.** No corpus member uses the Android Gradle plugin.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -186,6 +186,35 @@ annotations in its rendering and VibeTags deliberately does not, which moves out
 consumer using jspecify or the Checker Framework. [corpus/README.md](../corpus/README.md) has
 the reasoning and the full repo table.
 
+### Job: `corpus-jvm`
+
+The same question in Kotlin, Groovy and Scala. `corpus/run-corpus-jvm.sh` clones three
+permissively licensed repositories at pinned SHAs and builds each **twice with its own Gradle
+wrapper**, the only difference being `corpus/inject-vibetags.init.gradle` — an init script,
+because that is the supported way to add a plugin to a build you do not own, and it means nothing
+here edits a build file it did not write.
+
+It is a separate job from `corpus` because none of these languages reaches the processor the way
+Java does: Kotlin only through kapt, Groovy only when joint compilation's `javaAnnotationProcessing`
+is switched on, Scala not at all. `--rerun-tasks` is passed on every invocation, because otherwise
+Gradle's up-to-date checks let the treatment skip compilation entirely and the whole comparison
+becomes a green run that compiled nothing.
+
+The Scala member asserts a negative and its own anti-vacuity guard: annotated `.scala` must
+generate nothing, the Java half of the same build must generate everything, and the Scala showcase
+must have produced class files — otherwise "scalac generated nothing" and "scalac was never asked"
+are the same result.
+
+It found that **Groovy silently drops every field-level annotation**: groovyc's stubs carry types,
+constructors, methods and parameters and no fields, so `@AIPrivacy` on a Groovy field generates
+nothing at all. USAGE.md called that route "Full (joint compilation)" until this job ran.
+[corpus/README.md](../corpus/README.md#the-other-three-jvm-languages) has the stub evidence, the
+other findings, and the eight-repository survey behind the choice of Groovy member.
+
+Two caches: the checkouts on the manifest and harness hashes, and `~/.gradle` on the manifest,
+because six Gradle builds otherwise re-download a distribution each and that is most of the job's
+wall clock.
+
 ### Job: `ecj-degradation`
 
 The one leg that does not run javac. `scripts/ecj-degradation-check.sh` compiles

--- a/examples/basic/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/basic/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/examples/gradle-composite/app/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gradle-composite/app/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/examples/gradle-flat/app/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gradle-flat/app/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/examples/gradle-multimodule/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gradle-multimodule/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/examples/gradle-shared-buildfile/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gradle-shared-buildfile/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/examples/groovy/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/groovy/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/examples/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/examples/scala/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/scala/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/scripts/bump-dependencies.sh
+++ b/scripts/bump-dependencies.sh
@@ -53,6 +53,7 @@ nullaway.version                        com/uber/nullaway/nullaway
 cyclonedx-maven-plugin.version          org/cyclonedx/cyclonedx-maven-plugin
 central-publishing-maven-plugin.version org/sonatype/central/central-publishing-maven-plugin
 maven-gpg-plugin.version                org/apache/maven/plugins/maven-gpg-plugin
+ecj.version                             org/eclipse/jdt/ecj
 "
 
 prop() { sed -n "s:.*<$1>\(.*\)</$1>.*:\1:p" "$PARENT" | head -n1; }

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -88,9 +88,27 @@ jar {
     }
 }
 
+// The one shared version this module needs, read from the same place Maven reads it. Kept
+// deliberately smaller than vibetags/build.gradle's helper: this module has exactly one pin to
+// resolve, and a literal here is what turned every dependabot PMD bump into a red
+// BuildVersionParityTest.
+def pmdVersionFromParent = {
+    def pom = file("${projectDir}/../vibetags-parent/pom.xml")
+    if (!pom.exists()) {
+        throw new GradleException("vibetags-parent/pom.xml is missing, so there is nothing to read "
+            + 'pmd.version from. Shared versions live in the parent, never as a literal here.')
+    }
+    def m = (pom.text =~ /<pmd\.version>([^<]+)<\/pmd\.version>/)
+    if (!m) {
+        throw new GradleException('vibetags-parent/pom.xml <properties> does not define '
+            + '<pmd.version>. Add it there rather than hard-coding a number in build.gradle.')
+    }
+    m[0][1].trim()
+}()
+
 pmd {
     consoleOutput = true
-    toolVersion = "7.26.0"
+    toolVersion = pmdVersionFromParent
     ignoreFailures = false
     ruleSetFiles = files("${projectDir}/../pmd-ruleset.xml")
 }

--- a/vibetags-annotations/gradle/wrapper/gradle-wrapper.properties
+++ b/vibetags-annotations/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -96,7 +96,7 @@
              the documented claim that the processor degrades rather than fails under a compiler
              with no Tree API (docs/PROCESSOR.md, USAGE.md). scripts/ecj-degradation-check.sh
              reads this property so the version has one home, like every other pin here. -->
-        <ecj.version>3.44.0</ecj.version>
+        <ecj.version>3.46.0</ecj.version>
 
         <!-- Build plugins -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -189,7 +189,10 @@ jacocoTestReport {
 
 pmd {
     consoleOutput = true
-    toolVersion = "7.26.0"
+    // Derived, never a literal. A literal here is a mirror of pmd.version in the parent, and
+    // dependabot bumps the parent alone - so every PMD bump arrived as a red
+    // BuildVersionParityTest that a human had to hand-fix before the PR could merge.
+    toolVersion = pomVersion('pmd.version')
     ignoreFailures = false
     ruleSetFiles = files("${projectDir}/../pmd-ruleset.xml")
 }

--- a/vibetags/gradle/wrapper/gradle-wrapper.properties
+++ b/vibetags/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/BuildVersionParityTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/BuildVersionParityTest.java
@@ -62,6 +62,10 @@ class BuildVersionParityTest {
         "examples/kotlin/build.gradle.kts", "examples/groovy/build.gradle",
         "examples/scala/build.gradle");
 
+    private static final char EQUALS = '=';
+    private static final char SINGLE_QUOTE = '\'';
+    private static final char DOUBLE_QUOTE = '"';
+
     /** Directory names whose contents are build output or tool cache, never sources. */
     private static final Set<String> NON_SOURCE_DIRS =
         Set.of(".git", ".gradle", "build", "target", "node_modules");
@@ -158,27 +162,73 @@ class BuildVersionParityTest {
      * vibetags/build.gradle were on 7.26.0, which means the two modules were analysed by different
      * rule sets and a rule added between those releases ran on one module only.
      */
+    /**
+     * PMD's {@code toolVersion} must be <em>derived</em> from {@code pmd.version} in the parent,
+     * never copied.
+     *
+     * <p>This used to compare the literal against the parent, which is a weaker rule that reads
+     * the same. The difference shows up when dependabot bumps {@code pmd.version}: it edits the
+     * parent pom and nothing else, because that is where the property lives, and every Gradle
+     * file holding a copy of the old number then failed this test. Each PMD bump therefore
+     * arrived as a red PR that a human had to hand-fix before it could merge, which is not what
+     * an automated bump is for.
+     *
+     * <p>So the assertion is now about the mechanism rather than the value. A literal fails even
+     * if it happens to be correct today, and a file that never mentions {@code pmd.version} fails
+     * even if it has no literal - otherwise deleting the derivation would leave nothing to match
+     * and this test would pass on a file it no longer checks.
+     */
     @Test
-    void gradlePmdToolVersionsMatchTheParent() {
-        String expected = properties().get("pmd.version");
-        Pattern toolVersion = Pattern.compile("^\\s*toolVersion\\s*=\\s*['\"]([^'\"]+)['\"]",
-            Pattern.MULTILINE);
+    void gradlePmdToolVersionIsDerivedFromTheParentRatherThanCopied() {
         List<String> problems = new ArrayList<>();
+        int checked = 0;
 
         for (String file : gradleFiles()) {
-            Matcher m = toolVersion.matcher(read(repoRoot().resolve(file)));
-            while (m.find()) {
-                if (!expected.equals(m.group(1))) {
-                    problems.add(file + ": PMD toolVersion is " + m.group(1)
-                        + " but vibetags-parent declares pmd.version " + expected);
+            String text = read(repoRoot().resolve(file));
+            if (!text.contains("pmd {")) {
+                continue;
+            }
+            checked++;
+            for (String line : text.lines().toList()) {
+                String trimmed = line.trim();
+                int assignment = trimmed.indexOf(EQUALS);
+                if (!trimmed.startsWith("toolVersion") || assignment < 0) {
+                    continue;
+                }
+                if (isQuoted(trimmed.substring(assignment + 1).trim())) {
+                    problems.add(file + ": PMD toolVersion is a literal (" + trimmed
+                        + "). Read pmd.version from vibetags-parent instead, so that a bump"
+                        + " of the parent cannot leave this file behind.");
                 }
             }
+            if (!text.contains("pmd.version")) {
+                problems.add(file + ": applies the pmd plugin but never names pmd.version,"
+                    + " so nothing ties its analyser to the version the rest of the build"
+                    + " uses.");
+            }
         }
+
+        assertTrue(checked >= 2,
+            "Expected at least two Gradle modules applying PMD; found " + checked
+                + ". A walk that stops finding them passes this test while checking"
+                + " nothing.");
         assertTrue(problems.isEmpty(),
-            "A Gradle module analysed by a different PMD than the rest of the build:\n  "
-                + String.join("\n  ", problems));
+            "A Gradle module that a dependabot bump of pmd.version would leave behind: "
+                + String.join("; ", problems));
     }
 
+    /**
+     * Whether the right-hand side of a {@code toolVersion} assignment is a quoted number.
+     *
+     * <p>Only the start of the value is looked at, and that is the whole point: the first
+     * version of this asked whether the <em>line</em> contained a quote, which rejected
+     * {@code toolVersion = pomVersion('pmd.version')} - the very form it exists to require.
+     * A derived value may quote a property name; a copied one opens with the quote.
+     */
+    private static boolean isQuoted(String value) {
+        return !value.isEmpty()
+            && (value.charAt(0) == SINGLE_QUOTE || value.charAt(0) == DOUBLE_QUOTE);
+    }
     @Test
     void managedPomsDeclareNoVersionOfTheirOwn() {
         List<String> problems = new ArrayList<>();


### PR DESCRIPTION
## Why this exists

PRs #492 and #495 both show as **MERGED**, and neither reached `main`. They were a three-deep
stack merged bottom-first:

| Time (2026-08-25) | Event |
|---|---|
| 16:13:34Z | #491 `fix/issues-487-490` → **main** (squash) |
| 17:57:31Z | #492 `test/corpus-jvm-languages` → `fix/issues-487-490` — base already squashed, 1h44m dead |
| 18:18:09Z | #495 `docs/jvm-language-support` → `test/corpus-jvm-languages` — also dead |

The bottom of the stack landed. The two above it merged into a branch that `main` had already
absorbed and moved past, so their content went nowhere. Nothing reports this: both PRs are green
and closed as merged, which is exactly why it survived a week of nobody noticing.

This PR re-lands that work on current `main` by cherry-picking the two squash commits (`fb168a9`,
`7e45297`). Both applied without conflict.

## What comes back

31 files, 1841 insertions:

- `corpus/run-corpus-jvm.sh` — runs VibeTags over real Kotlin, Groovy and Scala projects, each
  built by its own Gradle, alongside the existing Java/javac corpus
- `corpus/repos-jvm.tsv`, `corpus/inject-vibetags.init.gradle`, and the three
  `corpus/showcase/CorpusShowcase.{kt,groovy,scala}.tmpl` fixtures
- `docs/JVM-LANGUAGES.md` — what Kotlin, Groovy, Scala and Clojure actually get, what is silently
  lost, and how each rating was measured rather than claimed
- The `build.yml` job that runs the JVM corpus on every PR
- The corrected Groovy claim, and the dependabot `pmd.version` fix that stops a bump turning the
  build red

## Verified

- Cherry-picks clean; `corpus/run-corpus-jvm.sh` kept mode `100755`, so CI will not hit the
  exit-126 trap that a dropped exec bit causes on this platform.
- The auto-merges in `CLAUDE.md` and `docs/CHANGELOG.md` were checked rather than trusted: #497's
  `.aiexclude` fix, its locked-files-guard fix and its `@AILocked` on `GuardrailAnnotations.ALL`
  are all still present, and `CLAUDE.md` carries both the regenerated guardrail block and the
  restored `run-corpus-jvm.sh` line. The `[Unreleased]` CHANGELOG section merged into coherent
  Added / Changed / Fixed sections with every entry from all three PRs.
- `mvn test -Pe2e`: **2415 passed, 0 failed, 0 skipped**.
- Locked-files guard against `main`: no locked code touched. 16 guard unit tests pass.
- gitleaks, end-of-file-fixer, trailing-whitespace pass.
- Diff against `main` is 31 files / 1841 insertions, matching the stranded work exactly.

## Note

This is a prerequisite for cutting 1.2.6: without it that release would ship without the JVM
corpus CI and `docs/JVM-LANGUAGES.md`, and `main`'s `CLAUDE.md` would keep pointing at a
`corpus/run-corpus-jvm.sh` that does not exist there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUjemLTYEwQHhjmztrrapT
