### PR TITLE
ci: build each change once, and cancel what a new push supersedes (#573)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,27 @@ name: Build and Test
 
 on:
   push:
-    branches: [ main, master, 'feature/*', 'fix/*', 'chore/*', 'docs/*', 'ci/*', 'release/*' ]
+    # main and master only. A branch with an open PR was building the whole matrix
+    # twice - once for the push, once for the pull_request - and the two runs were
+    # identical except Locked Files Guard, which skips on a push because it needs a PR
+    # base to diff against. The pull_request trigger below is what tests a branch, and
+    # it is deliberately unfiltered so a stacked PR is tested too. The cost of this
+    # narrowing, stated plainly: a branch pushed with no PR open runs nothing (#573).
+    branches: [ main, master ]
   # Deliberately unfiltered: a pull request is a request to review a change, so it is tested
   # whichever branch it targets. Restricting this to main meant a stacked PR — one targeting the
   # branch it was built on, so its diff shows only its own work — ran no tests at all, and its PR
   # page was indistinguishable from one whose tests had passed.
   pull_request:
+
+concurrency:
+  # One run per workflow per ref. cancel-in-progress everywhere except main: a superseded
+  # push has nothing left to say, while a run on main is the record of main's health and
+  # must finish. Without this a second push queued a full copy behind the run it replaced
+  # and both completed, which is half of why wall-clock tripled while every job kept its
+  # speed (#573).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,15 @@ on:
   schedule:
     - cron: "0 0 * * 1"
 
+concurrency:
+  # One run per workflow per ref. cancel-in-progress everywhere except main: a superseded
+  # push has nothing left to say, while a run on main is the record of main's health and
+  # must finish. Without this a second push queued a full copy behind the run it replaced
+  # and both completed, which is half of why wall-clock tripled while every job kept its
+  # speed (#573).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -19,6 +19,15 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review]
 
+concurrency:
+  # One run per workflow per ref. cancel-in-progress everywhere except main: a superseded
+  # push has nothing left to say, while a run on main is the record of main's health and
+  # must finish. Without this a second push queued a full copy behind the run it replaced
+  # and both completed, which is half of why wall-clock tripled while every job kept its
+  # speed (#573).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -12,6 +12,15 @@ on:
   workflow_dispatch:
 
 # Least privilege at the top level; the commit/PR job opts into the writes it needs.
+concurrency:
+  # One run per workflow per ref. cancel-in-progress everywhere except main: a superseded
+  # push has nothing left to say, while a run on main is the record of main's health and
+  # must finish. Without this a second push queued a full copy behind the run it replaced
+  # and both completed, which is half of why wall-clock tripled while every job kept its
+  # speed (#573).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: ["main"]
 
+concurrency:
+  # One run per workflow per ref. cancel-in-progress everywhere except main: a superseded
+  # push has nothing left to say, while a run on main is the record of main's health and
+  # must finish. Without this a second push queued a full copy behind the run it replaced
+  # and both completed, which is half of why wall-clock tripled while every job kept its
+  # speed (#573).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -23,6 +23,15 @@ on:
       - '**/gradle/wrapper/gradle-wrapper.properties'
       - '.github/workflows/gradle-wrapper-validation.yml'
 
+concurrency:
+  # One run per workflow per ref. cancel-in-progress everywhere except main: a superseded
+  # push has nothing left to say, while a run on main is the record of main's health and
+  # must finish. Without this a second push queued a full copy behind the run it replaced
+  # and both completed, which is half of why wall-clock tripled while every job kept its
+  # speed (#573).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -7,6 +7,15 @@ name: Mutation Testing (PIT)
 on:
   workflow_dispatch:
 
+concurrency:
+  # One run per workflow per ref. cancel-in-progress everywhere except main: a superseded
+  # push has nothing left to say, while a run on main is the record of main's health and
+  # must finish. Without this a second push queued a full copy behind the run it replaced
+  # and both completed, which is half of why wall-clock tripled while every job kept its
+  # speed (#573).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/nightly-perf.yml
+++ b/.github/workflows/nightly-perf.yml
@@ -18,6 +18,15 @@ on:
     - cron: '17 3 * * 1'
   workflow_dispatch:
 
+concurrency:
+  # One run per workflow per ref. cancel-in-progress everywhere except main: a superseded
+  # push has nothing left to say, while a run on main is the record of main's health and
+  # must finish. Without this a second push queued a full copy behind the run it replaced
+  # and both completed, which is half of why wall-clock tripled while every job kept its
+  # speed (#573).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -15,6 +15,15 @@ on:
     branches: ["main"]
 
 # Declare default permissions as read only.
+concurrency:
+  # One run per workflow per ref. cancel-in-progress everywhere except main: a superseded
+  # push has nothing left to say, while a run on main is the record of main's health and
+  # must finish. Without this a second push queued a full copy behind the run it replaced
+  # and both completed, which is half of why wall-clock tripled while every job kept its
+  # speed (#573).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
+
 permissions: read-all
 
 jobs:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI stopped building every branch twice and queueing behind itself.** Wall-clock per run
+  went from 6.5-10.7 minutes to 25-38 while every job kept its speed: on run 33791512492,
+  `JVM-Language Corpus` waited 24.6 minutes to run for 4.0. Two causes. `build.yml` fired on
+  both `push` to the branch prefixes and `pull_request`, so a branch with an open PR ran the
+  whole matrix twice - identically, except `Locked Files Guard`, which skips on a push
+  because it needs a PR base to diff against; the push trigger is now `main` and `master`
+  only, and the deliberately unfiltered `pull_request` trigger is what tests a branch. And
+  nine workflows had no `concurrency` group, so a second push queued a full copy behind the
+  run it superseded and both finished; they all have one now, cancelling in progress
+  everywhere except `main` and `master`. `publish.yml` is excluded on purpose - cancelling a
+  release mid-flight is worse than queueing behind it.
+
+  The cost, stated plainly: a branch pushed with no PR open now runs nothing. `docs/WORKFLOW.md`
+  said "PRs to `main`/`master`", which the unfiltered trigger never matched, and now describes
+  what the file actually does. (#573)
+
 ### Added
 
 - **CI runs the companion CLI against a real example.** `doctor --dir examples/groovy` must exit 1

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -6,7 +6,7 @@ This document describes what happens during CI builds in `.github/workflows/`. T
 
 | Workflow | File | Trigger |
 |---|---|---|
-| Build and Test | `build.yml` | Push to `main`/`master`/`feature/*`/`fix/*`, PRs to `main`/`master` |
+| Build and Test | `build.yml` | Push to `main`/`master`; every pull request, whichever branch it targets |
 | CodeQL | `codeql.yml` | Push/PR to `main`, weekly cron (Mondays 00:00 UTC) |
 | Dependency Review | `dependency-review.yml` | Pull requests |
 | Scorecard | `scorecards.yml` | Push to `main`, branch-protection-rule, weekly cron (Tuesdays 07:20 UTC) |
@@ -29,6 +29,20 @@ All third-party actions are pinned by full commit SHA with the version as a trai
 ## 1. Build and Test (`build.yml`)
 
 The main CI workflow. Jobs run in parallel except `load-tests`, which waits on `build-maven`.
+
+''It runs once per change, not twice.'' The `push` trigger is `main` and `master` only; every
+branch is tested through the `pull_request` trigger, which is deliberately unfiltered so a
+stacked PR - one targeting the branch it was built on - is tested too. Until #573 the push
+trigger also listed the branch prefixes, so a branch with an open PR ran the whole matrix
+twice, identically except `Locked Files Guard`, which skips on a push because it needs a PR
+base to diff against. The cost of the narrowing, stated plainly: a branch pushed with no PR
+open runs nothing.
+
+''A superseded run is cancelled.'' Every workflow except `publish.yml` and `dependency-review.yml`
+now declares a `concurrency` group keyed on the ref, cancelling in progress everywhere except
+`main` and `master` - a run there is the record of that branch's health and must finish.
+`publish.yml` is excluded on purpose: cancelling a release mid-flight is worse than queueing
+behind it.
 
 ### Job: `build-maven`
 


### PR DESCRIPTION
Fixes #573.

## The measurement

Run 33791512492, per job — queue wait against run time:

| Job | queued | ran |
|---|---:|---:|
| JVM-Language Corpus | **24.6 min** | 4.0 min |
| Maven Build (JDK 25) | **22.6 min** | 3.9 min |
| Non-javac Compiler Degradation (ECJ) | **21.5 min** | 2.0 min |
| Third-Party Corpus | **20.6 min** | 3.4 min |

Every job runs in 0.6–6.8 minutes. Wall-clock went from 6.5–10.7 minutes to 25–38, purely on
queue wait, with 13 runs waiting at once.

## What changed

**`build.yml` builds each change once.** The `push` trigger was `main`, `master` and six branch
prefixes *and* `pull_request`, so a branch with an open PR ran the whole matrix twice — identically,
except `Locked Files Guard`, which skips on a push because it needs a PR base to diff against. Push
is now `main`/`master` only. The `pull_request` trigger stays deliberately unfiltered, which is what
tests a stacked PR — the case the existing comment protects.

**A superseded run is cancelled.** Nine workflows had no `concurrency` group, so a second push
queued a full copy behind the run it replaced and both finished. All nine have one now, cancelling
in progress everywhere except `main`/`master`, where a run is the record of that branch's health and
must finish. `publish.yml` is excluded on purpose: cancelling a release mid-flight is worse than
queueing behind it.

## What it costs

A branch pushed with **no PR open** now runs nothing. That is the whole cost, and it is the reason
the trigger was written the way it was — so it is in the commit message, in `docs/WORKFLOW.md`, and
here rather than left for someone to discover.

## Docs corrected in the same change

`docs/WORKFLOW.md` said `build.yml` runs on "PRs to `main`/`master`". The trigger has been
unfiltered for as long as the comment above it has explained why, so the doc described a workflow
that did not exist.

## Verification

- All thirteen workflow files parse.
- `CodeQlActionVersionParityTest` and `EvalsNodePinTest`, the two tests that read these files, pass.
- The real proof is this PR's own run count: one per push, not two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVwoJARmbKjxH2WRy4AN47
