### PR TITLE
release: 1.3.1

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.3.0
+version: 1.3.1
 ---
 
 # VibeTags Usage Guide
@@ -27,7 +27,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
     <dependency>
         <groupId>se.deversity.vibetags</groupId>
         <artifactId>vibetags-annotations</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </dependency>
 </dependencies>
 
@@ -41,7 +41,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.3.0</version>
+                        <version>1.3.1</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -63,8 +63,8 @@ the whole processor and its SLF4J/Logback dependencies on your compile classpath
 
 ```groovy
 dependencies {
-    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.3.0'
-    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.0'
+    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.3.1'
+    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.1'
 }
 ```
 
@@ -221,7 +221,7 @@ though the build is green.
 Every way this setup fails is silent, so check rather than assume:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.3.0 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.3.1 doctor
 ```
 
 Or by hand, in the order things go wrong:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.1</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.3.0</version>
+                        <version>1.3.1</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -94,7 +94,7 @@ touch CLAUDE.md .cursorrules AGENTS.md   # Claude, Cursor, Codex CLI — add whi
 Or let the companion CLI do it (and `vibetags doctor` checks your setup afterwards):
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.3.0 init --platforms claude,cursor
+jbang se.deversity.vibetags:vibetags-cli:1.3.1 init --platforms claude,cursor
 ```
 
 **3. Annotate your first class:**
@@ -123,8 +123,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -170,8 +170,8 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.0"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.0"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.1"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.1"))
 
     compileOnly("se.deversity.vibetags:vibetags-annotations")
     kapt("se.deversity.vibetags:vibetags-processor")
@@ -502,8 +502,8 @@ build-tool wiring, active platforms, and `VIBETAGS-START`/`END` marker integrity
 installing anything:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.3.0 init --list
-jbang se.deversity.vibetags:vibetags-cli:1.3.0 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.3.1 init --list
+jbang se.deversity.vibetags:vibetags-cli:1.3.1 doctor
 ```
 
 The platform list and marker rules are read from `vibetags-processor` at runtime, so the CLI
@@ -536,7 +536,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.1</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -561,7 +561,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.3.0</version>
+                        <version>1.3.1</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -577,8 +577,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -592,15 +592,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.0'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.0'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.1'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.1'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/USAGE.md
+++ b/USAGE.md
@@ -321,7 +321,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - uses: PIsberg/vibetags/action/locked-files@v1.3.0
+      - uses: PIsberg/vibetags/action/locked-files@v1.3.1
 ```
 
 The action touches `.vibetags-locks` itself, rebuilds the PR head (so the report is never stale), and flags three things as inline PR annotations: edits inside a locked line range, removal of an `@AILocked` annotation line, and deletion of a file that contained `@AILocked`. Set `warn-only: true` to report without failing. See [action/locked-files/README.md](action/locked-files/README.md) for all inputs.

--- a/action/locked-files/README.md
+++ b/action/locked-files/README.md
@@ -34,7 +34,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - uses: PIsberg/vibetags/action/locked-files@v1.3.0
+      - uses: PIsberg/vibetags/action/locked-files@v1.3.1
         with:
           build-command: mvn -B -q compile
 ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-09-04
+
+### Upgrading
+
+Two things change under you on the first build after this upgrade. Neither is a code change
+you have to make; both are one regeneration you have to commit.
+
+1. **Guardrail files gain reason text and reflow.** A string member of an annotation that
+   spanned lines in the source used to render broken across lines, and on some platforms
+   its reason line did not render at all. Both are fixed, so regenerated guardrail files
+   differ from what is committed. Measured on the consumer sweep for this release: 3 files
+   in one consumer, 12 in another, 0 in a third. If your CI diffs regenerated guardrails -
+   and at least one consumer does - it fails until you rebuild and commit the result.
+
+2. **A locked or contracted constructor needs its baseline re-recorded.** Constructors are
+   now keyed under `<init>` in `.vibetags-baseline`, because a constructor and a method named
+   like its class rendered to one identical element path and collapsed into a single entry
+   - the baseline recorded whichever came second and the other was never checked. Run one
+   build with `-Avibetags.baseline.update=true` and commit the result. Until you do, that
+   constructor is reported as an approved entry with no matching element.
+
+The rendered element path is deliberately unchanged - it is byte-identical to javac's
+`toString()` because `action/locked-files` matches it against a PR diff.
+
 ### Changed
 
 - **CI stopped building every branch twice and queueing behind itself.** Wall-clock per run

--- a/examples/all-tiers/pom.xml
+++ b/examples/all-tiers/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.3.0</vibetags.bom.version>
+    <vibetags.bom.version>1.3.1</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/basic/build.gradle
+++ b/examples/basic/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/examples/basic/pom.xml
+++ b/examples/basic/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.3.0</vibetags.bom.version>
+        <vibetags.bom.version>1.3.1</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/examples/enforcing/pom.xml
+++ b/examples/enforcing/pom.xml
@@ -25,7 +25,7 @@
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. -->
-        <vibetags.bom.version>1.3.0</vibetags.bom.version>
+        <vibetags.bom.version>1.3.1</vibetags.bom.version>
         <!-- Enforcement is ON for every build of this example: the three provable families
              must match the committed .vibetags-baseline or compilation fails. That is the
              point of the example, so it is not hidden behind a profile. -->

--- a/examples/gradle-composite/app/build.gradle
+++ b/examples/gradle-composite/app/build.gradle
@@ -16,8 +16,8 @@ repositories {
 
 dependencies {
     implementation 'se.deversity.vibetags.example:vibetags-example-gradle-composite-lib'
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-composite/lib/build.gradle
+++ b/examples/gradle-composite/lib/build.gradle
@@ -15,8 +15,8 @@ repositories {
 }
 
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-flat/app/build.gradle
+++ b/examples/gradle-flat/app/build.gradle
@@ -21,8 +21,8 @@ allprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-multimodule/build.gradle
+++ b/examples/gradle-multimodule/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-shared-buildfile/build.gradle
+++ b/examples/gradle-shared-buildfile/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.apache.groovy:groovy:5.1.0'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
 
     // Annotations on compile, processor on the annotation-processor path only.
     compileOnly 'se.deversity.vibetags:vibetags-annotations'

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and kapt configurations so neither needs an explicit version.
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.0"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.0"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.1"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.1"))
 
     // Annotations on compile, processor on the kapt path only — keeps the processor's
     // slf4j/logback off the consumer's compile classpath. compileOnly is enough:

--- a/examples/multimodule-indexed/pom.xml
+++ b/examples/multimodule-indexed/pom.xml
@@ -37,7 +37,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.3.0</vibetags.bom.version>
+    <vibetags.bom.version>1.3.1</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/examples/multimodule/pom.xml
+++ b/examples/multimodule/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.3.0</vibetags.bom.version>
+    <vibetags.bom.version>1.3.1</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/scala/build.gradle
+++ b/examples/scala/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.scala-lang:scala-library:2.13.18'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.3.0</vibetags.bom.version>
+        <vibetags.bom.version>1.3.1</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.3.0'
+version = '1.3.1'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.3.0'
+            version = '1.3.1'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -43,8 +43,8 @@
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.0'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.0'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.1'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.1'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.3.0')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.0')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-cli/pom.xml
+++ b/vibetags-cli/pom.xml
@@ -28,7 +28,7 @@
         reports the project's VibeTags health — build-tool wiring, active platforms,
         marker integrity. Run it without installing anything:
 
-            jbang se.deversity.vibetags:vibetags-cli:1.3.0 init --list
+            jbang se.deversity.vibetags:vibetags-cli:1.3.1 init --list
 
         The platform list and marker rules are read from vibetags-processor, so this
         tool cannot drift from what the processor actually does.

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.3.0</revision>
+        <revision>1.3.1</revision>
 
         <!-- release, not source/target: on a JDK newer than 21 (CI builds 21, 25 and 26)
              source/target compiles against the *running* JDK's API and javac warns that the

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -35,7 +35,7 @@ def pomVersion = { String property ->
 }
 
 group = 'se.deversity.vibetags'
-version = '1.3.0'
+version = '1.3.1'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -49,7 +49,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.3.0'
+            version = '1.3.1'
             from components.java
 
             pom {
@@ -107,7 +107,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.3.0'
+    api 'se.deversity.vibetags:vibetags-annotations:1.3.1'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation "org.jspecify:jspecify:${pomVersion('jspecify.version')}"


### PR DESCRIPTION
25 commits since `v1.3.0`. Version bumped by `tools/set-version.sh`; `[Unreleased]` becomes
`[1.3.1]`.

## Two upgrade steps, and why they are in the notes rather than the diff

This is a patch release that changes two things in a consumer's *files* without changing their
code, so the CHANGELOG opens with an `### Upgrading` section rather than burying them:

1. **Guardrail files gain reason text and reflow.** A string member of an annotation that spanned
   lines used to render broken across lines, and on some platforms its reason line did not render
   at all. Regenerated guardrails therefore differ from what is committed — measured on the sweep
   below as 3 files in one consumer, 12 in another, 0 in a third. A CI step that diffs regenerated
   guardrails fails until the consumer rebuilds and commits. At least one consumer has that step.
2. **A locked or contracted constructor needs its baseline re-recorded** with one
   `-Avibetags.baseline.update=true` build. Constructors are now keyed under `<init>`, because a
   constructor and a method named like its class rendered to one identical element path and
   collapsed into a single baseline entry — so one of the two was never checked.

The rendered element path is deliberately unchanged: it is byte-identical to javac's `toString()`
because `action/locked-files` matches it against a PR diff.

## Consumer sweep (docs/RELEASING.md step 0)

Against locally installed 1.3.1:

| repo | result |
|---|---|
| `blindbean` | PASS |
| `codekarta` | PASS on JDK 21; 3 guardrail files drift |
| `common-license-lib` | PASS; 12 guardrail files gain a rendered reason line |
| `skill3` | PASS |
| `async-test-lib` | PASS; no content drift |

`codekarta` first came back FAIL. It was not a regression: it failed at its own enforcer rule,
`RequireJavaVersion — "Build with JDK 21 through 25"`, because `JAVA_HOME` on this machine is 26.
That fires before any VibeTags code runs. Rerun on 21, it passes. The skill's rule — a red result
is not a regression until it is shown to fail on the consumer's existing pinned version — is what
caught it.

## What is **not** verified locally

This machine has Maven 3.8.6 and the pinned `spotbugs-maven-plugin` requires 3.8.9, so the
artifacts used for the sweep were built with **SpotBugs skipped**. That is a skipped gate, not a
passed one. CI runs the real stack on this PR, and I do not consider the release verified until it
does.

## After this merges

The tag is what triggers `publish.yml` and Maven Central, and it cannot be undone — so that step is
yours, not mine. The release notes text is the `### Upgrading` section above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVwoJARmbKjxH2WRy4AN47
