### PR TITLE
fix: stop the suite depositing state into vibetags/ that fails the next run

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Maven](https://img.shields.io/badge/build-Maven-blue?logo=apachemaven)](https://github.com/PIsberg/vibetags/actions/workflows/build.yml)
 [![Gradle](https://img.shields.io/badge/build-Gradle-blue?logo=gradle)](https://github.com/PIsberg/vibetags/actions/workflows/build.yml)
 [![codecov](https://codecov.io/gh/PIsberg/vibetags/branch/main/graph/badge.svg)](https://codecov.io/gh/PIsberg/vibetags)
-[![PIT Mutation Testing](https://img.shields.io/badge/PIT%20Mutation-80%25-brightgreen?logo=apachemaven&logoColor=white)](https://github.com/PIsberg/vibetags/actions/workflows/mutation.yml)
+[![PIT Mutation Testing](https://img.shields.io/badge/PIT%20Mutation-86%25-brightgreen?logo=apachemaven&logoColor=white)](https://github.com/PIsberg/vibetags/actions/workflows/mutation.yml)
 [![Lines of Code](https://www.aschey.tech/tokei/github/PIsberg/VibeTags?languages=Java&category=code)](https://github.com/PIsberg/VibeTags)
 [![PMD](https://img.shields.io/badge/PMD-passing-brightgreen)](https://pmd.github.io/)
 [![Analyzed with codekoll](https://img.shields.io/badge/analyzed%20with-codekoll-brightgreen?logo=java&logoColor=white)](https://github.com/PIsberg/codekoll)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   coverage to one arbitrary test. Rendering per test method took the renderer from 41 surviving
   to 0.
 
+  Measured by a dispatched `mutation.yml` run on this branch: 3,992 mutants, 3,427 killed =
+  **86%**, test strength 89%. The README badge moves from 80% — a number measured on the
+  1.1.0-era codebase, which `main` had already outgrown to 83.84% — to 86%.
+
 ## [1.2.7] - 2026-08-29
 
 ### Fixed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A suite run deposited gitignored processor state into `vibetags/` that failed the next run**
+  ([#521](https://github.com/PIsberg/vibetags/issues/521)). Four test classes ran the processor
+  without `vibetags.root`, so it worked at the JVM working directory — the real module dir —
+  and left `.vibetags-mod-*` sidecars, `.vibetags-cache` and `vibetags.log` behind. All of them
+  are gitignored, so `git status` read as clean while the next run's tests read them back:
+
+  - a stale sidecar carrying a foreign module id (a PIT-mutated run writes one with an empty id)
+    activates the multi-module merge, and the departed run's sections appear in a build with no
+    annotations at all — failing the `no annotations → no section` tests in
+    `AIContractProcessorTest`, `AIPrivacyProcessorTest` and `AITestDrivenProcessorTest`;
+  - a leftover `.vibetags-cache` fed `WriteCacheFileFormatTest`'s parentless-path test, which
+    asserted the developer's working directory held zero cache entries.
+
+  The symptom was a suite that is green exactly once per clean checkout and red forever after,
+  which reads as deterministic breakage — it cost a wrong JDK-26 diagnosis before the ignored
+  files were noticed. CI never sees a second run, so nothing upstream ever caught it.
+
+  Fixed by giving every processor-running test a per-test `vibetags.root` temp directory
+  (which also stops the deposits), and by making the parentless-path cache test assert what the
+  fallback guarantees (no throw) rather than what the real directory holds. A new
+  `ModuleDirHygiene` extension on the four classes fails any test that deposits
+  `.vibetags-*`/`vibetags.log` into the module dir again; broken deliberately, it names the
+  deposited files. Verified with the reconstructed debris (red on the old tests, green now) and
+  with two back-to-back suite runs from a clean tree: run 1 deposits nothing, run 2 is green.
+
 ### Added
 
 - **Five test surfaces over code the mutation report showed was unverified.** A full PIT run on

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/AIContractProcessorTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/AIContractProcessorTest.java
@@ -24,6 +24,7 @@ import se.deversity.vibetags.annotations.AILocked;
 import se.deversity.vibetags.annotations.AIPerformance;
 import se.deversity.vibetags.annotations.AIPrivacy;
 
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Isolated;
 import se.deversity.vibetags.processor.internal.AnnotationValidator;
 
@@ -34,7 +35,18 @@ import static org.mockito.Mockito.*;
  * Tests for @AIContract annotation definition, validation, and per-platform output.
  */
 @Isolated
+@org.junit.jupiter.api.extension.ExtendWith(ModuleDirHygiene.class)
 class AIContractProcessorTest {
+
+    /**
+     * Root for everything the processor reads or writes in these tests. Without it the processor
+     * defaults to the JVM working directory — the real {@code vibetags/} module dir — where it
+     * deposited {@code .vibetags-mod-*} sidecars and {@code vibetags.log} that git ignores and the
+     * NEXT run then read back: a stale sidecar with a foreign module id merges its sections into
+     * the captured output and fails the no-annotation tests (#521).
+     */
+    @TempDir
+    java.nio.file.Path root;
 
     // -----------------------------------------------------------------------
     // Annotation definition
@@ -191,7 +203,7 @@ class AIContractProcessorTest {
 
     @Test
     void process_withContractAnnotation_writesContractSectionToCursorRules() throws Exception {
-        withCwdSignalFiles(List.of(".cursorrules"), () -> {
+        withSignalFiles(List.of(".cursorrules"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), contractRoundEnv("com.example.PricingService.calculatePrice", "OpenAPI v2 contract"));
             triggerGeneration(processor);
@@ -210,7 +222,7 @@ class AIContractProcessorTest {
 
     @Test
     void process_withContractAnnotation_writesContractSectionToClaudeMd() throws Exception {
-        withCwdSignalFiles(List.of("CLAUDE.md"), () -> {
+        withSignalFiles(List.of("CLAUDE.md"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), contractRoundEnv("com.example.BillingService.invoice", "Partner API SLA"));
             triggerGeneration(processor);
@@ -256,7 +268,7 @@ class AIContractProcessorTest {
 
     @Test
     void process_withContractAnnotation_writesContractSectionToGemini() throws Exception {
-        withCwdSignalFiles(List.of("gemini_instructions.md"), () -> {
+        withSignalFiles(List.of("gemini_instructions.md"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), contractRoundEnv("com.example.PaymentGateway.charge", "Bank partner API"));
             triggerGeneration(processor);
@@ -271,7 +283,7 @@ class AIContractProcessorTest {
 
     @Test
     void process_withContractAnnotation_writesContractSectionToCopilot() throws Exception {
-        withCwdSignalFiles(List.of(".github/copilot-instructions.md"), () -> {
+        withSignalFiles(List.of(".github/copilot-instructions.md"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), contractRoundEnv("com.example.ReportService.generate", "Analytics contract"));
             triggerGeneration(processor);
@@ -286,7 +298,7 @@ class AIContractProcessorTest {
 
     @Test
     void process_withContractAnnotation_writesContractSectionToQwen() throws Exception {
-        withCwdSignalFiles(List.of("QWEN.md"), () -> {
+        withSignalFiles(List.of("QWEN.md"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), contractRoundEnv("com.example.CatalogService.search", "Catalog API v3 contract"));
             triggerGeneration(processor);
@@ -301,7 +313,7 @@ class AIContractProcessorTest {
 
     @Test
     void process_noContractAnnotations_noContractSectionWritten() throws Exception {
-        withCwdSignalFiles(List.of(".cursorrules"), () -> {
+        withSignalFiles(List.of(".cursorrules"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), emptyRoundEnv());
             triggerGeneration(processor);
@@ -314,7 +326,7 @@ class AIContractProcessorTest {
 
     @Test
     void process_multipleContractElements_allListedInOutput() throws Exception {
-        withCwdSignalFiles(List.of(".cursorrules"), () -> {
+        withSignalFiles(List.of(".cursorrules"), () -> {
             Element el1 = contractElement("com.example.PricingService.calculatePrice", "OpenAPI v2");
             Element el2 = contractElement("com.example.PricingService.applyPromoCode", "Promotions contract");
 
@@ -342,7 +354,7 @@ class AIContractProcessorTest {
 
     @Test
     void process_contractAnnotation_defaultReasonAppearsInOutput() throws Exception {
-        withCwdSignalFiles(List.of(".cursorrules"), () -> {
+        withSignalFiles(List.of(".cursorrules"), () -> {
             Element element = mock(Element.class);
             when(element.toString()).thenReturn("com.example.ApiService.execute");
             when(element.getSimpleName()).thenReturn(nameOf("execute"));
@@ -372,7 +384,7 @@ class AIContractProcessorTest {
 
     @Test
     void process_contractAnnotation_llmsTxtContainsContractSection() throws Exception {
-        withCwdSignalFiles(List.of("llms.txt"), () -> {
+        withSignalFiles(List.of("llms.txt"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), contractRoundEnv("com.example.PricingService.calculatePrice", "OpenAPI v2 contract"));
             triggerGeneration(processor);
@@ -387,7 +399,7 @@ class AIContractProcessorTest {
 
     @Test
     void process_contractAnnotation_llmsFullTxtContainsContractSection() throws Exception {
-        withCwdSignalFiles(List.of("llms-full.txt"), () -> {
+        withSignalFiles(List.of("llms-full.txt"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), contractRoundEnv("com.example.PricingService.calculatePrice", "OpenAPI v2 contract"));
             triggerGeneration(processor);
@@ -402,7 +414,7 @@ class AIContractProcessorTest {
 
     @Test
     void process_contractAnnotation_aiderConventionsContainsContractSection() throws Exception {
-        withCwdSignalFiles(List.of("CONVENTIONS.md"), () -> {
+        withSignalFiles(List.of("CONVENTIONS.md"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), contractRoundEnv("com.example.BillingApi.invoice", "Partner SLA contract"));
             triggerGeneration(processor);
@@ -440,29 +452,23 @@ class AIContractProcessorTest {
         Messager messager = noopMessager();
         ProcessingEnvironment env = mock(ProcessingEnvironment.class);
         when(env.getMessager()).thenReturn(messager);
-        when(env.getOptions()).thenReturn(java.util.Map.of("vibetags.cache", "false"));
+        when(env.getOptions()).thenReturn(java.util.Map.of(
+            "vibetags.root", root.toString(),
+            "vibetags.cache", "false"));
         processor.init(env);
         return processor;
     }
 
-    private void withCwdSignalFiles(List<String> relPaths, ThrowingRunnable block) throws Exception {
-        java.nio.file.Path cwd = java.nio.file.Paths.get("").toAbsolutePath();
-        List<java.nio.file.Path> created = new ArrayList<>();
-        try {
-            for (String rel : relPaths) {
-                java.nio.file.Path p = cwd.resolve(rel);
-                if (!Files.exists(p)) {
-                    Files.createDirectories(p.getParent());
-                    Files.createFile(p);
-                    created.add(p);
-                }
-            }
-            block.run();
-        } finally {
-            for (java.nio.file.Path p : created) {
-                Files.deleteIfExists(p);
+    /** Creates the platform opt-in files under the test's own {@link #root}, never the cwd. */
+    private void withSignalFiles(List<String> relPaths, ThrowingRunnable block) throws Exception {
+        for (String rel : relPaths) {
+            java.nio.file.Path p = root.resolve(rel);
+            Files.createDirectories(p.getParent());
+            if (!Files.exists(p)) {
+                Files.createFile(p);
             }
         }
+        block.run();
     }
 
     @FunctionalInterface

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/AIGuardrailProcessorProcessTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/AIGuardrailProcessorProcessTest.java
@@ -38,7 +38,12 @@ import static org.mockito.Mockito.*;
  */
 @SuppressWarnings("unchecked")
 @Tag("e2e")
+@org.junit.jupiter.api.extension.ExtendWith(ModuleDirHygiene.class)
 class AIGuardrailProcessorProcessTest {
+
+    /** Per-test root for {@link #mockEnv}; see its javadoc. */
+    @org.junit.jupiter.api.io.TempDir
+    java.nio.file.Path mockEnvRoot;
 
     // -----------------------------------------------------------------------
     // process() — early-return paths
@@ -854,10 +859,17 @@ class AIGuardrailProcessorProcessTest {
         processor.process(Set.of(), genEnv);
     }
 
-    private static ProcessingEnvironment mockEnv(Messager messager) {
+    /**
+     * Everything a processor built on this env reads or writes lands under a per-test temp root.
+     * With no root option the processor works at the JVM working directory — the real
+     * {@code vibetags/} module dir — where these tests deposited {@code .vibetags-cache} and
+     * {@code vibetags.log} that git ignores and later runs tripped over (#521), and where
+     * pre-existing debris could change which platforms the processor saw as active.
+     */
+    private ProcessingEnvironment mockEnv(Messager messager) {
         ProcessingEnvironment env = mock(ProcessingEnvironment.class);
         when(env.getMessager()).thenReturn(messager);
-        when(env.getOptions()).thenReturn(Map.of());
+        when(env.getOptions()).thenReturn(Map.of("vibetags.root", mockEnvRoot.toString()));
         return env;
     }
 

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/AIPrivacyProcessorTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/AIPrivacyProcessorTest.java
@@ -21,6 +21,7 @@ import se.deversity.vibetags.annotations.AIIgnore;
 import se.deversity.vibetags.annotations.AILocked;
 import se.deversity.vibetags.annotations.AIPrivacy;
 
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Isolated;
 import se.deversity.vibetags.processor.internal.AnnotationValidator;
 
@@ -31,7 +32,18 @@ import static org.mockito.Mockito.*;
  * Tests for @AIPrivacy annotation definition and processing in AIGuardrailProcessor.
  */
 @Isolated
+@org.junit.jupiter.api.extension.ExtendWith(ModuleDirHygiene.class)
 class AIPrivacyProcessorTest {
+
+    /**
+     * Root for everything the processor reads or writes in these tests. Without it the processor
+     * defaults to the JVM working directory — the real {@code vibetags/} module dir — where it
+     * deposited {@code .vibetags-mod-*} sidecars and {@code vibetags.log} that git ignores and the
+     * NEXT run then read back: a stale sidecar with a foreign module id merges its sections into
+     * the captured output and fails the no-annotation tests (#521).
+     */
+    @TempDir
+    java.nio.file.Path root;
 
     // -----------------------------------------------------------------------
     // Annotation definition
@@ -133,7 +145,7 @@ class AIPrivacyProcessorTest {
 
     @Test
     void process_withPrivacyAnnotation_writesPiiSectionToCursorRules() throws Exception {
-        withCwdSignalFiles(List.of(".cursorrules"), () -> {
+        withSignalFiles(List.of(".cursorrules"), () -> {
             CapturingProcessor processor = makeCapturingProcessor(List.of());
             processor.process(Set.of(), privacyRoundEnv("com.example.User.email", "GDPR personal email"));
             triggerGeneration(processor);
@@ -152,7 +164,7 @@ class AIPrivacyProcessorTest {
 
     @Test
     void process_withPrivacyAnnotation_writesPiiSectionToClaudeMd() throws Exception {
-        withCwdSignalFiles(List.of("CLAUDE.md"), () -> {
+        withSignalFiles(List.of("CLAUDE.md"), () -> {
             CapturingProcessor processor = makeCapturingProcessor(List.of());
             processor.process(Set.of(), privacyRoundEnv("com.example.User.ssn", "SSN - PII"));
             triggerGeneration(processor);
@@ -198,7 +210,7 @@ class AIPrivacyProcessorTest {
 
     @Test
     void process_withPrivacyAnnotation_writesPiiSectionToGemini() throws Exception {
-        withCwdSignalFiles(List.of("gemini_instructions.md"), () -> {
+        withSignalFiles(List.of("gemini_instructions.md"), () -> {
             CapturingProcessor processor = makeCapturingProcessor(List.of());
             processor.process(Set.of(), privacyRoundEnv("com.example.Order.cardNumber", "PCI-DSS card data"));
             triggerGeneration(processor);
@@ -213,7 +225,7 @@ class AIPrivacyProcessorTest {
 
     @Test
     void process_withPrivacyAnnotation_writesPiiSectionToCopilot() throws Exception {
-        withCwdSignalFiles(List.of(".github/copilot-instructions.md"), () -> {
+        withSignalFiles(List.of(".github/copilot-instructions.md"), () -> {
             CapturingProcessor processor = makeCapturingProcessor(List.of());
             processor.process(Set.of(), privacyRoundEnv("com.example.User.address", "Home address PII"));
             triggerGeneration(processor);
@@ -228,7 +240,7 @@ class AIPrivacyProcessorTest {
 
     @Test
     void process_withPrivacyAnnotation_writesPiiSectionToQwen() throws Exception {
-        withCwdSignalFiles(List.of("QWEN.md"), () -> {
+        withSignalFiles(List.of("QWEN.md"), () -> {
             CapturingProcessor processor = makeCapturingProcessor(List.of());
             processor.process(Set.of(), privacyRoundEnv("com.example.Employee.salary", "Salary - confidential"));
             triggerGeneration(processor);
@@ -243,7 +255,7 @@ class AIPrivacyProcessorTest {
 
     @Test
     void process_noPrivacyAnnotations_noPiiSectionWritten() throws Exception {
-        withCwdSignalFiles(List.of(".cursorrules"), () -> {
+        withSignalFiles(List.of(".cursorrules"), () -> {
             CapturingProcessor processor = makeCapturingProcessor(List.of());
             processor.process(Set.of(), emptyRoundEnv());
             triggerGeneration(processor);
@@ -256,7 +268,7 @@ class AIPrivacyProcessorTest {
 
     @Test
     void process_multiplePrivacyElements_allListedInOutput() throws Exception {
-        withCwdSignalFiles(List.of(".cursorrules"), () -> {
+        withSignalFiles(List.of(".cursorrules"), () -> {
             Element el1 = privacyElement("com.example.User.email", "email address");
             Element el2 = privacyElement("com.example.User.phone", "phone number");
 
@@ -281,7 +293,7 @@ class AIPrivacyProcessorTest {
 
     @Test
     void process_privacyAnnotation_defaultReasonAppearsInOutput() throws Exception {
-        withCwdSignalFiles(List.of(".cursorrules"), () -> {
+        withSignalFiles(List.of(".cursorrules"), () -> {
             Element element = mock(Element.class);
             when(element.toString()).thenReturn("com.example.Profile.birthDate");
             when(element.getSimpleName()).thenReturn(nameOf("birthDate"));
@@ -345,7 +357,9 @@ class AIPrivacyProcessorTest {
         Messager messager = noopMessager();
         ProcessingEnvironment env = mock(ProcessingEnvironment.class);
         when(env.getMessager()).thenReturn(messager);
-        when(env.getOptions()).thenReturn(java.util.Map.of("vibetags.cache", "false"));
+        when(env.getOptions()).thenReturn(java.util.Map.of(
+            "vibetags.root", root.toString(),
+            "vibetags.cache", "false"));
         processor.init(env);
         return processor;
     }
@@ -354,24 +368,16 @@ class AIPrivacyProcessorTest {
      * Creates the given signal files in the CWD (vibetags/) if they don't exist,
      * runs the block, then deletes any files this method created.
      */
-    private void withCwdSignalFiles(List<String> relPaths, ThrowingRunnable block) throws Exception {
-        java.nio.file.Path cwd = java.nio.file.Paths.get("").toAbsolutePath();
-        List<java.nio.file.Path> created = new ArrayList<>();
-        try {
-            for (String rel : relPaths) {
-                java.nio.file.Path p = cwd.resolve(rel);
-                if (!Files.exists(p)) {
-                    Files.createDirectories(p.getParent());
-                    Files.createFile(p);
-                    created.add(p);
-                }
-            }
-            block.run();
-        } finally {
-            for (java.nio.file.Path p : created) {
-                Files.deleteIfExists(p);
+    /** Creates the platform opt-in files under the test's own {@link #root}, never the cwd. */
+    private void withSignalFiles(List<String> relPaths, ThrowingRunnable block) throws Exception {
+        for (String rel : relPaths) {
+            java.nio.file.Path p = root.resolve(rel);
+            Files.createDirectories(p.getParent());
+            if (!Files.exists(p)) {
+                Files.createFile(p);
             }
         }
+        block.run();
     }
 
     @FunctionalInterface

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/AITestDrivenProcessorTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/AITestDrivenProcessorTest.java
@@ -26,6 +26,7 @@ import se.deversity.vibetags.annotations.AIPerformance;
 import se.deversity.vibetags.annotations.AIPrivacy;
 import se.deversity.vibetags.annotations.AITestDriven;
 
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Isolated;
 import se.deversity.vibetags.processor.internal.AnnotationValidator;
 
@@ -36,7 +37,18 @@ import static org.mockito.Mockito.*;
  * Tests for @AITestDriven annotation definition, validation, and per-platform output.
  */
 @Isolated
+@org.junit.jupiter.api.extension.ExtendWith(ModuleDirHygiene.class)
 class AITestDrivenProcessorTest {
+
+    /**
+     * Root for everything the processor reads or writes in these tests. Without it the processor
+     * defaults to the JVM working directory — the real {@code vibetags/} module dir — where it
+     * deposited {@code .vibetags-mod-*} sidecars and {@code vibetags.log} that git ignores and the
+     * NEXT run then read back: a stale sidecar with a foreign module id merges its sections into
+     * the captured output and fails the no-annotation tests (#521).
+     */
+    @TempDir
+    java.nio.file.Path root;
 
     // -----------------------------------------------------------------------
     // Annotation definition
@@ -285,7 +297,7 @@ class AITestDrivenProcessorTest {
 
     @Test
     void process_withTestDrivenAnnotation_writesTestDrivenSectionToCursorRules() throws Exception {
-        withCwdSignalFiles(List.of(".cursorrules"), () -> {
+        withSignalFiles(List.of(".cursorrules"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), testDrivenRoundEnv("com.example.OrderService.calculateDiscount", 100, "JUNIT_5", ""));
             triggerGeneration(processor);
@@ -302,7 +314,7 @@ class AITestDrivenProcessorTest {
 
     @Test
     void process_withTestDrivenAnnotation_writesTestDrivenSectionToClaudeMd() throws Exception {
-        withCwdSignalFiles(List.of("CLAUDE.md"), () -> {
+        withSignalFiles(List.of("CLAUDE.md"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), testDrivenRoundEnv("com.example.OrderService.updateOrderStatus", 95, "JUNIT_5", "src/test/java/com/example/service/OrderServiceTest.java"));
             triggerGeneration(processor);
@@ -348,7 +360,7 @@ class AITestDrivenProcessorTest {
 
     @Test
     void process_withTestDrivenAnnotation_writesTestDrivenSectionToGemini() throws Exception {
-        withCwdSignalFiles(List.of("gemini_instructions.md"), () -> {
+        withSignalFiles(List.of("gemini_instructions.md"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), testDrivenRoundEnv("com.example.PricingService.calculatePrice", 100, "JUNIT_5", ""));
             triggerGeneration(processor);
@@ -363,7 +375,7 @@ class AITestDrivenProcessorTest {
 
     @Test
     void process_withTestDrivenAnnotation_writesTestDrivenSectionToCopilot() throws Exception {
-        withCwdSignalFiles(List.of(".github/copilot-instructions.md"), () -> {
+        withSignalFiles(List.of(".github/copilot-instructions.md"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), testDrivenRoundEnv("com.example.ReportService.generate", 80, "JUNIT_5", ""));
             triggerGeneration(processor);
@@ -378,7 +390,7 @@ class AITestDrivenProcessorTest {
 
     @Test
     void process_withTestDrivenAnnotation_writesTestDrivenSectionToQwen() throws Exception {
-        withCwdSignalFiles(List.of("QWEN.md"), () -> {
+        withSignalFiles(List.of("QWEN.md"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), testDrivenRoundEnv("com.example.CatalogService.search", 90, "JUNIT_5", ""));
             triggerGeneration(processor);
@@ -393,7 +405,7 @@ class AITestDrivenProcessorTest {
 
     @Test
     void process_noTestDrivenAnnotations_noTestDrivenSectionWritten() throws Exception {
-        withCwdSignalFiles(List.of(".cursorrules"), () -> {
+        withSignalFiles(List.of(".cursorrules"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), emptyRoundEnv());
             triggerGeneration(processor);
@@ -406,7 +418,7 @@ class AITestDrivenProcessorTest {
 
     @Test
     void process_testDrivenWithLocation_locationAppearsInOutput() throws Exception {
-        withCwdSignalFiles(List.of("CLAUDE.md"), () -> {
+        withSignalFiles(List.of("CLAUDE.md"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), testDrivenRoundEnv("com.example.Service.method", 100, "JUNIT_5", "src/test/java/com/example/ServiceTest.java"));
             triggerGeneration(processor);
@@ -419,7 +431,7 @@ class AITestDrivenProcessorTest {
 
     @Test
     void process_testDrivenWithMockPolicy_mockPolicyAppearsInOutput() throws Exception {
-        withCwdSignalFiles(List.of(".cursorrules"), () -> {
+        withSignalFiles(List.of(".cursorrules"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
 
             Element element = testDrivenElement("com.example.Service.method", 100, "Use H2 for database tests");
@@ -436,7 +448,7 @@ class AITestDrivenProcessorTest {
 
     @Test
     void process_testDrivenWithMockPolicy_mockPolicyAppearsInClaudeMd() throws Exception {
-        withCwdSignalFiles(List.of("CLAUDE.md"), () -> {
+        withSignalFiles(List.of("CLAUDE.md"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
 
             Element element = testDrivenElement("com.example.PaymentService.charge", 95, "Mock Stripe client; use real validation logic");
@@ -455,7 +467,7 @@ class AITestDrivenProcessorTest {
 
     @Test
     void process_testDrivenWithLocation_locationAppearsInLlmsFullTxt() throws Exception {
-        withCwdSignalFiles(List.of("llms-full.txt"), () -> {
+        withSignalFiles(List.of("llms-full.txt"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), testDrivenRoundEnv(
                 "com.example.OrderService.placeOrder", 100, "JUNIT_5",
@@ -472,7 +484,7 @@ class AITestDrivenProcessorTest {
 
     @Test
     void process_testDrivenWithMockPolicy_mockPolicyAppearsInLlmsFullTxt() throws Exception {
-        withCwdSignalFiles(List.of("llms-full.txt"), () -> {
+        withSignalFiles(List.of("llms-full.txt"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
 
             Element element = testDrivenElement("com.example.BillingService.invoice", 90, "Always mock the mailer");
@@ -491,7 +503,7 @@ class AITestDrivenProcessorTest {
 
     @Test
     void process_testDrivenAnnotation_llmsTxtContainsTestDrivenSection() throws Exception {
-        withCwdSignalFiles(List.of("llms.txt"), () -> {
+        withSignalFiles(List.of("llms.txt"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), testDrivenRoundEnv("com.example.OrderService.calculateDiscount", 100, "JUNIT_5", ""));
             triggerGeneration(processor);
@@ -504,7 +516,7 @@ class AITestDrivenProcessorTest {
 
     @Test
     void process_testDrivenAnnotation_llmsFullTxtContainsTestDrivenSection() throws Exception {
-        withCwdSignalFiles(List.of("llms-full.txt"), () -> {
+        withSignalFiles(List.of("llms-full.txt"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), testDrivenRoundEnv("com.example.OrderService.calculateDiscount", 100, "JUNIT_5", ""));
             triggerGeneration(processor);
@@ -519,7 +531,7 @@ class AITestDrivenProcessorTest {
 
     @Test
     void process_multipleTestDrivenElements_allListedInOutput() throws Exception {
-        withCwdSignalFiles(List.of(".cursorrules"), () -> {
+        withSignalFiles(List.of(".cursorrules"), () -> {
             Element el1 = testDrivenElement("com.example.OrderService.calculateDiscount", 100, "");
             Element el2 = testDrivenElement("com.example.BillingService.invoice", 90, "");
 
@@ -548,7 +560,7 @@ class AITestDrivenProcessorTest {
 
     @Test
     void process_multipleIdenticalTestDrivenElements_coalescedInClaudeMd() throws Exception {
-        withCwdSignalFiles(List.of("CLAUDE.md"), () -> {
+        withSignalFiles(List.of("CLAUDE.md"), () -> {
             Element el1 = testDrivenElement("com.example.diag.AlphaDetector", 80, "");
             Element el2 = testDrivenElement("com.example.diag.BetaDetector", 80, "");
             Element el3 = testDrivenElement("com.example.diag.GammaDetector", 80, "");
@@ -585,7 +597,7 @@ class AITestDrivenProcessorTest {
 
     @Test
     void process_testDrivenAnnotation_aiderConventionsContainsTestDrivenSection() throws Exception {
-        withCwdSignalFiles(List.of("CONVENTIONS.md"), () -> {
+        withSignalFiles(List.of("CONVENTIONS.md"), () -> {
             CapturingProcessor processor = makeCapturingProcessor();
             processor.process(Set.of(), testDrivenRoundEnv("com.example.BillingApi.invoice", 100, "JUNIT_5", ""));
             triggerGeneration(processor);
@@ -623,29 +635,23 @@ class AITestDrivenProcessorTest {
         Messager messager = noopMessager();
         ProcessingEnvironment env = mock(ProcessingEnvironment.class);
         when(env.getMessager()).thenReturn(messager);
-        when(env.getOptions()).thenReturn(java.util.Map.of("vibetags.cache", "false"));
+        when(env.getOptions()).thenReturn(java.util.Map.of(
+            "vibetags.root", root.toString(),
+            "vibetags.cache", "false"));
         processor.init(env);
         return processor;
     }
 
-    private void withCwdSignalFiles(List<String> relPaths, ThrowingRunnable block) throws Exception {
-        java.nio.file.Path cwd = java.nio.file.Paths.get("").toAbsolutePath();
-        List<java.nio.file.Path> created = new ArrayList<>();
-        try {
-            for (String rel : relPaths) {
-                java.nio.file.Path p = cwd.resolve(rel);
-                if (!Files.exists(p)) {
-                    Files.createDirectories(p.getParent());
-                    Files.createFile(p);
-                    created.add(p);
-                }
-            }
-            block.run();
-        } finally {
-            for (java.nio.file.Path p : created) {
-                Files.deleteIfExists(p);
+    /** Creates the platform opt-in files under the test's own {@link #root}, never the cwd. */
+    private void withSignalFiles(List<String> relPaths, ThrowingRunnable block) throws Exception {
+        for (String rel : relPaths) {
+            java.nio.file.Path p = root.resolve(rel);
+            Files.createDirectories(p.getParent());
+            if (!Files.exists(p)) {
+                Files.createFile(p);
             }
         }
+        block.run();
     }
 
     @FunctionalInterface

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ModuleDirHygiene.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ModuleDirHygiene.java
@@ -1,0 +1,64 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Fails a test that deposits VibeTags state into the module directory — the JVM working
+ * directory the whole suite shares.
+ *
+ * <p>This is the regression guard for #521: tests that ran the processor without
+ * {@code vibetags.root} left {@code .vibetags-mod-*} sidecars, {@code .vibetags-cache} and
+ * {@code vibetags.log} in {@code vibetags/}. All of them are gitignored, so the tree still read
+ * as clean, and the <em>next</em> run's tests read them back — a stale sidecar with a foreign
+ * module id merged phantom sections into a build with no annotations at all. CI never sees the
+ * second run, so without this guard the only symptom is a developer machine where the suite is
+ * green exactly once per clean checkout.
+ *
+ * <p>The comparison is first-run-shaped on purpose: only files that <em>appear</em> during the
+ * test fail it, so pre-existing debris on a developer machine does not turn the guard red — the
+ * fixed tests must pass with that debris present, which is the other half of the same bug.
+ */
+public final class ModuleDirHygiene implements BeforeEachCallback, AfterEachCallback {
+
+    private static final ExtensionContext.Namespace NS =
+        ExtensionContext.Namespace.create(ModuleDirHygiene.class);
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws IOException {
+        context.getStore(NS).put("before", vibetagsStateInModuleDir());
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws IOException {
+        @SuppressWarnings("unchecked")
+        Set<String> before = (Set<String>) context.getStore(NS).get("before", Set.class);
+        Set<String> after = vibetagsStateInModuleDir();
+        after.removeAll(before);
+        assertEquals(Set.of(), after,
+            "the test deposited VibeTags state into the module directory. Everything the "
+                + "processor writes must go under a per-test vibetags.root — a gitignored leftover "
+                + "here fails the NEXT suite run on this machine (#521)");
+    }
+
+    /** The gitignored processor-state files at the JVM working directory, by name. */
+    private static Set<String> vibetagsStateInModuleDir() throws IOException {
+        Set<String> found = new TreeSet<>();
+        try (Stream<Path> entries = Files.list(Path.of("").toAbsolutePath())) {
+            entries.map(p -> String.valueOf(p.getFileName()))
+                .filter(name -> name.startsWith(".vibetags-") || name.equals("vibetags.log"))
+                .forEach(found::add);
+        }
+        return found;
+    }
+}

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/internal/WriteCacheFileFormatTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/internal/WriteCacheFileFormatTest.java
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -277,12 +278,16 @@ class WriteCacheFileFormatTest {
     }
 
     @Test
-    void aCacheDirectlyInTheWorkingDirectoryStillResolvesItsEntries(@TempDir Path dir) throws IOException {
+    void aCacheDirectlyInTheWorkingDirectoryStillResolvesItsEntries() {
         // cachePath.getParent() is null for a bare file name; the constructor has to fall back to
-        // the working directory rather than NPE on the first entry lookup.
+        // the working directory rather than NPE on the first entry lookup. The working directory
+        // here is the REAL module dir, whose contents this test does not own: a .vibetags-cache
+        // deposited by an earlier run made the old `size() == 0` assertion fail every run after
+        // the first (#521). So assert only what the fallback guarantees — no throw on the lookups
+        // that walk the parentless path — never what the developer's directory happens to hold.
         WriteCache cache = new WriteCache(Path.of(CACHE));
-        assertEquals(0, cache.size());
-        assertTrue(cache.allCachedFilesStable());
-        assertNotNull(cache, "constructing from a parentless path must not throw");
+        assertDoesNotThrow(cache::size, "size() must resolve entries against the cwd fallback");
+        assertDoesNotThrow(cache::allCachedFilesStable,
+            "stability probing must resolve entries against the cwd fallback");
     }
 }


### PR DESCRIPTION
Fixes #521.

## The bug

Four test classes ran the processor without `vibetags.root`, so it worked at the JVM working directory - the real `vibetags/` module dir - and left `.vibetags-mod-*` sidecars, `.vibetags-cache` and `vibetags.log` behind. All gitignored, so `git status` read as clean while the NEXT run's tests read them back. The symptom: the suite is green exactly once per clean checkout and red forever after, with the same four failures. CI runs the suite once per job, so nothing upstream ever caught it.

## Root cause, established by bisection

Planting reconstructed debris one file at a time into a clean checkout (suite context, since the victims are only reachable there):

| Planted file | Result |
|---|---|
| `.vibetags-cache` with entries | `WriteCacheFileFormatTest.aCacheDirectlyInTheWorkingDirectoryStillResolvesItsEntries` fails - the test constructs `WriteCache` from a bare filename (its point is the parentless-path fallback) but asserted the developer's real cwd held zero entries |
| `.vibetags-mod-` sidecar with an **empty module id** (what a PIT-mutated run writes; its `modulePath` resolves to an existing directory, so departed-module pruning keeps it) | the multi-module merge activates and the stale module's rendered sections appear in a build with **no annotations at all** - failing the `no annotations -> no section` tests in `AIContractProcessorTest`, `AIPrivacyProcessorTest`, `AITestDrivenProcessorTest` |
| contentful `.cursorrules` alone | green (red herring; it is a side effect of the same missing root, not a cause) |

A sidecar whose `modulePath` names a directory that does not exist is pruned as departed, which is why earlier plants with `modulePath=stale` failed to reproduce and the empty-path one succeeds.

## The fix (tests only, no production changes)

- `AIContractProcessorTest`, `AIPrivacyProcessorTest`, `AITestDrivenProcessorTest`: per-test `@TempDir` passed as `vibetags.root`; `withCwdSignalFiles` becomes `withSignalFiles` and creates the opt-in files under that root. They stop depositing AND stop being sensitive to whatever the module dir holds.
- `AIGuardrailProcessorProcessTest.mockEnv()`: same per-test root. This also removes latent sensitivity where a dirty developer cwd changed which platforms those tests saw as active.
- `WriteCacheFileFormatTest`: the parentless-path test now asserts what the fallback guarantees (no throw on `size()` / `allCachedFilesStable()`), never what the real directory happens to hold.
- New `ModuleDirHygiene` extension on the four classes: fails any test that deposits `.vibetags-*` / `vibetags.log` into the module dir again. First-run-shaped on purpose - only files that *appear* during a test fail it, so pre-existing debris on a developer machine does not turn it red.

## Verification

- Reconstructed debris that reproduced all four failures on the old tests: green now, same plant.
- Guard broken deliberately (root option removed from one class): red, naming the deposited files (`.vibetags-mod-_root_`, `vibetags.log`); green again on restore.
- Depositor sweep from clean: the four classes create zero files in the module dir (was: `.github/`, `.vibetags-mod-_root_`, `.vibetags-cache`, `vibetags.log`).
- Two back-to-back suite runs from a clean tree: run 1 deposits nothing, run 2 green - the original symptom is gone.
- Full `mvn test -Pe2e` with all static-analysis gates: 2,544 tests green (local JDK 26 / Maven 3.9.11).

## Also in this PR

`f3f64fd` rescues the PIT badge commit from #522: that PR was squash-merged nine minutes before the badge commit reached its branch, so main still said 80% while the dispatched `mutation.yml` run on the merged content measured **86%** (3,992 mutants, 3,427 killed, test strength 89%). Same two-file diff, re-applied on top of main.

VibeTags guardrails considered: test-only changes plus one test extension; no production elements changed, so no annotations proposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjBgEV2Vz2eybywWdRS77Y
