### PR TITLE
fix: a sibling's edit inside one filesystem tick was skipped by the short-circuit

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A sibling's edit inside one filesystem tick was skipped by the reactor short-circuit.** The
+  sidecar stamp that gates the fingerprint short-circuit folded mtimes only, and timestamp
+  granularity is 1 s on HFS+ and 2 s on FAT while a reactor writes several sidecars a second. Two
+  saves inside one tick left the stamp unchanged, so the compiling module short-circuited past the
+  merge and shipped the previous content until something else moved a timestamp. The stamp now
+  folds each sidecar's name, mtime, size and content. (part of #556,
+  `MultiModuleAggregationTest.computeSidecarStamp_changesWhenContentChangesUnderAnUnchangedMtime`)
 - **A module could vanish from the merged guardrails with no trace in the log.**
   `ModuleSidecar.readAll` deleted a version-1, headerless or corrupt sidecar and skipped a
   future-version one without a single event: the class held no logger, so the only symptom was a

--- a/docs/PROCESSOR.md
+++ b/docs/PROCESSOR.md
@@ -188,6 +188,13 @@ output without being part of the annotation fingerprint, so they are bound separ
 context* (`# context: <hex>` in the same cache file, via `WriteCache.bindContext`); a stored
 fingerprint recorded under a different context is treated as absent and the build regenerates.
 
+In a reactor the short-circuit is also gated on a *sidecar stamp* (`# sidecar-stamp:` in the same
+file): a fold over every `.vibetags-mod-*` file's name, mtime, size and content. Content is in there
+because filesystem timestamp granularity is 1 s on HFS+ and 2 s on FAT while a reactor writes
+several sidecars a second — an mtime-only stamp left two saves inside one tick indistinguishable, so
+a sibling's edit stayed out of this module's output until something else moved a timestamp
+(issue #556). It costs one pass over files the same build reads again in `ModuleSidecar.readAll`.
+
 On the next compile, if the fingerprint still matches AND every previously written file is
 byte-stable on disk (size + mtime unchanged), the entire generate phase is skipped: no
 `GuardrailContentBuilder.build()`, no per-file compares, no writes. The two-part guard means a

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
@@ -1688,20 +1688,46 @@ public final class ModuleSidecar {
     }
 
     /**
-     * Computes a lightweight stamp over all sidecar mtimes. A change in any sibling sidecar
-     * changes the stamp, invalidating the fingerprint short-circuit so this module regenerates.
+     * A stamp over every sidecar in {@code root}: its name, mtime, size and content. A change in
+     * any sibling changes the stamp, which invalidates the fingerprint short-circuit so this module
+     * regenerates against the new merge.
+     *
+     * <p>Content is folded in, not just the mtime. Filesystem timestamp granularity is 1 s on
+     * HFS+ and 2 s on FAT, and a reactor writes several sidecars per second: two saves inside one
+     * tick left the stamp unchanged, so the sibling's edit stayed out of this module's output until
+     * something else happened to move a timestamp (issue #556). The name is folded in for the same
+     * reason — a module renamed with no edit is a different set of sidecars, and mtimes alone
+     * cannot see that.
+     *
+     * <p>The read this costs is one pass over files the same build reads again in
+     * {@link #readAll(Path)}, and a sidecar is the compressed form of one module's guardrails, not
+     * a source tree.
      */
     public static long computeSidecarStamp(Path root) {
         long stamp = 0L;
         for (Path p : listPaths(root)) {
             try {
-                stamp = 31L * stamp + Files.getLastModifiedTime(p).toMillis();
+                stamp = 31L * stamp + fileName(p).hashCode();
+                java.nio.file.attribute.BasicFileAttributes attrs =
+                    Files.readAttributes(p, java.nio.file.attribute.BasicFileAttributes.class);
+                stamp = 31L * stamp + attrs.lastModifiedTime().toMillis();
+                stamp = 31L * stamp + attrs.size();
+                stamp = 31L * stamp + contentStamp(p);
             } catch (IOException ignored) {
                 // A file that vanished between listing and stat contributes nothing to the stamp.
                 // That is correct: it is not there, so it is not part of this round of state.
             }
         }
         return stamp;
+    }
+
+    /** 64-bit FNV-1a over a sidecar's bytes. Not cryptographic; it only has to notice an edit. */
+    private static long contentStamp(Path sidecar) throws IOException {
+        long hash = 0xcbf29ce484222325L;
+        for (byte b : Files.readAllBytes(sidecar)) {
+            hash = (hash ^ (b & 0xffL)) * 0x100000001b3L;
+        }
+        return hash;
     }
 
     // -----------------------------------------------------------------------

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/MultiModuleAggregationTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/MultiModuleAggregationTest.java
@@ -244,6 +244,37 @@ class MultiModuleAggregationTest {
         assertNotEquals(stamp0, stamp1, "Stamp should change after a sidecar is written");
     }
 
+    /**
+     * Two saves the filesystem cannot tell apart in time.
+     *
+     * <p>Timestamp granularity is 1 s on HFS+ and 2 s on FAT, and a reactor writes several
+     * sidecars a second, so this is reachable on a real build rather than only in a test that
+     * forces the mtimes equal: the sibling's edit stayed out of this module's output until
+     * something else moved a timestamp (issue #556). The mtimes are pinned here so the case is
+     * deterministic on every filesystem, including the ones with millisecond resolution.
+     */
+    @Test
+    void computeSidecarStamp_changesWhenContentChangesUnderAnUnchangedMtime(@TempDir Path root)
+            throws IOException {
+        ModuleSidecar first = new ModuleSidecar("_root_", "");
+        first.putBody("cursor", "the rules as they were");
+        first.save(root);
+        java.nio.file.attribute.FileTime frozen =
+            java.nio.file.attribute.FileTime.fromMillis(1_700_000_000_000L);
+        java.nio.file.Path file = root.resolve(".vibetags-mod-_root_");
+        Files.setLastModifiedTime(file, frozen);
+        long before = ModuleSidecar.computeSidecarStamp(root);
+
+        ModuleSidecar edited = new ModuleSidecar("_root_", "");
+        edited.putBody("cursor", "the rules after the edit");
+        edited.save(root);
+        Files.setLastModifiedTime(file, frozen);
+
+        assertNotEquals(before, ModuleSidecar.computeSidecarStamp(root),
+            "a sibling's edit inside one filesystem tick left the stamp unchanged, so this "
+                + "module short-circuited past the merge and shipped the previous content");
+    }
+
     // -----------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Part of #556 — the half that needed no decision. **Stacked on #568**, base branch `fix/issue-555-sidecar-log-reasons`. The issue stays open for the other half; see below.

## The failure

`computeSidecarStamp` folded sidecar mtimes only. Filesystem timestamp granularity is 1 s on HFS+
and 2 s on FAT, and a reactor writes several sidecars a second, so two saves inside one tick left
the stamp unchanged. The compiling module then matched its stored `# sidecar-stamp`,
short-circuited past the merge entirely, and shipped the previous content — until something else
happened to move a timestamp.

## The fix

The stamp folds each sidecar's **name, mtime, size and content**.

- Name, because a module renamed with no edit is a different set of sidecars and mtimes cannot see
  that.
- Content, because it is the only input that survives a coarse clock. 64-bit FNV-1a; it only has to
  notice an edit.

Cost: one pass over files the same build reads again in `ModuleSidecar.readAll`. A sidecar is one
module's guardrails in compressed form, not a source tree.

## Verification

- `computeSidecarStamp_changesWhenContentChangesUnderAnUnchangedMtime` was written first and
  failed, both stamps equal at `1700000000000`. The mtimes are pinned equal on purpose so the case
  is deterministic on filesystems with millisecond resolution too — on HFS+ or FAT it happens on
  its own.
- `mvn test -Pe2e`: 2592 tests, 0 failures, 1 skipped. `TransitiveFingerprintTest`,
  `FingerprintShortCircuitTest`, `ProjectLifecycleEndToEndTest` and the reactor tests all pass —
  they are what would notice a stamp that changed when it should not.
- `mvn verify`: 0 Checkstyle violations, 0 SpotBugs findings, PMD and CPD clean.

## What is deliberately not in this PR

The other half of #556: `.vibetags-cache` carries one `# fingerprint` and one `# context` header
per root, so each module's flush overwrites its sibling's and only the module that flushed last can
ever short-circuit. Fixing it needs `WriteCache` to know the compiling module's id, which is
resolved *inside* `AIGuardrailProcessor.generateFiles()` — a `<locked_files>` element. That is
either a second locked-file edit (adding a statement, not just an argument) or the per-module cache
layout the issue itself calls a layout decision with fingerprint implications. Left for that
decision rather than taken as a drive-by; #556 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RZi9NMZweDr8wHYCy8pjj
