### PR TITLE
fix: a locked constructor could change and the enforcing gate passed

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A locked constructor could change and the enforcing gate passed.** javac renders a constructor
+  under its class's simple name, so `public Foo(String)` and a method `public void Foo(String)` on
+  the same class produce one identical element path. `EnforcementBaseline` keyed on that path
+  alone, so the two collapsed into one entry: the baseline recorded whichever came second, the
+  other was never checked, and `CLAUDE.md` listed the path twice. Constructors are now keyed under
+  `<init>` in the baseline. The rendered path is unchanged — it is deliberately byte-identical to
+  javac's `toString()` because `action/locked-files` matches it against a PR diff.
+  **Upgrade note:** a project with a locked or contracted constructor should run one build with
+  `-Avibetags.baseline.update=true` and commit the result; until it does, that constructor is
+  reported as an approved entry with no matching element. (#552,
+  `EnforcingModeEndToEndTest.failsTheBuildWhenTheGuardedConstructorChanges`)
 - **A truncated module sidecar loaded as a valid one.** `Base64.getDecoder()` accepts cut-off
   input and the `.vibetags-mod-*` format carried no length or checksum, so a sidecar missing its
   last seven bytes still loaded, with the body truncated mid-text — and that half-sentence was

--- a/docs/PROCESSOR.md
+++ b/docs/PROCESSOR.md
@@ -158,6 +158,13 @@ encodes its parameter types, so changing `charge(String,double)` to `charge(Stri
 the approved entry rather than editing it. An approved entry with no matching element in the
 compilation is therefore a violation too — that covers renames, deletions and removed annotations.
 
+A constructor is recorded under `<init>`: javac renders one under its class's simple name, so
+`public Foo(String)` and a method `public void Foo(String)` on the same class produce one identical
+element path, and a baseline keyed on that alone held one of the two while the other was silently
+unenforceable (issue #552). Only the baseline key moves, and only for constructors — the rendered
+path stays byte-identical to javac's own `toString()`, because `action/locked-files` matches it
+against a pull request's diff and the granular rule files are named from it.
+
 Recording is safe to run in parallel. Every enforcing module of a reactor rewrites its own lines
 in the one root-level file from its own javac invocation, so `update()` re-reads the file and merges
 under an exclusive lock on `.vibetags-baseline.lock` (empty, gitignored, never read) and renames a

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/EnforcementBaseline.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/EnforcementBaseline.java
@@ -246,6 +246,30 @@ public final class EnforcementBaseline {
         return family + "\t" + path;
     }
 
+    /**
+     * The path a constructor is recorded under: the class's own name replaced by {@code <init>}.
+     *
+     * <p>javac renders a constructor under the enclosing class's simple name, so
+     * {@code public Foo(String)} and a method {@code public void Foo(String)} on the same class
+     * produce one identical element path. Keyed on that alone, the baseline held one of the two and
+     * the other was silently unenforceable — a locked constructor could change and the gate passed
+     * (issue #552).
+     *
+     * <p>Applied here rather than in {@code ElementNaming} on purpose: the rendered path is
+     * deliberately byte-identical to javac's own {@code toString()}, because
+     * {@code action/locked-files} matches it against a pull request's diff and the granular rule
+     * files are named from it, which {@code ElementNamingFormatParityTest} keeps true. Only the
+     * baseline key moves, and only for constructors, so no other entry changes.
+     */
+    public static String constructorPath(String path) {
+        int paren = path.indexOf('(');
+        if (paren < 0) {
+            return path;
+        }
+        int dot = path.lastIndexOf('.', paren);
+        return dot < 0 ? path : path.substring(0, dot + 1) + "<init>" + path.substring(paren);
+    }
+
     private static String key(String moduleId, String family, String path) {
         return moduleId + "\t" + familyAndPath(family, path);
     }

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailEnforcer.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailEnforcer.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import se.deversity.vibetags.annotations.AIContract;
 import se.deversity.vibetags.annotations.AILocked;
 import se.deversity.vibetags.annotations.AIPublicAPI;
+import se.deversity.vibetags.processor.model.ElementTag;
 import se.deversity.vibetags.processor.model.GuardrailModel;
 import se.deversity.vibetags.processor.model.TaggedElement;
 
@@ -122,7 +123,10 @@ public final class GuardrailEnforcer {
                 if (element.signature().isEmpty()) {
                     continue; // no provable shape (a package, or an element javac did not model)
                 }
-                String key = EnforcementBaseline.familyAndPath(family, element.path());
+                String path = element.kind() == ElementTag.CONSTRUCTOR
+                    ? EnforcementBaseline.constructorPath(element.path())
+                    : element.path();
+                String key = EnforcementBaseline.familyAndPath(family, path);
                 current.put(key, element.signature());
                 elementsByKey.put(key, element);
             }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/EnforcingModeEndToEndTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/EnforcingModeEndToEndTest.java
@@ -84,6 +84,40 @@ class EnforcingModeEndToEndTest {
     @TempDir
     Path root;
 
+    /**
+     * A constructor and a method whose name is the class name. javac prints both under the class's
+     * simple name, so their element paths are byte-identical and a path-keyed baseline holds only
+     * one of them (issue #552).
+     */
+    private static final String NAMESAKE_V1 = """
+        package com.example;
+
+        import se.deversity.vibetags.annotations.AILocked;
+
+        public class PaymentGateway {
+            @AILocked(reason = "constructor invariants are frozen")
+            public PaymentGateway(String customerId) {}
+
+            @AILocked(reason = "the legacy factory entry point is frozen")
+            public void PaymentGateway(String customerId) {}
+        }
+        """;
+
+    /** The constructor gains a parameter; the method is untouched. */
+    private static final String NAMESAKE_V2_CONSTRUCTOR_CHANGED = """
+        package com.example;
+
+        import se.deversity.vibetags.annotations.AILocked;
+
+        public class PaymentGateway {
+            @AILocked(reason = "constructor invariants are frozen")
+            public PaymentGateway(String customerId, double fee) {}
+
+            @AILocked(reason = "the legacy factory entry point is frozen")
+            public void PaymentGateway(String customerId) {}
+        }
+        """;
+
     @AfterEach
     void tearDown() {
         VibeTagsLogger.shutdown();
@@ -123,6 +157,32 @@ class EnforcingModeEndToEndTest {
 
         List<Diagnostic<? extends JavaFileObject>> second = compile(CONTRACT_V1, "-Avibetags.enforce=contract");
         assertFalse(errors(second, "violation"), "an unchanged signature must pass");
+    }
+
+    @Test
+    void aConstructorAndAMethodNamedLikeItsClassAreSeparateEntries() throws IOException {
+        Files.createFile(root.resolve("CLAUDE.md"));
+        compile(NAMESAKE_V1, "-Avibetags.baseline.update=true");
+
+        String content = Files.readString(root.resolve(".vibetags-baseline"));
+        long entries = content.lines().filter(line -> !line.isBlank() && !line.startsWith("#")).count();
+        assertEquals(2, entries,
+            "both guarded elements must be recorded; keyed on the path alone javac renders them "
+                + "identically, so one silently replaces the other and is left unenforceable:\n"
+                + content);
+    }
+
+    @Test
+    void failsTheBuildWhenTheGuardedConstructorChanges() throws IOException {
+        Files.createFile(root.resolve("CLAUDE.md"));
+        compile(NAMESAKE_V1, "-Avibetags.baseline.update=true");
+
+        List<Diagnostic<? extends JavaFileObject>> broken =
+            compile(NAMESAKE_V2_CONSTRUCTOR_CHANGED, "-Avibetags.enforce=locked");
+
+        assertTrue(errors(broken, "@AILocked violation"),
+            "the constructor shares its rendered path with the namesake method, and the method won "
+                + "the single entry, so changing the constructor was invisible to the gate");
     }
 
     @Test

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/internal/EnforcementBaselineTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/internal/EnforcementBaselineTest.java
@@ -191,6 +191,30 @@ class EnforcementBaselineTest {
     }
 
     @Test
+    void aConstructorIsKeyedUnderInitSoItCannotCollideWithANamesakeMethod() {
+        assertEquals("com.acme.Foo.<init>(java.lang.String)",
+            EnforcementBaseline.constructorPath("com.acme.Foo.Foo(java.lang.String)"),
+            "javac renders both a constructor and a method named like the class under that name, "
+                + "and one key for two elements leaves one of them unenforceable");
+        assertEquals("com.acme.Outer.Inner.<init>(int)",
+            EnforcementBaseline.constructorPath("com.acme.Outer.Inner.Inner(int)"),
+            "a nested class's constructor is keyed under the nested class, not the outer one");
+        assertEquals("com.acme.Foo.<init>(java.util.List<T>)",
+            EnforcementBaseline.constructorPath("com.acme.Foo.<T>Foo(java.util.List<T>)"),
+            "a generic constructor drops its type parameters here; two constructors of one class "
+                + "cannot share a parameter list, so the key stays unique");
+    }
+
+    @Test
+    void aPathWithNoParameterListIsLeftAlone() {
+        assertEquals("com.acme.Foo",
+            EnforcementBaseline.constructorPath("com.acme.Foo"),
+            "nothing that is not an executable may be rewritten by the constructor rule");
+        assertEquals("Foo(int)", EnforcementBaseline.constructorPath("Foo(int)"),
+            "a path with no package is returned unchanged rather than half-rewritten");
+    }
+
+    @Test
     void updateMergesWhatIsOnDiskNowRatherThanWhatWasLoaded(@TempDir Path root) throws IOException {
         // Both modules of a reactor load the baseline before either has written: the shape of
         // `mvn -T` with two enforcing modules recording against one shared root.


### PR DESCRIPTION
Closes #552. **Stacked on #565** (which is stacked on #564) — base branch is `fix/issue-553-sidecar-trailer`, so this diff shows only the constructor-key change. Merge #564, then #565, then this.

## The failure

javac renders a constructor under its class's simple name, so `public Foo(String)` and a method
`public void Foo(String)` on the same class produce one identical element path,
`com.acme.Foo.Foo(java.lang.String)`. `TaggedElement.equals` separates them by kind; the
path-keyed baseline does not. The two collapsed into one entry, the baseline recorded whichever the
collector reached second, and a build with `-Avibetags.enforce=locked` passed a changed constructor
without a word.

## The fix, and what it deliberately does not touch

Constructors are keyed under `<init>` **in the baseline only**. The rendered element path stays
byte-identical to javac's own `toString()`, which `ElementNamingFormatParityTest` exists to keep
true: `action/locked-files` matches that path against a pull request's diff, and the granular rule
files are named from it. Renaming it there would move every consumer's locks report and rule
filenames to fix a two-element collision.

So only constructors' baseline keys move, and only for projects that guard a constructor.

## Verification

Both tests were written first and failed:

- `aConstructorAndAMethodNamedLikeItsClassAreSeparateEntries` — `expected: <2> but was: <1>` entries.
- `failsTheBuildWhenTheGuardedConstructorChanges` — no violation reported, because the namesake
  method had won the single key.

Worth recording: the first fixture I wrote gave the two elements *different* parameter lists, and
both tests passed — there is no collision unless the parameter lists are identical. The fixture in
this PR is the one that actually reproduces the bug.

- `mvn test -Pe2e`: 2588 tests, 0 failures, 1 skipped.
- `mvn verify`: 0 Checkstyle violations, 0 SpotBugs findings, PMD and CPD clean.
- `EnforcementBaselineTest` adds the edge cases: a nested class's constructor, a generic
  constructor (its type parameters drop out of the key — two constructors of one class cannot share
  a parameter list, so it stays unique), and paths with no parameter list, which are left alone.

**Upgrade note** (in the CHANGELOG): a project with a locked or contracted constructor should run
one build with `-Avibetags.baseline.update=true` and commit the result. Until it does, that
constructor is reported as an approved entry with no matching element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RZi9NMZweDr8wHYCy8pjj
