### PR TITLE
chore: prepare release v1.2.6

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.2.5
+version: 1.2.6
 ---
 
 # VibeTags Usage Guide
@@ -27,7 +27,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
     <dependency>
         <groupId>se.deversity.vibetags</groupId>
         <artifactId>vibetags-annotations</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6</version>
     </dependency>
 </dependencies>
 
@@ -41,7 +41,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.5</version>
+                        <version>1.2.6</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -63,8 +63,8 @@ the whole processor and its SLF4J/Logback dependencies on your compile classpath
 
 ```groovy
 dependencies {
-    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.2.5'
-    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.5'
+    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.2.6'
+    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.6'
 }
 ```
 
@@ -221,7 +221,7 @@ though the build is green.
 Every way this setup fails is silent, so check rather than assume:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.5 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.2.6 doctor
 ```
 
 Or by hand, in the order things go wrong:
@@ -1287,7 +1287,7 @@ Use on: **class, method, field**
 @AIKeepInSync(mirrors = {"pom.xml:<version>", "README.md badge", "docs/CHANGELOG.md"},
               reason = "The release version is asserted in three places and drifts silently",
               enforcedBy = "ProjectFactsConsistencyTest")
-public static final String VERSION = "1.2.5";
+public static final String VERSION = "1.2.6";
 ```
 
 The element is free to change — the failure mode is a *partial* change that desyncs a mirror no compiler checks. `@AIContract` freezes one signature so it cannot change at all; neither it nor `@AISchemaSafe` expresses "edit A ⇒ you must also edit B". Mirrors routinely point outside the compilation unit, so VibeTags can only *name* them, not verify them.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.2.5</version>
+            <version>1.2.6</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.5</version>
+                        <version>1.2.6</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -94,7 +94,7 @@ touch CLAUDE.md .cursorrules AGENTS.md   # Claude, Cursor, Codex CLI — add whi
 Or let the companion CLI do it (and `vibetags doctor` checks your setup afterwards):
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.5 init --platforms claude,cursor
+jbang se.deversity.vibetags:vibetags-cli:1.2.6 init --platforms claude,cursor
 ```
 
 **3. Annotate your first class:**
@@ -123,8 +123,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -170,8 +170,8 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.5"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.5"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.6"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.6"))
 
     compileOnly("se.deversity.vibetags:vibetags-annotations")
     kapt("se.deversity.vibetags:vibetags-processor")
@@ -499,8 +499,8 @@ build-tool wiring, active platforms, and `VIBETAGS-START`/`END` marker integrity
 installing anything:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.5 init --list
-jbang se.deversity.vibetags:vibetags-cli:1.2.5 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.2.6 init --list
+jbang se.deversity.vibetags:vibetags-cli:1.2.6 doctor
 ```
 
 The platform list and marker rules are read from `vibetags-processor` at runtime, so the CLI
@@ -529,7 +529,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.2.5</version>
+            <version>1.2.6</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -554,7 +554,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.5</version>
+                        <version>1.2.6</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -570,8 +570,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -585,15 +585,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.5'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.5'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.6'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.6'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.6] - 2026-08-25
+
 ### Added
 
 - **[docs/JVM-LANGUAGES.md](JVM-LANGUAGES.md): what Kotlin, Groovy and Scala actually get.** The
@@ -3393,7 +3395,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.2.5...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.2.6...HEAD
+[1.2.6]: https://github.com/PIsberg/vibetags/compare/v1.2.5...v1.2.6
 [1.2.5]: https://github.com/PIsberg/vibetags/compare/v1.2.4...v1.2.5
 [1.2.4]: https://github.com/PIsberg/vibetags/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/PIsberg/vibetags/compare/v1.2.2...v1.2.3

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -84,6 +84,96 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reasoning, so a later sweep that "completes" the set has to argue with it. Found by the
   third-party corpus, whose showcase failed to compile. (#488)
 
+
+- **A corpus of real third-party Java, compiled with and without VibeTags on every CI run.**
+  Every fixture in this repository was written by somebody who knew what VibeTags does, and that
+  is the wrong sample: the code VibeTags has to survive was written by people who had never heard
+  of it. `corpus/` pins six permissively licensed libraries to commit SHAs and compiles each one
+  twice with identical sources, classpath and flags, differing only in whether VibeTags is on the
+  processor path.
+
+  Four assertions, each against the control rather than against a hard-coded expectation, so a
+  repo that does not compile on its own is reported as such instead of blamed on VibeTags: the
+  treatment exits exactly as the control did, raises no diagnostic the control did not, writes
+  nothing into a project that never opted in, and renders every member the way javac does.
+
+  Then a second phase, because non-interference is only half the question. **Claude, Gemini and
+  Codex are all opted in, aggregate and granular**, and the output is read back. Two real elements
+  of the repo's own code are annotated, plus a showcase compiled into a package of its own that
+  carries a guardrail at every level one can attach to: package, type, nested type, field, method
+  and parameter, across both the safety tier and the granular tier.
+
+  Codex needs its marker pair seeded, because invariant 4 means an empty `AGENTS.md` alongside
+  other platforms is dropped from the active set rather than written. The corpus asserts
+  `AGENTS.md` grew beyond that pair, since "dropped" and "working" look identical otherwise.
+
+  Ten assertions cover the result, and the two worth naming are the ones that keep the rest from
+  rotting. **The tier split** is invariant 6 checked on somebody else's code: `@AIPrivacy` must
+  still be inline in the aggregate, `@AIContract` must not be, and must instead be in the rules
+  directory. Wrong in one direction and safety guardrails become comments that load only once the
+  agent already opened the file; wrong in the other and the aggregate bloats. **The richness
+  floor** requires at least 15 distinct showcase guardrails to reach a generated file, because
+  every other assertion names one guardrail and would still pass if half the annotation surface
+  quietly stopped rendering. 15 is measured from a green run, not chosen.
+
+  Full detail, including the three defects the corpus found and why none of its assertions could
+  have found the others, is in [corpus/README.md](../corpus/README.md).
+
+  Measured on the first green run: 6 repositories, roughly 495 files, **15,683 members audited**,
+  no exit code changed, no diagnostic added, no file written. The corpus contributes what the
+  fixtures cannot: 15 `package-info` files and 279 generic sources from commons-io, varargs
+  density from jimfs, records from record-builder, Java 17 from semver4j, and an annotation
+  library whose own processor runs alongside VibeTags.
+
+  Nothing is vendored: sources are cloned at build time into `target/corpus` and never committed,
+  so no third-party code enters this repository. Pins are commit SHAs rather than branches, so an
+  upstream push cannot turn this repository's CI red for a reason nobody here changed, and bumping
+  them stays a decision somebody makes.
+
+  What it has been worth so far, stated as findings rather than as a claim: **three defects, each
+  caught by a different assertion, none of which could have found the others.** Type-use
+  annotations reaching an element identity for declared types, caught on the first run by the
+  parity check. The same annotations surviving on a *type variable*, invisible to that check
+  because javac renders it identically, and caught only by generating output and reading it back.
+  And the corpus itself running against an unresolved classpath on a cold CI runner, where both
+  the control and the treatment failed identically so every comparison passed while checking
+  nothing. The third one was a defect in the harness, and it is the reason there is now an
+  assertion that a corpus member must compile before anything is concluded from it.
+
+  A fourth thing it settled was not a defect but a gap: no annotation declared
+  `ElementType.CONSTRUCTOR`, found by trying to annotate one. That is fixed above (#488). (#480)
+
+  The corpus now also opts in **every** platform the registry knows about, on one repository, and
+  reads the result back with a real parser: 48 of 62 files written, and all ten of the YAML, TOML
+  and JSON files parsed. That is the question the fixture tests cannot ask. They assert what a
+  renderer *contains*; none asserts that a parser accepts it, and a renderer emitting an unquoted
+  `@` or a trailing comma satisfies every `contains` assertion while being unloadable by the tool
+  it targets. Verified by corrupting two files and watching the check name them. (#489)
+
+- **CI compiles a fixture under a real ECJ and checks the degradation the docs promise.**
+  `docs/PROCESSOR.md` and `USAGE.md` both state that VibeTags degrades rather than fails under a
+  compiler with no Tree API, losing `@AILocked` line positions and nothing else. Nothing verified
+  either sentence, and the code behind it is unreachable from a JUnit test running under javac.
+  Reaching it from one would mean adding a seam to production code purely so a test could fail it.
+
+  `scripts/ecj-degradation-check.sh` compiles `examples/basic` twice, once with javac and once
+  with the Eclipse Compiler for Java, and asserts four things: ECJ exits 0, both compilers report
+  the same locked elements, every javac entry carries a position and no ECJ entry does, and the
+  generated guardrail region is byte-identical. Measured: 9 locked entries under each compiler, 9
+  positioned under javac and 0 under ECJ, 147 lines of region identical. The javac half is the
+  control, without which the ECJ assertion would pass equally well on an empty report. The ECJ
+  version is pinned in `vibetags-parent/pom.xml` with every other third-party version. (#475)
+
+- **The instruction evals pin the Node and npm that install the claude CLI.** The lockfile pinned
+  the CLI by integrity hash; nothing pinned the toolchain performing that install, so the job took
+  whatever `ubuntu-latest` shipped that week. npm's version is behaviour rather than plumbing:
+  npm 11.17 added an allow-scripts gate that can defer a package's postinstall, and this package's
+  postinstall is what replaces its 500-byte placeholder with the native binary. Node 22 LTS bundles
+  npm 10.9.x, which predates that gate. `EvalsNodePinTest` compares the pinned version against the
+  CLI's own `engines.node` in the lockfile and fails in the fast test tier, so a CLI bump that
+  raises the floor goes red in seconds rather than partway into an eval run that costs money to
+  reach. (#472)
+
 ### Changed
 
 - **A dependabot bump of `pmd.version` no longer turns the build red.** Every third-party version
@@ -118,6 +208,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The mirror tables in `docs/DEPENDENCIES.md` and the `bump-dependencies` skill were both wrong
   about the wrapper: they said three subprojects and six files respectively, against ten actual
   files. Both now say to enumerate rather than remember.
+
+
+- **The release process gates on the consumer sweep.** `scripts/consumer-sweep.sh` builds every
+  downstream consumer against a chosen version and reports which pass. It ran in no workflow and
+  at no step, so it ran when somebody remembered.
+
+  That matters because VibeTags writes files consumers commit, and nothing in this repository's own
+  CI can see them move: the fixtures and the third-party corpus are both projects with no committed
+  VibeTags output of their own. The element-identity change above is the worked example. It moves
+  committed files for any project using jspecify or the Checker Framework, and two independent
+  things stopped anyone noticing: this repository uses jspecify in 47 files but never on a parameter
+  of an annotated method, which is the only place a parameter type reaches an element path; and the
+  consumers are pinned to the previous release, so they had never run it.
+
+  The sweep is now a required step in the release skill, before the release PR is opened, so its
+  result can reach the CHANGELOG and the release notes. What it looks for is drift in already
+  committed generated files rather than whether the build passes, and the skill says what to do with
+  each outcome, including that a consumer which could not be swept is reported as not run rather
+  than as passing. `ReleaseConsumerSweepGateTest` fails if the step is dropped, if it moves after the
+  PR is opened, or if the honest-reporting clause goes: a checklist step is prose, and prose gets
+  tidied. (#490)
+
+- **The coverage gate is a ratchet rather than a floor.** `codecov.yml` moves from
+  `target: 90%, threshold: 2%` to `target: auto, threshold: 1%`, so the question it asks is "did
+  this pull request lose coverage" rather than "is coverage above a number somebody typed once".
+  The fixed floor had become slack. A 90% target with a 2% threshold only fails below 88%, and
+  measured coverage has been above 92% since #476, so a change could shed four points and still
+  pass green.
+
+  `docs/TESTS.md` gains a "Coverage and the fault paths" section recording what the gate does not
+  reach and why: 97.07% of lines and 90.58% of branches are covered, and the remainder concentrates
+  in six classes whose uncovered lines need a fault a test cannot cause, such as a filesystem that
+  fails one specific write or an executor task interrupted mid-flight. Reaching them means adding
+  seams to production code, which was considered and rejected. `CoverageGateTest` fails if the
+  ratchet is swapped back for a fixed floor, or if a class named in that table stops existing.
+  (#482)
 
 ### Fixed
 
@@ -245,134 +371,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   third-party code and reading it back exposed it. Type variables now resolve through
   `asElement()` like every other type, and anything left with no structural route has its
   annotations stripped rather than trusted. (#480)
-
-### Added
-
-- **A corpus of real third-party Java, compiled with and without VibeTags on every CI run.**
-  Every fixture in this repository was written by somebody who knew what VibeTags does, and that
-  is the wrong sample: the code VibeTags has to survive was written by people who had never heard
-  of it. `corpus/` pins six permissively licensed libraries to commit SHAs and compiles each one
-  twice with identical sources, classpath and flags, differing only in whether VibeTags is on the
-  processor path.
-
-  Four assertions, each against the control rather than against a hard-coded expectation, so a
-  repo that does not compile on its own is reported as such instead of blamed on VibeTags: the
-  treatment exits exactly as the control did, raises no diagnostic the control did not, writes
-  nothing into a project that never opted in, and renders every member the way javac does.
-
-  Then a second phase, because non-interference is only half the question. **Claude, Gemini and
-  Codex are all opted in, aggregate and granular**, and the output is read back. Two real elements
-  of the repo's own code are annotated, plus a showcase compiled into a package of its own that
-  carries a guardrail at every level one can attach to: package, type, nested type, field, method
-  and parameter, across both the safety tier and the granular tier.
-
-  Codex needs its marker pair seeded, because invariant 4 means an empty `AGENTS.md` alongside
-  other platforms is dropped from the active set rather than written. The corpus asserts
-  `AGENTS.md` grew beyond that pair, since "dropped" and "working" look identical otherwise.
-
-  Ten assertions cover the result, and the two worth naming are the ones that keep the rest from
-  rotting. **The tier split** is invariant 6 checked on somebody else's code: `@AIPrivacy` must
-  still be inline in the aggregate, `@AIContract` must not be, and must instead be in the rules
-  directory. Wrong in one direction and safety guardrails become comments that load only once the
-  agent already opened the file; wrong in the other and the aggregate bloats. **The richness
-  floor** requires at least 15 distinct showcase guardrails to reach a generated file, because
-  every other assertion names one guardrail and would still pass if half the annotation surface
-  quietly stopped rendering. 15 is measured from a green run, not chosen.
-
-  Full detail, including the three defects the corpus found and why none of its assertions could
-  have found the others, is in [corpus/README.md](../corpus/README.md).
-
-  Measured on the first green run: 6 repositories, roughly 495 files, **15,683 members audited**,
-  no exit code changed, no diagnostic added, no file written. The corpus contributes what the
-  fixtures cannot: 15 `package-info` files and 279 generic sources from commons-io, varargs
-  density from jimfs, records from record-builder, Java 17 from semver4j, and an annotation
-  library whose own processor runs alongside VibeTags.
-
-  Nothing is vendored: sources are cloned at build time into `target/corpus` and never committed,
-  so no third-party code enters this repository. Pins are commit SHAs rather than branches, so an
-  upstream push cannot turn this repository's CI red for a reason nobody here changed, and bumping
-  them stays a decision somebody makes.
-
-  What it has been worth so far, stated as findings rather than as a claim: **three defects, each
-  caught by a different assertion, none of which could have found the others.** Type-use
-  annotations reaching an element identity for declared types, caught on the first run by the
-  parity check. The same annotations surviving on a *type variable*, invisible to that check
-  because javac renders it identically, and caught only by generating output and reading it back.
-  And the corpus itself running against an unresolved classpath on a cold CI runner, where both
-  the control and the treatment failed identically so every comparison passed while checking
-  nothing. The third one was a defect in the harness, and it is the reason there is now an
-  assertion that a corpus member must compile before anything is concluded from it.
-
-  A fourth thing it settled was not a defect but a gap: no annotation declared
-  `ElementType.CONSTRUCTOR`, found by trying to annotate one. That is fixed above (#488). (#480)
-
-  The corpus now also opts in **every** platform the registry knows about, on one repository, and
-  reads the result back with a real parser: 48 of 62 files written, and all ten of the YAML, TOML
-  and JSON files parsed. That is the question the fixture tests cannot ask. They assert what a
-  renderer *contains*; none asserts that a parser accepts it, and a renderer emitting an unquoted
-  `@` or a trailing comma satisfies every `contains` assertion while being unloadable by the tool
-  it targets. Verified by corrupting two files and watching the check name them. (#489)
-
-- **CI compiles a fixture under a real ECJ and checks the degradation the docs promise.**
-  `docs/PROCESSOR.md` and `USAGE.md` both state that VibeTags degrades rather than fails under a
-  compiler with no Tree API, losing `@AILocked` line positions and nothing else. Nothing verified
-  either sentence, and the code behind it is unreachable from a JUnit test running under javac.
-  Reaching it from one would mean adding a seam to production code purely so a test could fail it.
-
-  `scripts/ecj-degradation-check.sh` compiles `examples/basic` twice, once with javac and once
-  with the Eclipse Compiler for Java, and asserts four things: ECJ exits 0, both compilers report
-  the same locked elements, every javac entry carries a position and no ECJ entry does, and the
-  generated guardrail region is byte-identical. Measured: 9 locked entries under each compiler, 9
-  positioned under javac and 0 under ECJ, 147 lines of region identical. The javac half is the
-  control, without which the ECJ assertion would pass equally well on an empty report. The ECJ
-  version is pinned in `vibetags-parent/pom.xml` with every other third-party version. (#475)
-
-- **The instruction evals pin the Node and npm that install the claude CLI.** The lockfile pinned
-  the CLI by integrity hash; nothing pinned the toolchain performing that install, so the job took
-  whatever `ubuntu-latest` shipped that week. npm's version is behaviour rather than plumbing:
-  npm 11.17 added an allow-scripts gate that can defer a package's postinstall, and this package's
-  postinstall is what replaces its 500-byte placeholder with the native binary. Node 22 LTS bundles
-  npm 10.9.x, which predates that gate. `EvalsNodePinTest` compares the pinned version against the
-  CLI's own `engines.node` in the lockfile and fails in the fast test tier, so a CLI bump that
-  raises the floor goes red in seconds rather than partway into an eval run that costs money to
-  reach. (#472)
-
-### Changed
-
-- **The release process gates on the consumer sweep.** `scripts/consumer-sweep.sh` builds every
-  downstream consumer against a chosen version and reports which pass. It ran in no workflow and
-  at no step, so it ran when somebody remembered.
-
-  That matters because VibeTags writes files consumers commit, and nothing in this repository's own
-  CI can see them move: the fixtures and the third-party corpus are both projects with no committed
-  VibeTags output of their own. The element-identity change above is the worked example. It moves
-  committed files for any project using jspecify or the Checker Framework, and two independent
-  things stopped anyone noticing: this repository uses jspecify in 47 files but never on a parameter
-  of an annotated method, which is the only place a parameter type reaches an element path; and the
-  consumers are pinned to the previous release, so they had never run it.
-
-  The sweep is now a required step in the release skill, before the release PR is opened, so its
-  result can reach the CHANGELOG and the release notes. What it looks for is drift in already
-  committed generated files rather than whether the build passes, and the skill says what to do with
-  each outcome, including that a consumer which could not be swept is reported as not run rather
-  than as passing. `ReleaseConsumerSweepGateTest` fails if the step is dropped, if it moves after the
-  PR is opened, or if the honest-reporting clause goes: a checklist step is prose, and prose gets
-  tidied. (#490)
-
-- **The coverage gate is a ratchet rather than a floor.** `codecov.yml` moves from
-  `target: 90%, threshold: 2%` to `target: auto, threshold: 1%`, so the question it asks is "did
-  this pull request lose coverage" rather than "is coverage above a number somebody typed once".
-  The fixed floor had become slack. A 90% target with a 2% threshold only fails below 88%, and
-  measured coverage has been above 92% since #476, so a change could shed four points and still
-  pass green.
-
-  `docs/TESTS.md` gains a "Coverage and the fault paths" section recording what the gate does not
-  reach and why: 97.07% of lines and 90.58% of branches are covered, and the remainder concentrates
-  in six classes whose uncovered lines need a fault a test cannot cause, such as a filesystem that
-  fails one specific write or an executor task interrupted mid-flight. Reaching them means adding
-  seams to production code, which was considered and rejected. `CoverageGateTest` fails if the
-  ratchet is swapped back for a fixed floor, or if a class named in that table stops existing.
-  (#482)
 
 ### Tests
 

--- a/examples/all-tiers/pom.xml
+++ b/examples/all-tiers/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.2.5</vibetags.bom.version>
+    <vibetags.bom.version>1.2.6</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/basic/build.gradle
+++ b/examples/basic/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/examples/basic/pom.xml
+++ b/examples/basic/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.2.5</vibetags.bom.version>
+        <vibetags.bom.version>1.2.6</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/examples/gradle-composite/app/build.gradle
+++ b/examples/gradle-composite/app/build.gradle
@@ -16,8 +16,8 @@ repositories {
 
 dependencies {
     implementation 'se.deversity.vibetags.example:vibetags-example-gradle-composite-lib'
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-composite/lib/build.gradle
+++ b/examples/gradle-composite/lib/build.gradle
@@ -15,8 +15,8 @@ repositories {
 }
 
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-flat/app/build.gradle
+++ b/examples/gradle-flat/app/build.gradle
@@ -21,8 +21,8 @@ allprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-multimodule/build.gradle
+++ b/examples/gradle-multimodule/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-shared-buildfile/build.gradle
+++ b/examples/gradle-shared-buildfile/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.apache.groovy:groovy:5.1.0'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
 
     // Annotations on compile, processor on the annotation-processor path only.
     compileOnly 'se.deversity.vibetags:vibetags-annotations'

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and kapt configurations so neither needs an explicit version.
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.5"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.5"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.6"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.6"))
 
     // Annotations on compile, processor on the kapt path only — keeps the processor's
     // slf4j/logback off the consumer's compile classpath. compileOnly is enough:

--- a/examples/multimodule-indexed/pom.xml
+++ b/examples/multimodule-indexed/pom.xml
@@ -37,7 +37,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.2.5</vibetags.bom.version>
+    <vibetags.bom.version>1.2.6</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/examples/multimodule/pom.xml
+++ b/examples/multimodule/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.2.5</vibetags.bom.version>
+    <vibetags.bom.version>1.2.6</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/scala/build.gradle
+++ b/examples/scala/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.scala-lang:scala-library:2.13.18'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.2.5</vibetags.bom.version>
+        <vibetags.bom.version>1.2.6</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.2.5'
+version = '1.2.6'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.2.5'
+            version = '1.2.6'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -39,12 +39,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.2.5&lt;/version&gt;
+                &lt;version&gt;1.2.6&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.5'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.5'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.6'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.6'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -36,7 +36,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.2.5&lt;/version&gt;
+                        &lt;version&gt;1.2.6&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.2.5')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.5')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-cli/pom.xml
+++ b/vibetags-cli/pom.xml
@@ -28,7 +28,7 @@
         reports the project's VibeTags health — build-tool wiring, active platforms,
         marker integrity. Run it without installing anything:
 
-            jbang se.deversity.vibetags:vibetags-cli:1.2.5 init --list
+            jbang se.deversity.vibetags:vibetags-cli:1.2.6 init --list
 
         The platform list and marker rules are read from vibetags-processor, so this
         tool cannot drift from what the processor actually does.

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.2.5</revision>
+        <revision>1.2.6</revision>
 
         <!-- release, not source/target: on a JDK newer than 21 (CI builds 21, 25 and 26)
              source/target compiles against the *running* JDK's API and javac warns that the

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -35,7 +35,7 @@ def pomVersion = { String property ->
 }
 
 group = 'se.deversity.vibetags'
-version = '1.2.5'
+version = '1.2.6'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -49,7 +49,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.2.5'
+            version = '1.2.6'
             from components.java
 
             pom {
@@ -107,7 +107,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.2.5'
+    api 'se.deversity.vibetags:vibetags-annotations:1.2.6'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation "org.jspecify:jspecify:${pomVersion('jspecify.version')}"


### PR DESCRIPTION
Bumps `1.2.5` → `1.2.6` via `scripts/set-version.sh` and cuts the `[Unreleased]` CHANGELOG
section. 19 entries across Added / Changed / Fixed / Tests.

## Highlights

- **`docs/JVM-LANGUAGES.md`** — what Kotlin, Groovy, Scala and Clojure actually get, what is
  silently lost, and how each rating was measured rather than claimed.
- **A JVM-language corpus in CI** — VibeTags now runs over real Kotlin, Groovy and Scala projects,
  each built by its own Gradle, on every PR.
- **A constructor can carry a guardrail** — 34 of the 44 annotations accept `ElementType.CONSTRUCTOR`
  now. The two exclusions are argued for in `ConstructorLevelGuardrailTest` rather than left implicit.
- **`.aiexclude` no longer excludes a file because a member shares its name** — `@AILocked` on a
  method or field emitted `**/<simpleName>.java`, which is dead weight when it matches nothing and a
  silent over-exclusion when it matches something. Only a type contributes a glob now.
- **The locked-files guard no longer fails the PR that introduces a lock** — adding `@AILocked` to
  existing code is itself a change to the lines the lock covers, so the guard blocked exactly the
  adoption this project recommends.
- **Six load-bearing guardrails dogfooded into the processor's own core**, one per Tier-1 invariant
  that had no inline guardrail.

## Verification

- `BuildVersionParityTest` passes: no Gradle file, example pom or managed pom disagrees with
  `<revision>`.
- Residue sweep for `1.2.5` leaves only the CHANGELOG's own 1.2.5 entry. The two
  `.flattened-pom.xml` hits are gitignored build artifacts.
- Build chain in order at 1.2.6 — `vibetags-annotations`, `vibetags`, `vibetags-bom`,
  `vibetags-cli`, then `examples/basic`, `examples/multimodule`, `examples/multimodule-indexed`.
  All seven pass; the `vibetags` install runs the whole suite plus checkstyle, Error Prone, PMD,
  CPD and spotbugs.
- **Zero guardrail drift.** Every changed file is a version bump or the CHANGELOG. The processor
  version feeds `BuildFingerprint`, so this release invalidates every consumer's fingerprint and
  reruns the whole generate phase — the examples still regenerate byte-for-byte.
- CHANGELOG section consolidation verified by invariant: every non-heading line in the 1.2.6 block
  is byte-identical before and after.
- Hooks: gitleaks, end-of-file-fixer and trailing-whitespace pass. `checkstyle` was **skipped** —
  its hook needs a Docker daemon that is not running here. It is bound to Maven's `validate` phase,
  so the build above ran it over the whole project.

## Consumer sweep

Result reported in a comment below once it completes, per repository and honestly — a skipped
consumer is recorded as not run, not as passing.

Prior evidence on the one behaviour change that touches committed consumer output: across all five
consumers there are 9 `@AILocked` uses, 5 type-level (globs unchanged) and 4 member-level (globs
dropped — two `serialVersionUID` fields in blindbean, two methods in codekarta). Every dropped glob
matched no file, so no correct consumer data depended on the old behaviour. That is what makes this
a patch rather than a compatibility break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUjemLTYEwQHhjmztrrapT
