### PR TITLE
chore: merge scripts/ into tools/ and index every tool

### DIFF
--- a/.claude/skills/bump-dependencies/SKILL.md
+++ b/.claude/skills/bump-dependencies/SKILL.md
@@ -14,7 +14,7 @@ see is whether the pinned version is *current*, which is what this skill is for.
 
 ```bash
 git fetch origin && git checkout -b chore/bump-dependencies-$(date +%F) origin/main
-scripts/bump-dependencies.sh            # read-only; add --include-prereleases to see betas
+tools/bump-dependencies.sh            # read-only; add --include-prereleases to see betas
 ```
 
 The script prints one line per property with its Maven Central latest, then the toolchains
@@ -47,7 +47,7 @@ Edit the property in `vibetags-parent/pom.xml`. Then the places that cannot inhe
 | Groovy, Scala | `examples/groovy/build.gradle`, `examples/scala/build.gradle` (Scala stays on the 2.13 line: the example is about Java-only support) |
 | pre-commit hook revs | `python -m pre_commit autoupdate`; the `checkstyle` hook runs in Docker, so unless Docker is available revert its rev and say so - an unverifiable bump is not a verified one |
 
-Never touch `<revision>`: that is the VibeTags release version, owned by `scripts/set-version.sh`
+Never touch `<revision>`: that is the VibeTags release version, owned by `tools/set-version.sh`
 and the `release` skill.
 
 ## Step 4 - Verify with the gates CI runs

--- a/.claude/skills/consumer-regression-suite/SKILL.md
+++ b/.claude/skills/consumer-regression-suite/SKILL.md
@@ -9,7 +9,7 @@ VibeTags' own 1537 tests say the processor works. They say nothing about whether
 consumer still builds. This skill answers that second question, for every Java repo under
 `../` that depends on VibeTags.
 
-The executable core is `scripts/consumer-sweep.sh` in this repo. This document is the
+The executable core is `tools/consumer-sweep.sh` in this repo. This document is the
 judgement around it: what to run, what a result means, and what not to believe.
 
 ## Step 1 — Decide which VibeTags the sweep is testing
@@ -43,8 +43,8 @@ the result.
 ## Step 2 — Run the sweep
 
 ```bash
-bash scripts/consumer-sweep.sh <version>            # every consumer
-bash scripts/consumer-sweep.sh <version> blindbean  # one
+bash tools/consumer-sweep.sh <version>            # every consumer
+bash tools/consumer-sweep.sh <version> blindbean  # one
 ```
 
 Per repo it fetches, branches off `origin/main`, rewrites every place that repo declares the

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -54,11 +54,11 @@ git checkout -b release/v<version>
 
 ## Step 3 — Bump the version
 
-`scripts/set-version.sh` does the whole bump in one pass (it reads the current
+`tools/set-version.sh` does the whole bump in one pass (it reads the current
 version fresh from the parent, so it is idempotent):
 
 ```bash
-scripts/set-version.sh <version>
+tools/set-version.sh <version>
 ```
 
 That rewrites `<revision>` in `vibetags-parent/pom.xml` — which every managed pom
@@ -190,7 +190,7 @@ repository's fixtures and the third-party corpus, and neither of those is a proj
 already has committed VibeTags output.
 
 ```bash
-scripts/consumer-sweep.sh <version>
+tools/consumer-sweep.sh <version>
 ```
 
 **What you are looking for is not "did it build".** It is whether the version being cut

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,7 +40,7 @@ updates:
   # redirected, and deliberately:
   #
   #   - examples/*/pom.xml and tools/demo/pom.xml pin se.deversity.vibetags artifacts at the
-  #     released version. That number is owned by scripts/set-version.sh, and
+  #     released version. That number is owned by tools/set-version.sh, and
   #     BuildVersionParityTest fails if it disagrees with <revision>. A dependabot PR moving it
   #     would be red on arrival and could never merge.
   #   - Their maven-compiler-plugin literals are mirrors of the parent property. Bumping the copy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1364,7 +1364,7 @@ jobs:
       # Runs both compilers over the same fixture and compares. The javac half is the
       # control: without it every ECJ assertion passes equally well on an empty report.
       - name: Verify the processor degrades under ECJ rather than failing
-        run: scripts/ecj-degradation-check.sh
+        run: tools/ecj-degradation-check.sh
 
   locked-files:
     name: Locked Files Guard

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Each line names its enforcing check; run it, do not just read this list.
 11. Dependency manifests live under a Java package path, never `META-INF/`. `TransitiveGuardrailLifecycleE2ETest`
 12. Anything that becomes generated content reaches `BuildFingerprint`. `TransitiveFingerprintTest`
 13. Granular rule files are written through `ModuleSidecar.mergeGranular`, never directly. `MultiModuleGranularRoleMergeTest`
-14. Version literals live in `vibetags-parent/pom.xml` and nowhere else; bump via `scripts/set-version.sh`. `BuildVersionParityTest`
+14. Version literals live in `vibetags-parent/pom.xml` and nowhere else; bump via `tools/set-version.sh`. `BuildVersionParityTest`
 15. Logging is law: `domain.event key=value`, `reason=` on every `.skip`, tested events are contracts. [docs/LOGGING.md](docs/LOGGING.md), `GuardrailFileWriterLogContractTest`
 16. Every module that compiles Java runs the same static-analysis stack, and each module keeps its own `.mvn/jvm.config` because Error Prone silently does not run without it. `BuildToolchainParityTest`
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -140,7 +140,7 @@ needing a hand-fix before it could merge. Deriving the value removes the copy th
 policing; asserting the *mechanism* is what stops the check passing vacuously once there is no
 literal left to compare.
 
-To bump the VibeTags release version itself, use `scripts/set-version.sh <version>` and then run
+To bump the VibeTags release version itself, use `tools/set-version.sh <version>` and then run
 that test.
 
 ### Versions deliberately not taken

--- a/docs/LOAD-BEARING.md
+++ b/docs/LOAD-BEARING.md
@@ -235,4 +235,4 @@ and this section seem to disagree, the enforcing test decides.
   `vibetags-bom` and `load-tests` inherit every version; a literal there is one the next release
   will miss. The Gradle builds and the standalone example poms cannot inherit, so they hold
   literals — `BuildVersionParityTest` fails the build when any of them disagrees with the parent.
-  To bump: `scripts/set-version.sh <version>`, then that test.
+  To bump: `tools/set-version.sh <version>`, then that test.

--- a/docs/PROCESSOR.md
+++ b/docs/PROCESSOR.md
@@ -243,7 +243,7 @@ last-writer-wins. Positions come from `SourcePositionResolver` (javac Compiler T
 wrapper is reflectively unwrapped so positions survive Gradle-run javac (`treesFor`); under
 genuinely non-javac compilers (ECJ) entries omit position fields. That last sentence is
 measured rather than asserted: the `ecj-degradation` CI leg
-(`scripts/ecj-degradation-check.sh`) compiles `examples/basic` under both compilers and
+(`tools/ecj-degradation-check.sh`) compiles `examples/basic` under both compilers and
 compares — same locked elements, positions under javac only.
 
 The `kind` field is `ElementTag.name()`, which mirrors `javax.lang.model.element.ElementKind`

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ Read one of these before anything under `docs/`.
 | [`TESTS.md`](TESTS.md) | Which test class covers what, the fast/e2e tier split, and the coverage rules `CoverageGateTest` enforces. Read this before writing a test, not after. |
 | [`WORKFLOW.md`](WORKFLOW.md) | What CI actually runs, step by step, and why each verification exists. |
 | [`DEPENDENCIES.md`](DEPENDENCIES.md) | Every third-party artifact, why it is here, what ships to consumers, and what only runs the build. |
-| [`RELEASING.md`](RELEASING.md) | The release process end to end, including which files carry a version, which `scripts/set-version.sh` rewrites, and which are still updated by hand. |
+| [`RELEASING.md`](RELEASING.md) | The release process end to end, including which files carry a version, which `tools/set-version.sh` rewrites, and which are still updated by hand. |
 | [`CHANGELOG.md`](CHANGELOG.md) | What each release changed and why. The largest file in the repository; search it, do not read it. |
 
 ### Evidence

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -155,14 +155,14 @@ cd vibetags-annotations && mvn install -DskipTests
 cd ../vibetags         && mvn install -DskipTests
 cd ../vibetags-bom     && mvn install
 
-bash scripts/consumer-sweep.sh <version>
+bash tools/consumer-sweep.sh <version>
 ```
 
 The `consumer-regression-suite` skill drives this and covers how to read the results — in
 particular, that a failure is not a regression until it has been shown to pass on the
 consumer's existing pinned version.
 
-While the tree is being prepared, `scripts/bump-dependencies.sh` reports which third-party
+While the tree is being prepared, `tools/bump-dependencies.sh` reports which third-party
 pins in `vibetags-parent/pom.xml` (and the Gradle wrapper, Kotlin, Groovy and Scala pins in the
 examples) have a newer stable release. Applying them is its own PR, before the release branch,
 driven by the `bump-dependencies` skill; a release should not be the first build on a new
@@ -183,7 +183,7 @@ git checkout -b release/vX.Y.Z
 Update the version:
 
 ```bash
-scripts/set-version.sh 1.0.0
+tools/set-version.sh 1.0.0
 cd vibetags && mvn test -Dtest=BuildVersionParityTest
 ```
 
@@ -437,7 +437,7 @@ Release created on GitHub
 ## File Checklist
 
 See the table in [§2 Update the version](#2-update-the-version) for the authoritative list of
-files needing a version bump, and run `scripts/set-version.sh` to cover the three core modules
+files needing a version bump, and run `tools/set-version.sh` to cover the three core modules
 in one pass. This section used to keep a second copy of that list; it drifted out of date, so
 the table is now the only place it lives.
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -217,7 +217,7 @@ wall clock.
 
 ### Job: `ecj-degradation`
 
-The one leg that does not run javac. `scripts/ecj-degradation-check.sh` compiles
+The one leg that does not run javac. `tools/ecj-degradation-check.sh` compiles
 `examples/basic` twice over — once with javac, once with the Eclipse Compiler for Java pinned by
 `<ecj.version>` in `vibetags-parent/pom.xml` — and compares the results.
 

--- a/examples/gradle-multimodule/.vibetags-manifest
+++ b/examples/gradle-multimodule/.vibetags-manifest
@@ -15,5 +15,5 @@
 # The version is deliberately two-segment and NOT the VibeTags release version. The origin string
 # is rendered into every generated file of every consuming module, so a coordinate tracking the
 # release would put the release version into committed demo files and oblige
-# scripts/set-version.sh to rewrite generated output, which ReleaseScriptCoverageTest refuses.
+# tools/set-version.sh to rewrite generated output, which ReleaseScriptCoverageTest refuses.
 se.deversity.vibetags.example:gradle-multimodule-core:1.0

--- a/examples/multimodule/.vibetags-manifest
+++ b/examples/multimodule/.vibetags-manifest
@@ -10,7 +10,7 @@
 #
 # The version here is deliberately NOT the VibeTags release version. The origin string is rendered
 # into every generated file of every consuming module, so a coordinate tracking the release would
-# put the release version into a dozen committed demo files and oblige scripts/set-version.sh to
+# put the release version into a dozen committed demo files and oblige tools/set-version.sh to
 # rewrite generated output — which ReleaseScriptCoverageTest correctly refuses to let happen.
 # A two-segment version cannot collide with VibeTags' three-segment releases.
 se.deversity.vibetags.example:multimodule-core:1.0

--- a/tools/README.md
+++ b/tools/README.md
@@ -41,5 +41,7 @@ apart. "manual" means nothing runs it automatically; it exists for a human (or t
 | `demo-commands.sh` | The command sequence asciinema replays inside `tools/demo/` to produce `docs/demo.gif` | `demo.yml` |
 | `make-demo-cast.py` | Generates `docs/vibetags-demo.cast` from real VibeTags output | manual |
 
-Through v1.2.7 the four gate scripts lived in a separate `scripts/` directory; `docs/CHANGELOG.md`
-entries from those releases refer to them there.
+The four gate scripts previously lived in a separate `scripts/` directory; older
+`docs/CHANGELOG.md` entries refer to them there. No release version appears in this file on
+purpose: `ReleaseScriptCoverageTest` fails any tracked file that states one unless
+`set-version.sh` rewrites it.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,45 @@
+# tools/
+
+Every hand-run or CI-run script in the repository, except the CI-internal publish helper
+(`.github/scripts/deploy-to-central.sh`, which only `publish.yml` calls). `tools/demo/` is not a
+tool: it is the Maven fixture the animated README demo builds against (excluded from
+`ExampleCoverageTest`, version pinned by `BuildVersionParityTest`).
+
+The "Enforced by" column names the check that notices when the script and the repository drift
+apart. "manual" means nothing runs it automatically; it exists for a human (or the named skill).
+
+## Release and build gates
+
+| Tool | What it does | Run by | Enforced by |
+|---|---|---|---|
+| `set-version.sh` | Rewrites every file that states the release version, in one pass | `release` skill | `ReleaseScriptCoverageTest`, `BuildVersionParityTest` |
+| `consumer-sweep.sh` | Builds every downstream consumer against a given VibeTags version | `release` and `consumer-regression-suite` skills | `ReleaseConsumerSweepGateTest` |
+| `bump-dependencies.sh` | Reports third-party pins that have a newer stable release (read-only) | `bump-dependencies` skill | manual |
+| `ecj-degradation-check.sh` | Compiles `examples/basic` under javac and ECJ, compares the locks output | `ecj` job in `build.yml` | that CI job |
+
+## Architecture diagrams
+
+| Tool | What it does | Run by | Enforced by |
+|---|---|---|---|
+| `generate-architecture-diagrams.sh` | Regenerates the code-karta SVGs under `docs/diagrams/codekarta/` | `diagrams` job in `build.yml` | that job fails on structural drift |
+| `diagram-structure.sh` | Structural fingerprint of the SVGs (sorted `<title>` multiset); the comparison the drift gate uses | `diagrams` job in `build.yml` | that CI job |
+
+## Load-test plots (see `load-tests/README.md`)
+
+| Tool | What it does | Run by |
+|---|---|---|
+| `plot-results.py` | Release-trend plots from every committed `load-tests/results/<version>/` folder | `load-tests` skill, per release |
+| `plot-cache-hit.py` | Wall-clock and allocation plots from `WriteCacheHitBenchmark` JMH output | `load-tests` skill, per release |
+| `plot-processor-tax.py` | Splits "processor overhead" into javac's share and VibeTags' | `load-tests` skill, per release |
+| `plot-release-comparison.py` | Same-session allocation comparison against prior releases, for the changelog | `load-tests` skill, per release |
+| `plot-alloc-before-after.py` | One-off figure for the 1.0.0-RC1 allocation optimizations | manual, historical |
+
+## README demo
+
+| Tool | What it does | Run by |
+|---|---|---|
+| `demo-commands.sh` | The command sequence asciinema replays inside `tools/demo/` to produce `docs/demo.gif` | `demo.yml` |
+| `make-demo-cast.py` | Generates `docs/vibetags-demo.cast` from real VibeTags output | manual |
+
+Through v1.2.7 the four gate scripts lived in a separate `scripts/` directory; `docs/CHANGELOG.md`
+entries from those releases refer to them there.

--- a/tools/bump-dependencies.sh
+++ b/tools/bump-dependencies.sh
@@ -4,8 +4,8 @@
 # Read-only: it changes nothing. Applying, verifying and the places each pin is mirrored are
 # in .claude/skills/bump-dependencies/SKILL.md, which is the procedure this script serves.
 #
-#   scripts/bump-dependencies.sh                       # stable releases only
-#   scripts/bump-dependencies.sh --include-prereleases # also alpha/beta/M/RC (never applied by default)
+#   tools/bump-dependencies.sh                       # stable releases only
+#   tools/bump-dependencies.sh --include-prereleases # also alpha/beta/M/RC (never applied by default)
 #
 # Every version pin lives in vibetags-parent/pom.xml as a <name.version> property, so the table
 # below maps each property to the Maven Central path whose maven-metadata.xml is authoritative.

--- a/tools/consumer-sweep.sh
+++ b/tools/consumer-sweep.sh
@@ -3,10 +3,10 @@
 # honestly which ones pass.
 #
 # Usage:
-#   scripts/consumer-sweep.sh <vibetags-version> [repo ...]
+#   tools/consumer-sweep.sh <vibetags-version> [repo ...]
 #
-#   scripts/consumer-sweep.sh <version>             # every known consumer
-#   scripts/consumer-sweep.sh <version> blindbean   # just one
+#   tools/consumer-sweep.sh <version>             # every known consumer
+#   tools/consumer-sweep.sh <version> blindbean   # just one
 #
 # The examples deliberately say <version> rather than a real one: a literal release version
 # here would be a second place the release has to be remembered, and ReleaseScriptCoverageTest

--- a/tools/ecj-degradation-check.sh
+++ b/tools/ecj-degradation-check.sh
@@ -27,7 +27,7 @@
 #      live in .vibetags-locks, not here. This assertion was narrower for one commit, while
 #      issue #480 - which this check found - was open; the comment above it has the story.
 #
-# Usage: scripts/ecj-degradation-check.sh
+# Usage: tools/ecj-degradation-check.sh
 # Requires: a JDK, mvn on PATH, and vibetags-annotations + vibetags installed
 #           (see CLAUDE.md "Build and test" for the order).
 set -euo pipefail

--- a/tools/set-version.sh
+++ b/tools/set-version.sh
@@ -2,10 +2,10 @@
 # Sets the VibeTags release version.
 #
 # Usage:
-#   scripts/set-version.sh <new-version>
+#   tools/set-version.sh <new-version>
 #
 # Example:
-#   scripts/set-version.sh 1.0.0
+#   tools/set-version.sh 1.0.0
 #
 # The version lives in ONE place: <revision> in vibetags-parent/pom.xml. Every pom that
 # inherits from the parent — vibetags-annotations, vibetags, vibetags-bom, load-tests —
@@ -49,7 +49,7 @@ set -eu
 
 NEW_VERSION="${1:-}"
 if [ -z "$NEW_VERSION" ]; then
-    echo "Usage: scripts/set-version.sh <new-version>" >&2
+    echo "Usage: tools/set-version.sh <new-version>" >&2
     exit 1
 fi
 

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -94,7 +94,7 @@
 
         <!-- Verification-only tooling: never on any module's classpath. ECJ is how CI checks
              the documented claim that the processor degrades rather than fails under a compiler
-             with no Tree API (docs/PROCESSOR.md, USAGE.md). scripts/ecj-degradation-check.sh
+             with no Tree API (docs/PROCESSOR.md, USAGE.md). tools/ecj-degradation-check.sh
              reads this property so the version has one home, like every other pin here. -->
         <ecj.version>3.46.0</ecj.version>
 

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseConsumerSweepGateTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseConsumerSweepGateTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * noticed, both of them the normal case rather than bad luck: this repository uses jspecify
  * heavily but never on a parameter of an annotated method, which is the only place a parameter
  * type reaches an element path; and the consumers are pinned to the previous release, so they had
- * never run the change. {@code scripts/consumer-sweep.sh} is the only thing that would have run it
+ * never run the change. {@code tools/consumer-sweep.sh} is the only thing that would have run it
  * for them, and it ran in no workflow and at no step (#490).
  *
  * <p>So the gate lives at the release, which is the moment the consequence becomes real. This test
@@ -41,12 +41,12 @@ class ReleaseConsumerSweepGateTest {
     @DisplayName("the release skill runs the consumer sweep before opening the release PR")
     void releaseSkillRunsTheConsumerSweep() throws IOException {
         Path skill = REPO_ROOT.resolve(".claude/skills/release/SKILL.md");
-        Path script = REPO_ROOT.resolve("scripts/consumer-sweep.sh");
+        Path script = REPO_ROOT.resolve("tools/consumer-sweep.sh");
 
         // Deliberately not assumeTrue on a missing file. A skipped check reads exactly like a
         // passed one, and this exists because something that ran nowhere looked fine for months.
         assertTrue(Files.isRegularFile(script),
-            "scripts/consumer-sweep.sh is gone, so the release gate below refers to a script that "
+            "tools/consumer-sweep.sh is gone, so the release gate below refers to a script that "
                 + "does not exist. If the sweep moved, point this test and the release skill at "
                 + "wherever it went; if it was deleted, #490 needs reopening rather than the test "
                 + "deleting.");
@@ -56,7 +56,7 @@ class ReleaseConsumerSweepGateTest {
         String text = Files.readString(skill, StandardCharsets.UTF_8);
 
         assertTrue(text.contains("consumer-sweep.sh"),
-            "the release skill no longer runs scripts/consumer-sweep.sh. Without it a release "
+            "the release skill no longer runs tools/consumer-sweep.sh. Without it a release "
                 + "goes out having been verified against this repository's fixtures and the "
                 + "third-party corpus only, neither of which has committed VibeTags output to "
                 + "move, and downstream maintainers find a diff they did not cause (#490).");

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
- * {@code scripts/set-version.sh} must rewrite every file that states the release version.
+ * {@code tools/set-version.sh} must rewrite every file that states the release version.
  *
  * <p>The version lives once, in {@code <revision>}, and everything that can inherit it does. What
  * is left is the set of files that cannot: the Gradle builds, the standalone example poms a user
@@ -139,7 +139,7 @@ class ReleaseScriptCoverageTest {
     @Test
     @DisplayName("no tracked file states the version without the script knowing about it")
     void everyVersionCarryingFileIsInTheScript() throws IOException, InterruptedException {
-        Path script = REPO_ROOT.resolve("scripts/set-version.sh");
+        Path script = REPO_ROOT.resolve("tools/set-version.sh");
         assumeTrue(Files.isRegularFile(script), "set-version.sh not reachable; skipping");
 
         String version = revision();
@@ -172,7 +172,7 @@ class ReleaseScriptCoverageTest {
         }
 
         assertTrue(missing.isEmpty(),
-            "These files state the release version but scripts/set-version.sh does not rewrite "
+            "These files state the release version but tools/set-version.sh does not rewrite "
                 + "them, so the next release leaves them pointing at " + version + ". Add them to "
                 + "the script, or record them in HISTORICAL here with the reason they must not "
                 + "change:\n  " + String.join("\n  ", missing));


### PR DESCRIPTION
## Why

Two script directories with no stated rule for which held what: `scripts/` carried the four release/build gates, `tools/` everything else (plots, diagrams, demo). This merges `scripts/` into `tools/` and adds `tools/README.md`: one line per tool saying what it does, who runs it, and which test or CI job notices if it drifts. That fact set was previously scattered across five docs.

## Direction

`scripts/` moved rather than `tools/` because `tools/demo/` is pinned by name in `BuildVersionParityTest`, `ExampleCoverageTest`, and `demo.yml`'s path trigger; moving the other way would touch all three for no gain.

## What stays as-is

- `docs/CHANGELOG.md` keeps its old `scripts/` paths: frozen history, true when written. The index's last line points readers there.
- `.github/scripts/deploy-to-central.sh` stays where it is: CI-internal, only `publish.yml` calls it.

## Verified

- `ReleaseScriptCoverageTest`, `ReleaseConsumerSweepGateTest`, `BuildVersionParityTest`, `ExampleCoverageTest`: 11 tests, 0 failures
- Full fast tier: 1752 tests, 0 failures, BUILD SUCCESS
- `grep -rE 'scripts/'` finds no live references outside the changelog and `.github/scripts/`
- pre-commit: 3 hooks passed, checkstyle **skipped** locally (Docker daemon not running); CI runs it
- Exec bits on the moved `.sh` files match what main had (checked `git ls-files -s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUgKNm1SbrnJPCDbFwaVqM
