### PR TITLE
fix: a corrupt .vibetags-baseline fails the enforcing build instead of passing it

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,12 @@ and the keys are current again. Consumers without annotated enum constants see n
 
 ### Fixed
 
+- **A corrupt `.vibetags-baseline` switched enforcement off with a warning.** `EnforcementBaseline`
+  read a file it could not decode as an empty one, so `-Avibetags.enforce` saw "nothing recorded
+  for this module", printed the advisory warning and passed. One byte that is not UTF-8 (a Cp1252
+  save from a Windows editor) was enough. The reader now throws, and the enforcer reports a compile
+  error that names the file and the way out; `EnforcementBaselineTest` and
+  `EnforcingModeEndToEndTest` pin both halves.
 - **Guardrails on two enum constants of the same name were one element.**
   `ElementNaming.elementPath` prepended the enclosing type only for fields, methods and
   constructors; an enum constant (and a record component) fell through to `Element.toString()`,

--- a/docs/PROCESSOR.md
+++ b/docs/PROCESSOR.md
@@ -149,7 +149,10 @@ compilation is therefore a violation too — that covers renames, deletions and 
 Enforcement runs in `process()` before `generateFiles()`, deliberately: the generation path has a
 fingerprint short-circuit that would let an unchanged-inputs build skip the check silently.
 Switching the option on before a baseline exists warns and checks nothing, rather than failing every
-build on day one.
+build on day one. A baseline that exists but cannot be read is different: a byte that is not UTF-8
+(a Cp1252 save from a Windows editor), a permission error, anything that stops the file from being
+parsed is a compile **error** naming the file, never an unrecorded baseline. The gate does not go
+quiet on a file it could not read.
 
 ## Top-level fingerprint short-circuit
 

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/EnforcementBaseline.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/EnforcementBaseline.java
@@ -49,42 +49,40 @@ public final class EnforcementBaseline {
         this.entries = entries;
     }
 
-    /** Reads the baseline at {@code root}, or an empty one when absent or unreadable. */
-    public static EnforcementBaseline load(Path root) {
+    /**
+     * Reads the baseline at {@code root}, or an empty one when absent.
+     *
+     * <p>A file that is present but cannot be read or decoded throws instead of loading empty.
+     * Loading it empty told the enforcer "nothing recorded", which it answers with a warning and a
+     * pass; one Cp1252 byte from a Windows editor was enough to switch the gate off unnoticed.
+     */
+    public static EnforcementBaseline load(Path root) throws IOException {
         Map<String, String> entries = new LinkedHashMap<>();
         Path file = root.resolve(FILE_NAME);
         if (!Files.isRegularFile(file)) {
             return new EnforcementBaseline(entries);
         }
-        try {
-            for (String line : Files.readAllLines(file, StandardCharsets.UTF_8)) {
-                if (line.isBlank() || line.startsWith("#")) {
-                    continue;
-                }
-                int lastTab = line.lastIndexOf('\t');
-                if (lastTab < 0) {
-                    continue;
-                }
-                entries.put(line.substring(0, lastTab), line.substring(lastTab + 1));
+        for (String line : Files.readAllLines(file, StandardCharsets.UTF_8)) {
+            if (line.isBlank() || line.startsWith("#")) {
+                continue;
             }
-        } catch (IOException | RuntimeException e) {
-            return new EnforcementBaseline(new LinkedHashMap<>());
+            int lastTab = line.lastIndexOf('\t');
+            if (lastTab < 0) {
+                continue;
+            }
+            entries.put(line.substring(0, lastTab), line.substring(lastTab + 1));
         }
         return new EnforcementBaseline(entries);
     }
 
-    /** True when the file exists and carries a format header this processor understands. */
-    public static boolean exists(Path root) {
+    /**
+     * True when the file exists and carries a format header this processor understands. Throws
+     * when the file is there but cannot be read, for the same reason {@link #load} does.
+     */
+    public static boolean exists(Path root) throws IOException {
         Path file = root.resolve(FILE_NAME);
-        if (!Files.isRegularFile(file)) {
-            return false;
-        }
-        try {
-            return Files.readAllLines(file, StandardCharsets.UTF_8).stream()
-                        .anyMatch(FORMAT_MARKER::equals);
-        } catch (IOException e) {
-            return false;
-        }
+        return Files.isRegularFile(file)
+            && Files.readAllLines(file, StandardCharsets.UTF_8).stream().anyMatch(FORMAT_MARKER::equals);
     }
 
     /** The approved signature for {@code path} under {@code family}, or {@code null} if unrecorded. */

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailEnforcer.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailEnforcer.java
@@ -128,7 +128,24 @@ public final class GuardrailEnforcer {
             }
         }
 
-        EnforcementBaseline baseline = EnforcementBaseline.load(root);
+        EnforcementBaseline baseline;
+        boolean recorded;
+        try {
+            baseline = EnforcementBaseline.load(root);
+            recorded = EnforcementBaseline.exists(root);
+        } catch (IOException e) {
+            // Present but unreadable is not "nothing recorded". Reading it as empty fell through to
+            // the warning below and a pass: one Cp1252 byte from a Windows editor switched the gate
+            // off, and the build stayed green.
+            messager.printMessage(Diagnostic.Kind.ERROR,
+                "VibeTags: could not read " + EnforcementBaseline.FILE_NAME + " ("
+                    + e.getClass().getSimpleName() + ": " + e.getMessage() + "); enforcement did not run."
+                    + " Fix the file, or delete it and record it again with -Avibetags.baseline.update=true.");
+            if (log != null) {
+                log.error("enforce.skip module={} reason=baseline-unreadable error={}", moduleId, e.toString());
+            }
+            return 1;
+        }
         if (update) {
             try {
                 baseline.update(root, moduleId, current);
@@ -143,7 +160,7 @@ public final class GuardrailEnforcer {
             return 0;
         }
 
-        if (!EnforcementBaseline.exists(root) || baseline.hasNothingFor(moduleId)) {
+        if (!recorded || baseline.hasNothingFor(moduleId)) {
             // Enforcing against a baseline that was never recorded would fail every build on the
             // day the option is switched on, which teaches people to switch it off again.
             messager.printMessage(Diagnostic.Kind.WARNING,

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/EnforcingModeEndToEndTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/EnforcingModeEndToEndTest.java
@@ -247,4 +247,28 @@ class EnforcingModeEndToEndTest {
 
         assertFalse(errors(added, "violation"), "adding a guarded element is not breaking one");
     }
+
+    /**
+     * A baseline that is there but cannot be decoded is not "nothing recorded". Treating it that
+     * way turned one Cp1252 byte from a Windows editor into a green enforcing build with a
+     * warning nobody reads; the gate must fail loudly on a file it could not parse.
+     */
+    @Test
+    void failsRatherThanPassesOnABaselineItCannotRead() throws IOException {
+        Files.createFile(root.resolve("CLAUDE.md"));
+        compile(CONTRACT_V1, "-Avibetags.baseline.update=true");
+        Path baseline = root.resolve(".vibetags-baseline");
+        byte[] bytes = Files.readAllBytes(baseline);
+        bytes[bytes.length - 2] = (byte) 0xE5; // 'å' as Cp1252 writes it: not valid UTF-8
+        Files.write(baseline, bytes);
+
+        List<Diagnostic<? extends JavaFileObject>> diagnostics =
+            compile(CONTRACT_V2_BROKEN, "-Avibetags.enforce=contract");
+
+        assertTrue(errors(diagnostics, "could not read .vibetags-baseline"),
+            "an unreadable baseline must stop the build, not be waved through");
+        assertTrue(errors(diagnostics, "-Avibetags.baseline.update=true"), "and must name the way out");
+        assertFalse(warns(diagnostics, "records nothing for module"),
+            "an unreadable file is not an unrecorded one");
+    }
 }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/internal/EnforcementBaselineTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/internal/EnforcementBaselineTest.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -45,7 +46,7 @@ class EnforcementBaselineTest {
     }
 
     @Test
-    void anAbsentBaselineLoadsEmptyAndReportsItself(@TempDir Path root) {
+    void anAbsentBaselineLoadsEmptyAndReportsItself(@TempDir Path root) throws IOException {
         assertFalse(EnforcementBaseline.exists(root));
         EnforcementBaseline baseline = EnforcementBaseline.load(root);
         assertTrue(baseline.hasNothingFor("core"));
@@ -101,6 +102,26 @@ class EnforcementBaselineTest {
             "a baseline that cannot be read approves nothing, and must not fail the compile");
         assertFalse(EnforcementBaseline.exists(root),
             "a directory is not a baseline file");
+    }
+
+    /**
+     * A file that is there but cannot be decoded is the other read-side failure: reading it as
+     * empty told the enforcer "nothing recorded", and the gate went quiet with a warning. One
+     * Cp1252 byte from a Windows editor is all it takes, so the reader must say so, not shrug.
+     */
+    @Test
+    void aBaselineWithAByteThatIsNotUtf8IsReportedRatherThanReadAsEmpty(@TempDir Path root)
+            throws IOException {
+        byte[] bytes = ("# format: 1\n"
+            + line("core", "AIContract", "com.example.Ledger#charge(int)", "charge(int):boolean")
+            + "\n").getBytes(StandardCharsets.UTF_8);
+        bytes[bytes.length - 2] = (byte) 0xE5;
+        Files.write(root.resolve(EnforcementBaseline.FILE_NAME), bytes);
+
+        assertThrows(IOException.class, () -> EnforcementBaseline.load(root),
+            "a corrupt baseline must not load as an empty one");
+        assertThrows(IOException.class, () -> EnforcementBaseline.exists(root),
+            "nor be reported as absent");
     }
 
     @Test


### PR DESCRIPTION
## The failure this prevents

`EnforcementBaseline.load` and `exists` caught every `IOException` and answered "empty" and "absent". `GuardrailEnforcer` then took the day-one path: a warning that the baseline records nothing for this module, zero violations, green build. One byte that is not UTF-8, the shape a Cp1252 save from a Windows editor leaves behind, was enough to switch `-Avibetags.enforce` off without anyone noticing. A skipped gate reported as a passed one.

Probe that found it (single-file program against `target/classes`, not committed): a `.vibetags-baseline` with `# format: 1`, one entry, and byte `0xE5` in the signature gave `exists()=false` and `hasNothingFor(mod)=true`.

## The change

- `EnforcementBaseline.load` and `exists` declare `IOException` and let a read or decode failure out. A directory in the file's place still reads as absent: nothing was read, nothing was mistaken (the existing test for that case is unchanged).
- `GuardrailEnforcer.enforce` catches it once, before both the update and the check branches, and reports a compile **error** naming the file and the way out (fix it, or delete it and record it again with `-Avibetags.baseline.update=true`). Logged as `enforce.skip reason=baseline-unreadable`.
- `docs/PROCESSOR.md` says an unreadable baseline is an error, not an unrecorded one; changelog entry under Unreleased.

## Verification

- `EnforcementBaselineTest#aBaselineWithAByteThatIsNotUtf8IsReportedRatherThanReadAsEmpty` and `EnforcingModeEndToEndTest#failsRatherThanPassesOnABaselineItCannotRead` were red before the fix (nothing thrown; no error diagnostic, only the "records nothing" warning) and are green after.
- `mvn verify` on `vibetags/`: 1869 tests, 0 failures; Error Prone, PMD, SpotBugs and Checkstyle clean. PMD flagged one `SimplifyBooleanReturns` on the first version of `exists`, fixed before commit.
- `pre-commit run --all-files` with the Checkstyle hook skipped (it needs Docker, which was not running; Maven's Checkstyle covered the same rules). Secrets, end-of-file and trailing-whitespace hooks pass.

## Out of scope, tracked

From the same review, none of them bug fixes:

- #547 Sweep, Mentat and Plandex render an undeclared subset of the 44 annotations
- #548 Three JSON string escapers exist; collapse them into one
- #549 A multi-line reason (Java text block) is emitted raw into Markdown bullets

The other four findings of that review (three `GuardrailFileWriter` hand-content losses and the enum-constant element path) were already fixed on main in #541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
