### PR TITLE
chore: prepare release v1.3.0

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.2.7
+version: 1.3.0
 ---
 
 # VibeTags Usage Guide
@@ -27,7 +27,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
     <dependency>
         <groupId>se.deversity.vibetags</groupId>
         <artifactId>vibetags-annotations</artifactId>
-        <version>1.2.7</version>
+        <version>1.3.0</version>
     </dependency>
 </dependencies>
 
@@ -41,7 +41,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.7</version>
+                        <version>1.3.0</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -63,8 +63,8 @@ the whole processor and its SLF4J/Logback dependencies on your compile classpath
 
 ```groovy
 dependencies {
-    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.2.7'
-    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.7'
+    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.3.0'
+    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.0'
 }
 ```
 
@@ -221,7 +221,7 @@ though the build is green.
 Every way this setup fails is silent, so check rather than assume:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.7 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.3.0 doctor
 ```
 
 Or by hand, in the order things go wrong:
@@ -1287,7 +1287,7 @@ Use on: **class, method, field**
 @AIKeepInSync(mirrors = {"pom.xml:<version>", "README.md badge", "docs/CHANGELOG.md"},
               reason = "The release version is asserted in three places and drifts silently",
               enforcedBy = "ProjectFactsConsistencyTest")
-public static final String VERSION = "1.2.7";
+public static final String VERSION = "1.3.0";
 ```
 
 The element is free to change — the failure mode is a *partial* change that desyncs a mirror no compiler checks. `@AIContract` freezes one signature so it cannot change at all; neither it nor `@AISchemaSafe` expresses "edit A ⇒ you must also edit B". Mirrors routinely point outside the compilation unit, so VibeTags can only *name* them, not verify them.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.2.7</version>
+            <version>1.3.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.7</version>
+                        <version>1.3.0</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -94,7 +94,7 @@ touch CLAUDE.md .cursorrules AGENTS.md   # Claude, Cursor, Codex CLI — add whi
 Or let the companion CLI do it (and `vibetags doctor` checks your setup afterwards):
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.7 init --platforms claude,cursor
+jbang se.deversity.vibetags:vibetags-cli:1.3.0 init --platforms claude,cursor
 ```
 
 **3. Annotate your first class:**
@@ -123,8 +123,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -170,8 +170,8 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.7"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.7"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.0"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.0"))
 
     compileOnly("se.deversity.vibetags:vibetags-annotations")
     kapt("se.deversity.vibetags:vibetags-processor")
@@ -502,8 +502,8 @@ build-tool wiring, active platforms, and `VIBETAGS-START`/`END` marker integrity
 installing anything:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.2.7 init --list
-jbang se.deversity.vibetags:vibetags-cli:1.2.7 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.3.0 init --list
+jbang se.deversity.vibetags:vibetags-cli:1.3.0 doctor
 ```
 
 The platform list and marker rules are read from `vibetags-processor` at runtime, so the CLI
@@ -532,7 +532,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.2.7</version>
+            <version>1.3.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -557,7 +557,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.2.7</version>
+                        <version>1.3.0</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -573,8 +573,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -588,15 +588,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.2.7</version>
+    <version>1.3.0</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.7'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.7'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.0'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.0'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-31
+
+A minor rather than a patch because `vibetags doctor` gains a capability (the Groovy
+field-guardrail check) — the same reasoning as 1.1.0. The processor's rendering changes only
+for granular rule filenames that differ solely in capitalisation, which no example or surveyed
+consumer has.
+
+### Upgrade note
+
+The pre-release consumer sweep found guardrail drift in four of five downstream repositories,
+and all of it is the 1.2.5–1.2.7 rendering fixes arriving late: a consumer pinned at 1.2.4 or
+older that upgrades straight to 1.3.0 will see its per-element rule files under
+`.claude/rules/`, `.gemini/rules/` and friends gain the annotations' `reason()` as a
+`- **Reason**:` line (#508, #511). That is the fix landing, not breakage — regenerate and
+commit the files with the version bump. A consumer already on 1.2.5+ sees no drift unless it
+has case-colliding rule filenames (see Fixed below).
+
 ### Fixed
 
 - **Case-colliding granular stems from different reactor modules still lost a file on
@@ -3648,7 +3665,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.2.7...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/PIsberg/vibetags/compare/v1.2.7...v1.3.0
 [1.2.7]: https://github.com/PIsberg/vibetags/compare/v1.2.6...v1.2.7
 [1.2.6]: https://github.com/PIsberg/vibetags/compare/v1.2.5...v1.2.6
 [1.2.5]: https://github.com/PIsberg/vibetags/compare/v1.2.4...v1.2.5

--- a/examples/all-tiers/pom.xml
+++ b/examples/all-tiers/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.2.7</vibetags.bom.version>
+    <vibetags.bom.version>1.3.0</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/basic/build.gradle
+++ b/examples/basic/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/examples/basic/pom.xml
+++ b/examples/basic/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.2.7</vibetags.bom.version>
+        <vibetags.bom.version>1.3.0</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/examples/gradle-composite/app/build.gradle
+++ b/examples/gradle-composite/app/build.gradle
@@ -16,8 +16,8 @@ repositories {
 
 dependencies {
     implementation 'se.deversity.vibetags.example:vibetags-example-gradle-composite-lib'
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-composite/lib/build.gradle
+++ b/examples/gradle-composite/lib/build.gradle
@@ -15,8 +15,8 @@ repositories {
 }
 
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-flat/app/build.gradle
+++ b/examples/gradle-flat/app/build.gradle
@@ -21,8 +21,8 @@ allprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-multimodule/build.gradle
+++ b/examples/gradle-multimodule/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-shared-buildfile/build.gradle
+++ b/examples/gradle-shared-buildfile/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.apache.groovy:groovy:5.1.0'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
 
     // Annotations on compile, processor on the annotation-processor path only.
     compileOnly 'se.deversity.vibetags:vibetags-annotations'

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and kapt configurations so neither needs an explicit version.
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.2.7"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.2.7"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.0"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.0"))
 
     // Annotations on compile, processor on the kapt path only — keeps the processor's
     // slf4j/logback off the consumer's compile classpath. compileOnly is enough:

--- a/examples/multimodule-indexed/pom.xml
+++ b/examples/multimodule-indexed/pom.xml
@@ -37,7 +37,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.2.7</vibetags.bom.version>
+    <vibetags.bom.version>1.3.0</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/examples/multimodule/pom.xml
+++ b/examples/multimodule/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.2.7</vibetags.bom.version>
+    <vibetags.bom.version>1.3.0</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/scala/build.gradle
+++ b/examples/scala/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.scala-lang:scala-library:2.13.18'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.2.7</vibetags.bom.version>
+        <vibetags.bom.version>1.3.0</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.2.7'
+version = '1.3.0'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.2.7'
+            version = '1.3.0'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -39,12 +39,12 @@
             &lt;dependency&gt;
                 &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                 &lt;artifactId&gt;vibetags-annotations&lt;/artifactId&gt;
-                &lt;version&gt;1.2.7&lt;/version&gt;
+                &lt;version&gt;1.3.0&lt;/version&gt;
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.2.7'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.2.7'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.0'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.0'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -36,7 +36,7 @@
                     &lt;dependency&gt;
                         &lt;groupId&gt;se.deversity.vibetags&lt;/groupId&gt;
                         &lt;artifactId&gt;vibetags-bom&lt;/artifactId&gt;
-                        &lt;version&gt;1.2.7&lt;/version&gt;
+                        &lt;version&gt;1.3.0&lt;/version&gt;
                         &lt;type&gt;pom&lt;/type&gt;
                         &lt;scope&gt;import&lt;/scope&gt;
                     &lt;/dependency&gt;
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.2.7')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.2.7')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-cli/pom.xml
+++ b/vibetags-cli/pom.xml
@@ -28,7 +28,7 @@
         reports the project's VibeTags health — build-tool wiring, active platforms,
         marker integrity. Run it without installing anything:
 
-            jbang se.deversity.vibetags:vibetags-cli:1.2.7 init --list
+            jbang se.deversity.vibetags:vibetags-cli:1.3.0 init --list
 
         The platform list and marker rules are read from vibetags-processor, so this
         tool cannot drift from what the processor actually does.

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.2.7</revision>
+        <revision>1.3.0</revision>
 
         <!-- release, not source/target: on a JDK newer than 21 (CI builds 21, 25 and 26)
              source/target compiles against the *running* JDK's API and javac warns that the

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -35,7 +35,7 @@ def pomVersion = { String property ->
 }
 
 group = 'se.deversity.vibetags'
-version = '1.2.7'
+version = '1.3.0'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -49,7 +49,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.2.7'
+            version = '1.3.0'
             from components.java
 
             pom {
@@ -107,7 +107,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.2.7'
+    api 'se.deversity.vibetags:vibetags-annotations:1.3.0'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation "org.jspecify:jspecify:${pomVersion('jspecify.version')}"


### PR DESCRIPTION
Prepares v1.3.0. A minor rather than a patch: `vibetags doctor` gains the Groovy field-guardrail check (#494), the same reasoning as 1.1.0.

## In this release (from the CHANGELOG)

**Fixed**
- Case-colliding granular rule filenames no longer lose an element's guardrails on case-insensitive filesystems - within one module (#510) and across reactor modules (#525): colliding stems plan one merged rule file written byte-identically under each name.
- A suite run no longer deposits gitignored processor state into `vibetags/` that failed the next run (#521).

**Changed**
- The kapt "options not recognized" warning is attributed (kapt's own bookkeeping, `:kaptKotlin`, unavoidable from VibeTags' side) and documented for consumers (#493).

**Added**
- `vibetags doctor` names the field-level guardrails groovyc silently drops, per file/line/annotation (#494).
- `HARNESS.md` agent-harness entry point; `ArchiveIndexCompletenessTest` (#504); five mutation-hardening test surfaces (PIT 83.84% -> 86%, badge updated from the dispatched run).

## Upgrade note (also in the CHANGELOG)

The pre-release consumer sweep found guardrail drift in four of five downstream repos - all of it the 1.2.5-1.2.7 `reason()` rendering fixes arriving late for consumers pinned at <= 1.2.4. Their per-element rule files gain `- **Reason**:` lines on this upgrade; regenerate and commit with the bump. Consumers on 1.2.5+ see no drift unless they have case-colliding rule filenames.

## Verification

- `BuildVersionParityTest` green (6/6) after `tools/set-version.sh 1.3.0`; stale-version grep clean (only regenerated `.flattened-pom.xml` and the documented leftovers).
- Full build chain in order (annotations -> processor -> bom -> cli) plus `examples/basic`, `examples/multimodule`, `examples/multimodule-indexed`: all green with full gates, and **zero guardrail drift** - `git status` after the example compiles shows only version pins and the CHANGELOG, so the examples regenerate byte-for-byte.
- **Consumer sweep (step 5b)**: satisfied by the sweep completed earlier today against a `0-SNAPSHOT` build of this same code (delta to this branch: docs-only #530 + changelog). All five consumers PASS (blindbean after correcting a harness-side JDK pin; async-test-lib via manual worktree because another agent's untracked handoff file trips the script's dirty check). Drift found, attributed to #508/#511, and already captured in prepared `chore/vibetags-1.3.0` branches in all five repos - rerunning the sweep script now would reset those branches, which is why it was not run a second time.
- Pre-commit: gitleaks + whitespace hooks passed; checkstyle hook skipped (Docker down) but checkstyle ran in every Maven build above.

After merge: I create the GitHub release (with your explicit go-ahead on the notes - that step publishes to Maven Central), then push the five prepared consumer bump branches and open their PRs once 1.3.0 resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjBgEV2Vz2eybywWdRS77Y
