### PR TITLE
refactor: one JSON string escaper for the manifest, the locks report and the platform files

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -85,6 +85,15 @@ and the keys are current again. Consumers without annotated enum constants see n
   The one shape VibeTags ever wrote above its header was a single title line glued to it; only
   that is boilerplate now.
 
+### Changed
+
+- **One JSON string escaper instead of three.** `Json.quote` (the transitive manifest) and the
+  `.vibetags-locks` report now escape through `Escape.json`, the same code every JSON platform
+  file uses. The one observable difference is in the JSON platform files: a backspace or form
+  feed in an annotation value is now written as the RFC 8259 short escape rather than the
+  six-character `u` form the manifest already used; both decode identically, and `JsonTest`
+  round-trips both through the manifest parser. Closes #548.
+
 ## [1.3.0] - 2026-08-31
 
 A minor rather than a patch because `vibetags doctor` gains a capability (the Groovy

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/Json.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/Json.java
@@ -1,6 +1,7 @@
 package se.deversity.vibetags.processor.internal;
 
 import org.jspecify.annotations.Nullable;
+import se.deversity.vibetags.processor.internal.content.Escape;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -167,35 +168,17 @@ public final class Json {
         return value instanceof String s ? s : fallback;
     }
 
-    /** The JSON string literal for {@code value}, quotes included, escaped per RFC 8259. */
+    /**
+     * The JSON string literal for {@code value}, quotes included, escaped per RFC 8259, or the
+     * literal {@code null}. The escaping itself is {@link Escape#json}: one implementation for the
+     * manifest, the locks report and every JSON platform file, so a value that is safe in one is
+     * safe in all of them.
+     */
     public static String quote(@Nullable String value) {
         if (value == null) {
             return "null";
         }
-        StringBuilder sb = new StringBuilder(value.length() + 16);
-        sb.append('"');
-        for (int i = 0; i < value.length(); i++) {
-            char c = value.charAt(i);
-            switch (c) {
-                case '"'  -> sb.append("\\\"");
-                case '\\' -> sb.append("\\\\");
-                case '\n' -> sb.append("\\n");
-                case '\r' -> sb.append("\\r");
-                case '\t' -> sb.append("\\t");
-                case '\b' -> sb.append("\\b");
-                case '\f' -> sb.append("\\f");
-                default -> {
-                    // Control characters must be escaped; everything else (including non-ASCII) is
-                    // emitted as-is, because the manifest is written and read as UTF-8.
-                    if (c < 0x20) {
-                        sb.append(String.format("\\u%04x", (int) c));
-                    } else {
-                        sb.append(c);
-                    }
-                }
-            }
-        }
-        return sb.append('"').toString();
+        return '"' + Escape.json(value) + '"';
     }
 
     // ---------------------------------------------------------------------------------------

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/Escape.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/Escape.java
@@ -59,6 +59,8 @@ public final class Escape {
                 case '\n': sb.append("\\n"); break;
                 case '\r': sb.append("\\r"); break;
                 case '\t': sb.append("\\t"); break;
+                case '\b': sb.append("\\b"); break;
+                case '\f': sb.append("\\f"); break;
                 default:
                     if (c < 0x20) {
                         sb.append(String.format("\\u%04x", (int) c));

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/platforms/LocksReportRenderer.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/platforms/LocksReportRenderer.java
@@ -3,6 +3,7 @@ package se.deversity.vibetags.processor.internal.content.platforms;
 import se.deversity.vibetags.annotations.AILocked;
 import se.deversity.vibetags.processor.model.GuardrailModel;
 import se.deversity.vibetags.processor.model.SourceLocation;
+import se.deversity.vibetags.processor.internal.content.Escape;
 import se.deversity.vibetags.processor.internal.content.Platform;
 import se.deversity.vibetags.processor.internal.content.PlatformRenderer;
 import se.deversity.vibetags.processor.internal.content.RenderingContext;
@@ -48,39 +49,16 @@ public final class LocksReportRenderer implements PlatformRenderer {
             SourceLocation pos = model.lockedPosition(e);
 
             sb.append("{\"type\":\"locked\"")
-              .append(",\"element\":\"").append(escapeJson(e.path())).append('"')
+              .append(",\"element\":\"").append(Escape.json(e.path())).append('"')
               .append(",\"kind\":\"").append(e.kind().name()).append('"');
             if (pos != null) {
-                sb.append(",\"file\":\"").append(escapeJson(pos.file())).append('"')
+                sb.append(",\"file\":\"").append(Escape.json(pos.file())).append('"')
                   .append(",\"startLine\":").append(pos.startLine())
                   .append(",\"endLine\":").append(pos.endLine());
             }
-            sb.append(",\"reason\":\"").append(escapeJson(reason)).append('"')
+            sb.append(",\"reason\":\"").append(Escape.json(reason)).append('"')
               .append("}\n");
         }
         return sb.toString();
-    }
-
-    /** Minimal JSON string escaping: backslash, quote, and control characters. */
-    private static String escapeJson(String s) {
-        StringBuilder out = new StringBuilder(s.length() + 8);
-        for (int i = 0; i < s.length(); i++) {
-            char c = s.charAt(i);
-            switch (c) {
-                case '\\' -> out.append("\\\\");
-                case '"' -> out.append("\\\"");
-                case '\n' -> out.append("\\n");
-                case '\r' -> out.append("\\r");
-                case '\t' -> out.append("\\t");
-                default -> {
-                    if (c < 0x20) {
-                        out.append(String.format("\\u%04x", (int) c));
-                    } else {
-                        out.append(c);
-                    }
-                }
-            }
-        }
-        return out.toString();
     }
 }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/internal/JsonTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/internal/JsonTest.java
@@ -47,7 +47,7 @@ class JsonTest {
 
     @Test
     void roundTripsThroughQuote() {
-        String awkward = "line1\nline2\t\"quoted\" \\ back \u0001 control å";
+        String awkward = "line1\nline2\t\"quoted\" \\ back \u0001 control \b backspace \f feed å";
         Map<String, Object> parsed = Json.parseObject("{\"v\":" + Json.quote(awkward) + "}");
         assertEquals(awkward, parsed.get("v"),
             "anything quote() emits must read back identically, or a library's own words change "

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/internal/content/EscapeTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/internal/content/EscapeTest.java
@@ -63,9 +63,9 @@ class EscapeTest {
     @Test
     void json_escapesOtherControlCharsAsLowercaseUnicode() {
         assertEquals("\\u0000", Escape.json(ch(0x00)));
-        assertEquals("\\u0008", Escape.json(ch(0x08)));  // backspace — not a switch shorthand
+        assertEquals("\\b", Escape.json(ch(0x08)));  // backspace — the RFC 8259 short escape
         assertEquals("\\u000b", Escape.json(ch(0x0b)));  // vertical tab — not a switch shorthand
-        assertEquals("\\u000c", Escape.json(ch(0x0c)));  // form feed — not a switch shorthand
+        assertEquals("\\f", Escape.json(ch(0x0c)));  // form feed — the RFC 8259 short escape
         assertEquals("\\u001f", Escape.json(ch(0x1f)));  // last control char below 0x20
         // 0x20 (space) and above are ordinary and pass through unchanged
         assertEquals(" ", Escape.json(ch(0x20)));


### PR DESCRIPTION
## Why

Three implementations escaped JSON strings: `Escape.json` in the rendering layer, `Json.quote` for the transitive manifest, and a private copy inside `LocksReportRenderer`. They agreed on everything except how backspace and form feed are spelled, and two tests pinned that disagreement from opposite sides (`EscapeTest` wanted the six-character `u` form, `JsonTruncationTest` wanted the short escape). A fix to one escaper would have drifted from the other two with nothing to say so. Closes #548.

## The change

- `Json.quote` and `LocksReportRenderer` delegate to `Escape.json`; the private copy is deleted.
- `Escape.json` emits the RFC 8259 short escapes for backspace and form feed, so all JSON output agrees. Manifest bytes are unchanged. A JSON platform file changes only for an annotation value carrying one of those two characters; both spellings decode identically.
- Changelog entry under Unreleased.

## Verification

- `JsonTest#roundTripsThroughQuote` now carries a backspace and a form feed through `quote()` and the parser. `EscapeTest` pins the short escapes; `JsonTruncationTest`'s existing pin passes unchanged.
- First full `mvn verify` after the change failed on exactly that `JsonTruncationTest` pin, which is what made the disagreement visible; the second run after unifying is green: 1875 tests, 0 failures, one pre-existing skip in the release-script test, Error Prone, PMD, SpotBugs and Checkstyle clean.
- `pre-commit run --all-files` with the Docker-only Checkstyle hook skipped (Maven's Checkstyle covers it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
