### PR TITLE
chore: prepare release v1.2.7

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.2.6
+version: 1.2.7
 ---
 
 # VibeTags Usage Guide
@@ -27,7 +27,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
     <dependency>
         <groupId>se.deversity.vibetags</groupId>
         <artifactId>vibetags-annotations</artifactId>
-        <version>1.2.6</version>
+        <version>1.2.7</version>
     </dependency>
 </dependencies>
 
@@ -41,7 +41,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.6</version>
+                        <version>1.2.7</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -63,8 +63,8 @@ the whole processor and its SLF4J/Logback dependencies on your compile classpath
 
 ```groovy
 dependencies {
-    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.2.6'
-    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.6'
+    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.2.7'
+    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.7'
 }
 ```
 
@@ -221,7 +221,7 @@ though the build is green.
 Every way this setup fails is silent, so check rather than assume:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.6 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.2.7 doctor
 ```
 
 Or by hand, in the order things go wrong:
@@ -1287,7 +1287,7 @@ Use on: **class, method, field**
 @AIKeepInSync(mirrors = {"pom.xml:<version>", "README.md badge", "docs/CHANGELOG.md"},
               reason = "The release version is asserted in three places and drifts silently",
               enforcedBy = "ProjectFactsConsistencyTest")
-public static final String VERSION = "1.2.6";
+public static final String VERSION = "1.2.7";
 ```
 
 The element is free to change — the failure mode is a *partial* change that desyncs a mirror no compiler checks. `@AIContract` freezes one signature so it cannot change at all; neither it nor `@AISchemaSafe` expresses "edit A ⇒ you must also edit B". Mirrors routinely point outside the compilation unit, so VibeTags can only *name* them, not verify them.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.2.6</version>
+            <version>1.2.7</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.6</version>
+                        <version>1.2.7</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -94,7 +94,7 @@ touch CLAUDE.md .cursorrules AGENTS.md   # Claude, Cursor, Codex CLI — add whi
 Or let the companion CLI do it (and `vibetags doctor` checks your setup afterwards):
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.6 init --platforms claude,cursor
+jbang se.deversity.vibetags:vibetags-cli:1.2.7 init --platforms claude,cursor
 ```
 
 **3. Annotate your first class:**
@@ -123,8 +123,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -170,8 +170,8 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.6"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.6"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.7"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.7"))
 
     compileOnly("se.deversity.vibetags:vibetags-annotations")
     kapt("se.deversity.vibetags:vibetags-processor")
@@ -502,8 +502,8 @@ build-tool wiring, active platforms, and `VIBETAGS-START`/`END` marker integrity
 installing anything:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.6 init --list
-jbang se.deversity.vibetags:vibetags-cli:1.2.6 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.2.7 init --list
+jbang se.deversity.vibetags:vibetags-cli:1.2.7 doctor
 ```
 
 The platform list and marker rules are read from `vibetags-processor` at runtime, so the CLI
@@ -532,7 +532,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.2.6</version>
+            <version>1.2.7</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -557,7 +557,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.6</version>
+                        <version>1.2.7</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -573,8 +573,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -588,15 +588,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.2.6</version>
+    <version>1.2.7</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.6'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.6'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.7'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.7'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.7] - 2026-08-29
+
 ### Fixed
 
 - **`reason` reached the aggregate files and was discarded on the way to the per-element rule
@@ -42,6 +44,77 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   than hand-listed, so an annotation that gains a reason is covered on the day it lands:
   `GranularReasonRenderedTest`, `GranularReasonEndToEndTest`, and a new sweep in
   `BuildFingerprintMutationTest`.
+
+
+- **A short-form annotation left a bold label with nothing after it in every per-element rule
+  file** ([#507](https://github.com/PIsberg/vibetags/issues/507)). `GranularRenderer` builds its
+  stanzas by string concatenation, so a member the author never set still wrote its label and its
+  colon. A bare `@AIContext` put `- **Focus**:` and `- **Avoid**:` into the file with nothing after
+  them, `@AIObservability` did the same with `- **Details**:`, and `@AIArchitecture` with
+  `- **Layer**:`. Each line costs an agent a slice of its context window and returns no guardrail,
+  and it reads as though the value went missing rather than as though nobody wrote one.
+  `CommonFormatterHelper.bullet` had guarded the aggregate renderers against exactly that, on every
+  platform, since the bare-annotation sweep; the granular renderer never grew an equivalent.
+
+  The guard now sits at the one place every stanza line passes through, so it covers all 44
+  annotations and the one added next, including the seven labels reachable only by passing an empty
+  value explicitly. A stanza left with no lines is not recorded at all, so a class carrying only a
+  bare `@AIContext` or `@AIArchitecture` gets no rule file, and no scoped-rules index entry either.
+  That was already the stated outcome: `CoreRules` warns at compile time that a blank `@AIContext`
+  will be ignored, and `ArchitectureRule` warns about a blank `belongsTo`.
+
+- **A role named on two lines of `.vibetags-roles` lost half its globs**
+  ([#511](https://github.com/PIsberg/vibetags/pull/511)). Routing had always treated a repeated
+  name as one role, so every class either line matched landed in one rule file. `globsFor` answered
+  with the first line alone, so that file declared only the first line's glob in its frontmatter and
+  never loaded when an agent opened one of the second line's classes. The guardrails were in the
+  file; the file was simply not read, which is the one thing a granular rule file exists to do.
+  Appending a line rather than extending one is how a config grows, so this needed no typo to reach.
+
+- **Two role names that resolve to one filename silently dropped one of them**
+  ([#511](https://github.com/PIsberg/vibetags/pull/511)). `RoleConfig.sanitize` maps every character
+  a filename cannot carry to a dash, so `api endpoints` and `api-endpoints` are two roles with one
+  stem. The writer planned them one at a time into a map keyed by that stem, and the second replaced
+  the first: every class of the losing role lost its rule file, while the scoped-rules index went on
+  pointing those classes at the survivor, which does not mention them. They are now merged, with
+  members concatenated in config order, globs unioned, and the heading naming every contributing
+  role. That is the answer the multi-module case already gave: a file several producers write is
+  merged, never replaced.
+
+### Changed
+
+- **The build now warns when two rule filenames differ only in capitalisation**
+  ([#510](https://github.com/PIsberg/vibetags/issues/510)). A granular stem is the element's
+  fully-qualified name with its dots turned into dashes, so the package `com.example.payment` and
+  the class `com.example.Payment` produce `com-example-payment` and `com-example-Payment`. A
+  case-sensitive filesystem holds two files and both guardrails survive. Windows and macOS, which
+  are case-insensitive by default, hold one: measured on Windows, the rules directory held a single
+  `com-example-payment.md` and the class's `@AILocked` appeared nowhere in the output tree, while
+  the index still named both elements. The same sources therefore generated different output
+  depending on which machine compiled them.
+
+  No generated file changes. Merging the two, or renaming one, would rewrite output that is correct
+  today on every case-sensitive filesystem, which is a decision about the generated layout rather
+  than a defect to patch quietly; #510 carries it with the options and their costs. What the build
+  can do without that decision is stop being silent, so it now names the colliding filenames and
+  says what will happen.
+
+
+### Upgrade note
+
+- **Your committed rule files will move on this upgrade, and that is the fix landing.** The
+  `reason` repair above means every per-element rule file gains the sentences its annotations
+  always carried and never rendered, so regenerating after the bump produces a diff in
+  `.claude/rules/`, `.cursor/rules/`, `.gemini/rules/` and every other scoped-rules directory.
+  Two further shapes show up in it, both intended: a section that used to collapse several
+  elements under one `- **Applies to**:` list splits into per-element subsections once their
+  reasons differ, which is exactly the byte-identical-guidance defect being corrected; and a
+  reason whose text contains a line break loses a trailing space, because rule-file lines are now
+  right-trimmed so a `trailing-whitespace` hook cannot rewrite generated output on commit.
+
+  Measured rather than predicted: building `codekarta` against 1.2.7 moved 12 committed rule files,
+  22 insertions and 4 deletions, every one of them an added reason, a split section, or that
+  trailing space. Nothing was lost. Review the diff and commit it.
 
 ## [1.2.6] - 2026-08-25
 
@@ -3429,7 +3502,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.2.6...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.2.7...HEAD
+[1.2.7]: https://github.com/PIsberg/vibetags/compare/v1.2.6...v1.2.7
 [1.2.6]: https://github.com/PIsberg/vibetags/compare/v1.2.5...v1.2.6
 [1.2.5]: https://github.com/PIsberg/vibetags/compare/v1.2.4...v1.2.5
 [1.2.4]: https://github.com/PIsberg/vibetags/compare/v1.2.3...v1.2.4

--- a/examples/all-tiers/pom.xml
+++ b/examples/all-tiers/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.2.6</vibetags.bom.version>
+    <vibetags.bom.version>1.2.7</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/basic/build.gradle
+++ b/examples/basic/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/examples/basic/pom.xml
+++ b/examples/basic/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.2.6</vibetags.bom.version>
+        <vibetags.bom.version>1.2.7</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/examples/gradle-composite/app/build.gradle
+++ b/examples/gradle-composite/app/build.gradle
@@ -16,8 +16,8 @@ repositories {
 
 dependencies {
     implementation 'se.deversity.vibetags.example:vibetags-example-gradle-composite-lib'
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-composite/lib/build.gradle
+++ b/examples/gradle-composite/lib/build.gradle
@@ -15,8 +15,8 @@ repositories {
 }
 
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-flat/app/build.gradle
+++ b/examples/gradle-flat/app/build.gradle
@@ -21,8 +21,8 @@ allprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-multimodule/build.gradle
+++ b/examples/gradle-multimodule/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-shared-buildfile/build.gradle
+++ b/examples/gradle-shared-buildfile/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.apache.groovy:groovy:5.1.0'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
 
     // Annotations on compile, processor on the annotation-processor path only.
     compileOnly 'se.deversity.vibetags:vibetags-annotations'

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and kapt configurations so neither needs an explicit version.
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.6"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.6"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.7"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.7"))
 
     // Annotations on compile, processor on the kapt path only — keeps the processor's
     // slf4j/logback off the consumer's compile classpath. compileOnly is enough:

--- a/examples/multimodule-indexed/pom.xml
+++ b/examples/multimodule-indexed/pom.xml
@@ -37,7 +37,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.2.6</vibetags.bom.version>
+    <vibetags.bom.version>1.2.7</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/examples/multimodule/pom.xml
+++ b/examples/multimodule/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.2.6</vibetags.bom.version>
+    <vibetags.bom.version>1.2.7</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/scala/build.gradle
+++ b/examples/scala/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.scala-lang:scala-library:2.13.18'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.2.6</vibetags.bom.version>
+        <vibetags.bom.version>1.2.7</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.2.6'
+version = '1.2.7'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.2.6'
+            version = '1.2.7'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -39,12 +39,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.2.6&lt;/version&gt;
+                &lt;version&gt;1.2.7&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.6'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.6'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.7'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.7'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -36,7 +36,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.2.6&lt;/version&gt;
+                        &lt;version&gt;1.2.7&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.2.6')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.6')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-cli/pom.xml
+++ b/vibetags-cli/pom.xml
@@ -28,7 +28,7 @@
         reports the project's VibeTags health — build-tool wiring, active platforms,
         marker integrity. Run it without installing anything:
 
-            jbang se.deversity.vibetags:vibetags-cli:1.2.6 init --list
+            jbang se.deversity.vibetags:vibetags-cli:1.2.7 init --list
 
         The platform list and marker rules are read from vibetags-processor, so this
         tool cannot drift from what the processor actually does.

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.2.6</revision>
+        <revision>1.2.7</revision>
 
         <!-- release, not source/target: on a JDK newer than 21 (CI builds 21, 25 and 26)
              source/target compiles against the *running* JDK's API and javac warns that the

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -35,7 +35,7 @@ def pomVersion = { String property ->
 }
 
 group = 'se.deversity.vibetags'
-version = '1.2.6'
+version = '1.2.7'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -49,7 +49,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.2.6'
+            version = '1.2.7'
             from components.java
 
             pom {
@@ -107,7 +107,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.2.6'
+    api 'se.deversity.vibetags:vibetags-annotations:1.2.7'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation "org.jspecify:jspecify:${pomVersion('jspecify.version')}"


### PR DESCRIPTION
Prepares `v1.2.7`. Patch release: four fixes, one new warning, no API or annotation change.

## What is in it

**`reason` reached the aggregate files and was discarded on the way to the per-element rule files**
([#506](https://github.com/PIsberg/vibetags/issues/506)). Twelve of the nineteen annotations that
declare a `reason()` had it dropped by `GranularRenderer`, so every scoped-rules directory carried
the annotation's canned sentence and nothing the author wrote. Editing only a reason did not
invalidate the cache either, so the renderer fix alone would have shipped something nobody could
observe without deleting `.vibetags-cache` first. Both halves landed together.

**A short-form annotation left a bold label with nothing after it**
([#507](https://github.com/PIsberg/vibetags/issues/507)). A bare `@AIContext` wrote `- **Focus**:`
and `- **Avoid**:` with nothing after them, `@AIObservability` wrote `- **Details**:`, and
`@AIArchitecture` wrote `- **Layer**:`. The guard now sits at the one place every stanza line passes
through, so it covers all 44 annotations and the one added next.

**Two role-routing defects** ([#511](https://github.com/PIsberg/vibetags/pull/511)). A role named on
two lines of `.vibetags-roles` kept only the first line's globs, so the file holding both lines'
classes never loaded for half of them. And two role names resolving to one filename dropped one of
them entirely, with the scoped-rules index still pointing its classes at the survivor.

**A new warning for rule filenames differing only in capitalisation**
([#510](https://github.com/PIsberg/vibetags/issues/510)). On Windows and macOS those are one file
and one element's guardrails are lost. No generated output changes; the layout decision is filed
rather than taken, and the build stops being silent about it.

## Upgrade note for consumers

Committed rule files will move on this upgrade, and that is the fix landing. The CHANGELOG carries
the full note. Measured rather than predicted: building `codekarta` against 1.2.7 moved 12 committed
rule files, 22 insertions and 4 deletions, every one of them an added reason, a section that
correctly stops collapsing once its reasons differ, or a trailing space now trimmed. Nothing was
lost.

## Verification

| Gate | Result |
|---|---|
| `mvn test -Pe2e` at 1.2.7 | 2437 tests, 0 failures |
| Checkstyle | 0 violations |
| PMD, CPD | pass |
| SpotBugs | **0 bug instances** |
| `BuildVersionParityTest` | pass |
| `pre-commit` (gitleaks, end-of-file, trailing-whitespace) | pass |
| `pre-commit` checkstyle hook | **not run**: needs a Docker daemon that is not up (checkstyle itself ran in the Maven build) |
| Examples regenerate byte-for-byte | **no drift**: only version bumps and the CHANGELOG appear in `git status` |

Build order followed as documented: `vibetags-annotations` → `vibetags` → `vibetags-bom` →
`vibetags-cli` → `examples/basic`, `examples/multimodule`, `examples/multimodule-indexed`.

### Consumer sweep

| Repo | Result |
|---|---|
| `codekarta` | **builds; drift as described above, all attributable** |
| `blindbean` | **not run**: working tree dirty, left alone |
| `common-license-lib` | **not run**: working tree dirty, left alone |
| `skill3` | **not run**: working tree dirty, left alone |
| `async-test-lib` | **not run**: working tree dirty, left alone |

A skipped consumer is not a passing consumer. Four of the five were not exercised; if you want them
covered before the tag, commit or stash in each and re-run `scripts/consumer-sweep.sh 1.2.7`.
`codekarta` is left on branch `chore/vibetags-1.2.7` with its bump and regenerated rule files
uncommitted, which is what the sweep script is designed to do.

Merge once CI is green; the release tags `main` afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWpYQBT3n96cSVscEtdBfV
