### PR TITLE
docs: attribute the kapt options-not-recognized warning and close it out

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -104,7 +104,7 @@ kapt {
 Processor options (`vibetags.log.path`, `vibetags.check`, …) are passed through the same
 `kapt { arguments { ... } }` block, without the `-A` prefix.
 
-Two kapt-specific limitations, both consequences of kapt processing generated Java stubs
+Three kapt-specific caveats, the first two consequences of kapt processing generated Java stubs
 rather than the Kotlin sources:
 
 - **Method-body-scoped annotations are invisible.** Stubs carry no method bodies, so an
@@ -113,6 +113,16 @@ rather than the Kotlin sources:
 - **Source positions describe the stub.** The `.vibetags-locks` report's line ranges would
   point into the generated stub, not the `.kt` file, so don't opt a pure-Kotlin module into
   the locks report.
+- **Some builds print `warning: The following options were not recognized by any processor:
+  '[vibetags.root, kapt.kotlin.generated]'`. It is harmless and it is kapt's, not yours.** kapt
+  forwards its option map to its embedded javac without registering any processor's
+  `@SupportedOptions`, so javac's unmatched-options bookkeeping flags everything — including
+  `kapt.kotlin.generated`, kapt's own option, in the same breath, which is how you can tell no
+  amount of VibeTags configuration will silence it. The warning appears during the `kaptKotlin`
+  task immediately after the processor has already printed its resolved root from the very
+  option being reported: the value arrives and is used. Whether the message surfaces at all
+  depends on the consumer's Gradle/kapt logging configuration, not on the Kotlin version — the
+  same option block is silent in `examples/kotlin` on both 2.3.10 and 2.4.10.
 
 A complete working consumer is in [`examples/kotlin/`](examples/kotlin/README.md), built in CI
 on the JDK 21 Gradle leg.

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -401,12 +401,17 @@ is that a toolchain pin overrides the JDK you launched Gradle with, so a develop
 
 `warning: The following options were not recognized by any processor: '[vibetags.root,
 kapt.kotlin.generated]'` — for an option `AIGuardrailProcessor` declares in `@SupportedOptions`
-and demonstrably receives, since it prints the resolved root from the same task. `examples/kotlin`
-on Kotlin 2.4.10 does not produce it; this member on Kotlin 2.3.10 does. Removing the javac-side
-configuration so only the documented `kapt { arguments { … } }` route remained did not change it.
+and demonstrably receives, since it prints the resolved root from the same task.
 
-That is as far as the evidence goes, so it is allow-listed as kapt bookkeeping with the evidence
-written next to it, and tracked as an open question rather than asserted to be harmless.
+Attributed on 2026-08-31 (#493) by an `-i` treatment run of this member: the warning is emitted
+by `:kaptKotlin` — not stub generation — two lines after the processor's own
+`Note: VibeTags: Root resolved: …` from the very option being reported. kapt forwards its option
+map to its embedded javac without registering any processor's supported-option set, which is why
+`kapt.kotlin.generated`, kapt's own option, is flagged in the same message: even perfect
+delegation on our side would leave the warning firing for kapt's half. The version hypothesis is
+dead — `examples/kotlin` is silent with its Kotlin/kapt pinned to this member's 2.3.10 as well
+as at 2.4.10 — so surfacing is a property of the consumer's Gradle/kapt logging configuration.
+Allow-listed as attributed kapt bookkeeping; USAGE.md's kapt section says the same to consumers.
 
 **And one in the harness, which is the reason J2 can be trusted at all.**
 

--- a/corpus/run-corpus-jvm.sh
+++ b/corpus/run-corpus-jvm.sh
@@ -234,12 +234,13 @@ while IFS=$'\t' read -r name url sha lang module src task licence why; do
   #
   # That entry: kapt reports the processor options it forwards as unrecognised, vibetags.root
   # among them - an option AIGuardrailProcessor does declare in @SupportedOptions, and does
-  # receive, since it prints the resolved root from the same task. examples/kotlin, configured
-  # exactly as USAGE.md documents and built on Kotlin 2.4.10, does not produce it; this member,
-  # on Kotlin 2.3.10, does. Removing the javac-side configuration so that only the documented
-  # `kapt { arguments { ... } }` route remained did not change it either. That is as far as the
-  # evidence goes, so it is allow-listed as kapt bookkeeping and tracked as an open question
-  # rather than asserted to be harmless.
+  # receive, since it prints the resolved root from the same task. Attributed (#493, 2026-08-31,
+  # -i run of kotlin-obd-api): emitted by :kaptKotlin two lines after the processor's own
+  # "Root resolved" note, and it names kapt.kotlin.generated - kapt's own option - in the same
+  # message, so it is kapt failing to register any processor's supported-option set with its
+  # embedded javac, and nothing VibeTags declares can silence it. Not version-bound:
+  # examples/kotlin is silent at 2.3.10 and 2.4.10 alike. Allow-listed as attributed kapt
+  # bookkeeping; corpus/README.md carries the full evidence and USAGE.md warns consumers.
   KAPT_NOISE="The following options were not recognized by any processor"
   new_diags=$(comm -13 <(grep -hE "$DIAG_RE" "$dir/.corpus-ctrl.log" | sort -u)                        <(grep -hE "$DIAG_RE" "$dir/.corpus-vt.log" | sort -u)               | grep -vF "$KAPT_NOISE")
   if [ -n "$new_diags" ]; then

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The kapt "options not recognized" warning is now attributed and documented, not an open
+  question** ([#493](https://github.com/PIsberg/vibetags/issues/493)). An `-i` treatment run of
+  the corpus member pinned it: `:kaptKotlin` emits it two lines after the processor's own
+  "Root resolved" note from the very option being reported, and it names
+  `kapt.kotlin.generated` — kapt's own option — in the same message, so it is kapt failing to
+  register any processor's `@SupportedOptions` with its embedded javac, and nothing VibeTags
+  declares can silence it. The version hypothesis is dead: `examples/kotlin` is silent with its
+  Kotlin/kapt swapped to the corpus member's 2.3.10 as well as at its committed 2.4.10, so
+  whether the message surfaces is a property of the consumer's Gradle/kapt logging
+  configuration. USAGE.md's kapt section now tells consumers it is harmless and whose it is;
+  the corpus allow-list entry is reclassified from unattributed to attributed.
+
 ### Fixed
 
 - **A suite run deposited gitignored processor state into `vibetags/` that failed the next run**


### PR DESCRIPTION
Fixes #493, by settling both prongs of its "what would settle it".

## The attribution

An `-i` treatment run of the corpus member (`corpus/run-corpus-jvm.sh kotlin-obd-api`, 2026-08-31):

```
> Task :kaptKotlin
...
Note: VibeTags: Root resolved: ...\.corpus-vibetags-root
Note: VibeTags: user.dir:      ...\kotlin-obd-api
warning: The following options were not recognized by any processor: '[vibetags.root, kapt.kotlin.generated]'
```

- Emitted by `:kaptKotlin`, not stub generation, two lines after the processor printed the resolved root **from the very option being reported** - the value arrives and is used.
- `kapt.kotlin.generated` - kapt's own option, which no processor anywhere declares - is flagged in the same message. That answers the delegation question from the outside: kapt does not register any processor's `@SupportedOptions` with its embedded javac's unmatched-options bookkeeping, and even perfect delegation of ours would leave the warning firing for kapt's half. Nothing VibeTags declares can silence it.
- The version hypothesis is dead: `examples/kotlin` built with its Kotlin/kapt swapped to the corpus member's `2.3.10` produces zero occurrences, same as at its committed `2.4.10` (both builds green, grepped logs). So whether the message *surfaces* is a property of the consumer's Gradle/kapt logging configuration, not of the Kotlin version.

Full method and negative results on the issue: https://github.com/PIsberg/vibetags/issues/493#issuecomment-5477526333

## The changes (docs only)

- **USAGE.md** - the kapt section's caveat list grows a third entry, as the issue asked: the warning is harmless, it is kapt's, and how a reader can tell (kapt's own option in the same message).
- **corpus/README.md** and the **`KAPT_NOISE` allow-list comment** in `run-corpus-jvm.sh` - reclassified from "unattributed open question" to attributed, with the evidence in place. The allow-list itself is unchanged: still one entry, anything else still fails J2.

Doc-consistency gates green locally (DocumentationLinks, DocsIndexCompleteness, DocumentedCommands, ProjectFactsConsistency, ReleaseScriptCoverage - 13 tests).

VibeTags guardrails considered: docs and comments only, no code elements changed, no annotations proposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjBgEV2Vz2eybywWdRS77Y
