### PR TITLE
docs: pin the action ref to a release tag, and say the CLI jar is not standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,10 @@ jbang se.deversity.vibetags:vibetags-cli:1.3.0 doctor
 The platform list and marker rules are read from `vibetags-processor` at runtime, so the CLI
 cannot drift from what the processor actually does.
 
+The jar itself is not standalone: it declares a `Main-Class` but carries no dependencies, so
+`java -jar vibetags-cli-1.3.0.jar` fails on the processor classes. jbang — or any launcher that
+resolves the Maven coordinate — is the supported way to run it.
+
 ## 🚀 Installation
 
 ### Prerequisites

--- a/USAGE.md
+++ b/USAGE.md
@@ -321,7 +321,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - uses: PIsberg/vibetags/action/locked-files@main
+      - uses: PIsberg/vibetags/action/locked-files@v1.3.0
 ```
 
 The action touches `.vibetags-locks` itself, rebuilds the PR head (so the report is never stale), and flags three things as inline PR annotations: edits inside a locked line range, removal of an `@AILocked` annotation line, and deletion of a file that contained `@AILocked`. Set `warn-only: true` to report without failing. See [action/locked-files/README.md](action/locked-files/README.md) for all inputs.
@@ -414,6 +414,11 @@ jbang se.deversity.vibetags:vibetags-cli:<version> init --list
 jbang se.deversity.vibetags:vibetags-cli:<version> init --platforms claude,cursor,claude_granular
 jbang se.deversity.vibetags:vibetags-cli:<version> doctor
 ```
+
+The launcher is not a convenience: the published `vibetags-cli` jar declares a `Main-Class` but
+carries no dependencies and no `Class-Path`, so `java -jar vibetags-cli-<version>.jar doctor` fails
+with a `NoClassDefFoundError` on the processor classes. Run it through jbang, or any other launcher
+that resolves the Maven coordinate.
 
 - **`init --list`** prints every opt-in platform key with the file it maps to, marking the
   ones already active in the current directory.

--- a/action/locked-files/README.md
+++ b/action/locked-files/README.md
@@ -34,7 +34,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - uses: PIsberg/vibetags/action/locked-files@main
+      - uses: PIsberg/vibetags/action/locked-files@v1.3.0
         with:
           build-command: mvn -B -q compile
 ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The `vibetags-cli` jar looked runnable and was not.** It declares a `Main-Class` but carries
+  no dependencies and no `Class-Path`, so `java -jar vibetags-cli-1.3.0.jar doctor` fails with
+  `NoClassDefFoundError: se/deversity/vibetags/processor/internal/ServiceRegistry`. Every
+  documented invocation goes through jbang, which resolves the dependencies, so the jar only
+  misled someone who downloaded it directly. README.md and USAGE.md now say the jar is not
+  standalone and that jbang — or any launcher that resolves the Maven coordinate — is the
+  supported way to run it. No shaded artifact is published. (#557)
+- **The documented `locked-files` action ref was `@main`.** `USAGE.md` and
+  `action/locked-files/README.md` are snippets a consumer copies verbatim into a workflow, in a
+  repository that SHA-pins every action it consumes itself, so the one action VibeTags publishes
+  was the only unpinned thing in the file. Both now pin `@v1.3.0`, `tools/set-version.sh` rewrites
+  the ref on every release, and `ReleaseScriptCoverageTest` fails if either snippet drifts back to
+  a floating ref — which the version-coverage test alone could not catch, since `@main` states no
+  version at all. (#559)
 - **A parallel reactor recording enforcement baselines lost a module's approvals, or failed the
   build.** `mvn -T` with two enforcing modules under `-Avibetags.baseline.update=true` had both
   merge into the snapshot they loaded before either wrote, so the second rename erased the first

--- a/tools/set-version.sh
+++ b/tools/set-version.sh
@@ -169,6 +169,22 @@ replace_gradle_vibetags_refs() {
     echo "  updated ${file#"$ROOT_DIR"/} (se.deversity.vibetags refs only)"
 }
 
+# Scoped edit for the composite action's `uses:` ref in the docs. A consumer copies these
+# snippets verbatim into a workflow, and this repository SHA- or tag-pins every action it
+# consumes itself; @main hands them a ref that changes under them, including behaviour
+# changes like the guard that now fails when it finds no report (#559). Anchored on the
+# action path, so a version elsewhere on the line is left alone.
+replace_action_ref() {
+    file="$1"
+    if [ ! -f "$file" ]; then
+        echo "warning: $file not found, skipping" >&2
+        return 0
+    fi
+    sed -i.bak -E "s#(PIsberg/vibetags/action/locked-files@v)$OLD_ESCAPED#\1$NEW_VERSION#g" "$file"
+    rm -f "$file.bak"
+    echo "  updated ${file#"$ROOT_DIR"/} (locked-files action ref only)"
+}
+
 # The one authoritative edit — <revision> only, so a third-party version pin that happens to
 # equal $OLD_VERSION (jspecify.version has collided with it before) is never touched.
 replace_xml_property "$PARENT_POM" "revision"
@@ -204,6 +220,14 @@ for rel in \
     .claude/skills/vibetags-usage/SKILL.md \
 ; do
     replace_in_file "$ROOT_DIR/$rel"
+done
+
+# The action's `uses:` ref, which no other pattern here matches.
+for rel in \
+    USAGE.md \
+    action/locked-files/README.md \
+; do
+    replace_action_ref "$ROOT_DIR/$rel"
 done
 
 echo "Done."

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseScriptCoverageTest.java
@@ -232,6 +232,38 @@ class ReleaseScriptCoverageTest {
                 + "change:\n  " + String.join("\n  ", missing));
     }
 
+    /**
+     * The composite action's {@code uses:} ref in the docs names a release tag, never
+     * {@code @main}.
+     *
+     * <p>Both files are snippets a consumer copies verbatim into a workflow, and this repository
+     * SHA-pins every action it consumes itself. A floating ref changes under whoever copied it —
+     * including behaviour changes such as the guard that now fails when it finds no report, which
+     * a pinned ref lets them adopt on their own schedule (issue #559).
+     *
+     * <p>Pinned to the <em>current</em> version on purpose: that is what {@code set-version.sh}
+     * rewrites, and what {@link #everyVersionCarryingFileIsInTheScript} then keeps in the script.
+     * Reverting either snippet to {@code @main} would satisfy that test — nothing states a version
+     * any more — and only this one catches it.
+     */
+    @Test
+    @DisplayName("the documented action ref is pinned to this release's tag")
+    void theDocumentedActionRefIsPinnedToThisReleasesTag() throws IOException {
+        String version = revision();
+        assumeTrue(version != null && !version.isBlank(), "could not read <revision>; skipping");
+
+        for (String rel : List.of("USAGE.md", "action/locked-files/README.md")) {
+            Path doc = REPO_ROOT.resolve(rel);
+            assumeTrue(Files.isRegularFile(doc), rel + " not reachable; skipping");
+            String text = Files.readString(doc, StandardCharsets.UTF_8);
+            assumeTrue(text.contains("PIsberg/vibetags/action/locked-files@"),
+                rel + " no longer shows the action; skipping");
+            assertTrue(text.contains("PIsberg/vibetags/action/locked-files@v" + version),
+                rel + " must pin the locked-files action at @v" + version + ". A consumer copies "
+                    + "this snippet verbatim, and an unpinned ref changes under them.");
+        }
+    }
+
     // -----------------------------------------------------------------------
 
     /**


### PR DESCRIPTION
Closes #559 and #557 — two corrections to snippets a consumer copies verbatim. Based on `main`, independent of the #564/#565/#566 stack.

## The action ref was `@main` (#559)

`USAGE.md` and `action/locked-files/README.md` showed
`uses: PIsberg/vibetags/action/locked-files@main`, in a repository that SHA-pins every action it
consumes and whose Scorecard badge depends on pinning. A floating ref changes under whoever copied
it — including behaviour changes like the guard that now fails when it finds no report, which a
pinned ref lets them adopt on their own schedule.

- Both snippets pin `@v1.3.0`.
- `tools/set-version.sh` rewrites the ref on every release, through a pattern anchored on the
  action path so a version elsewhere on the line is untouched.
- `ReleaseScriptCoverageTest.theDocumentedActionRefIsPinnedToThisReleasesTag` fails if either
  snippet drifts back to a floating ref. The existing version-coverage test cannot catch that:
  `@main` states no version, so the file simply drops out of its scope.

Verified: reverting `USAGE.md` to `@main` fails the new assertion; `sh tools/set-version.sh 1.3.1`
rewrites both snippets to `@v1.3.1` and changes nothing else in them.

## The CLI jar looked runnable and was not (#557)

Confirmed by running it, not by reading the issue:

```
$ unzip -p vibetags-cli-1.3.0.jar META-INF/MANIFEST.MF
Main-Class: se.deversity.vibetags.cli.Main        # and no Class-Path

$ java -jar vibetags-cli-1.3.0.jar doctor
vibetags doctor — C:\dev\private\vibetags
build tool:      none recognised (no pom.xml or build.gradle[.kts])
Exception in thread "main" java.lang.NoClassDefFoundError: se/deversity/vibetags/processor/internal/ServiceRegistry
```

Every documented invocation goes through jbang, which resolves the dependencies, so the jar only
misleads someone who downloads it directly. Per the decision on the issue, this is fixed in the
docs rather than by publishing a shaded `-all` artifact — a shaded jar changes what Maven Central
carries for `vibetags-cli` on every future release. README.md and USAGE.md now say the jar is not
standalone and name jbang, or any Maven-resolving launcher, as the supported way to run it.

This half is documentation of measured behaviour and ships without a test of its own; a
prose-matching assertion would pin the wording, not the fact.

## Verification

- `mvn test -Pe2e`: 2581 tests, 0 failures, 1 skipped.
- `ReleaseScriptCoverageTest`: 3 tests, 1 skipped — the round-trip script test needs a POSIX shell
  and skips on Windows; it runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RZi9NMZweDr8wHYCy8pjj
