### PR TITLE
fix: correctness hunt 2026-09-05, five bugs in the fingerprint, writer, cache, baseline and mirror paths

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The build fingerprint now folds in each annotated element's kind. A class that became an
+  interface (or a record, or an enum) with nothing else moving kept the same path, lines and
+  attributes, so the short-circuit skipped regeneration and `.vibetags-locks` went on reporting
+  `"kind":"CLASS"` while check mode failed on the same tree. `FingerprintShortCircuitTest` pins it.
+- A granular rule file that had no YAML header (a role file written by hand before the build) got
+  the generated block appended without the `globs:` / `paths:` / `applyTo:` header the editor reads
+  to decide when the rule loads, so the rule never applied. The rendered header now opens such a
+  file, with the hand content below it. `WriteFileFrontMatterTest` pins it.
+- A marker file the round found already current was never recorded in `.vibetags-cache`, so on a
+  fresh clone the short-circuit could not see a later hand edit inside its generated block and left
+  it there while check mode failed on the same tree. `WriteCacheProcessorIntegrationTest` pins it.
+
 ## [1.3.1] - 2026-09-04
 
 ### Upgrading

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A marker file the round found already current was never recorded in `.vibetags-cache`, so on a
   fresh clone the short-circuit could not see a later hand edit inside its generated block and left
   it there while check mode failed on the same tree. `WriteCacheProcessorIntegrationTest` pins it.
+- `-Avibetags.baseline.update=true` combined with `-Avibetags.enforce=<one family>` replaced the
+  module's whole block in `.vibetags-baseline`, so the families it was not asked about lost their
+  approvals and the next `-Avibetags.enforce=all` build read a broken contract as newly annotated
+  and passed. The update now rewrites only the families named. `EnforcingModeEndToEndTest` pins it.
+- Cross-module mirroring (`.vibetags-mirror`) deleted a sibling's files in two shapes. A module
+  whose id begins another's (`core` beside `core-api`) cleaned up under `mirrored-core-`, which is
+  how `mirrored-core-api-…` begins, so every build of `core` alone removed `core-api`'s mirrored
+  rules and check mode failed on the tree. And the test source set of a module shared the main
+  round's namespace, so each round removed what the other had mirrored. The cleanup now leaves
+  alone the prefix of any sibling module directory whose id extends this module's, and a
+  non-primary source set mirrors under `mirrored-<id>__<sourceSet>-`. `MirrorEndToEndTest` pins
+  both.
+
+### Upgrading
+
+- A module whose *test* sources carry VibeTags annotations and that mirrors into a sibling now
+  writes those mirrors as `mirrored-<id>__test-…`. The files it previously wrote under
+  `mirrored-<id>-…` from the test round are removed by the main round's cleanup on the next build,
+  as they were before; nothing else changes on disk.
 
 ## [1.3.1] - 2026-09-04
 

--- a/docs/MULTI-MODULE.md
+++ b/docs/MULTI-MODULE.md
@@ -368,10 +368,17 @@ Mechanics:
   (`.claude/rules/`, `.cursor/rules/`, …). Aggregate files are not mirrored — a module's own
   `CLAUDE.md` is its to own, and merging siblings into the root aggregate is what the sidecar
   merge already does.
-- Filenames carry the reserved prefix `mirrored-<sourceModuleId>-`. Modules of a reactor compile in
-  separate javac invocations, so each source module must be able to clean up its own stale mirrors
-  without touching the target's own rules or another module's. A module's ordinary granular cleanup
-  skips anything starting with `mirrored-`, and `cleanupMirrored` only ever considers its own prefix.
+- Filenames carry the reserved prefix `mirrored-<sourceModuleId>-`; a non-primary source set of the
+  module mirrors under `mirrored-<sourceModuleId>__<sourceSet>-` (the test round of `core` writes
+  `mirrored-core__test-…`), so the main and test rounds of one module never clean up each other's
+  files. Modules of a reactor compile in separate javac invocations, so each source module must be
+  able to clean up its own stale mirrors without touching the target's own rules or another
+  module's. A module's ordinary granular cleanup skips anything starting with `mirrored-`, and
+  `cleanupMirrored` only ever considers its own prefix. One prefix can begin another's — `core`
+  beside `core-api` — so the cleanup also leaves alone every file under the prefix of a sibling
+  module directory whose id extends this module's id; the siblings are read off the module
+  directories under the root (build file present, up to three levels down), which a cold clone has
+  before any sidecar exists.
   **`mirrored-` is therefore reserved** at the start of a granular filename: a role named
   `mirrored-…`, or a class in a top-level package named `mirrored`, produces a stem VibeTags will
   still write and refresh, but will not garbage-collect once its annotations are gone. Rename either

--- a/docs/PROCESSOR.md
+++ b/docs/PROCESSOR.md
@@ -185,7 +185,8 @@ quiet on a file it could not read.
 ## Top-level fingerprint short-circuit
 
 The processor records a fingerprint of the build inputs — the processor version (`ProcessorVersion`),
-every collected annotation (FQN + attribute values), plus the resolved active-services set — into
+every collected annotation (element path, element kind and attribute values), plus the resolved
+active-services set — into
 `.vibetags-cache` under a `# fingerprint: <hex>` header. Folding the version in means upgrading the
 processor invalidates the previous fingerprint, so a release that renders different content from
 unchanged annotations can never be skipped. The cache file also carries a `# format: <n>` header; a

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/BuildFingerprint.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/BuildFingerprint.java
@@ -83,6 +83,8 @@ public final class BuildFingerprint {
      * Computes the fingerprint over (processor version × collector annotations × resolved active
      * services).
      *
+     * <p>Each element contributes its path, its kind and its attribute values.
+     *
      * <p>Element ordering is normalised by element-path (a stable, FQN-like string) before hashing,
      * because {@link java.util.LinkedHashSet} preserves insertion order and javac's discovery order
      * is not guaranteed to be deterministic across runs. Active services are sorted alphabetically
@@ -360,7 +362,13 @@ public final class BuildFingerprint {
         List<TaggedElement> sorted = new ArrayList<>(elements);
         sorted.sort(Comparator.comparing(TaggedElement::path));
         for (TaggedElement e : sorted) {
-            sb.append(e.path()).append('=').append(attrs.extract(e)).append(';');
+            // The kind is rendered content too: the locks report names it, so a class that
+            // becomes an interface with nothing else moving — same path, same lines, same reason
+            // — changes what the file says while every other input here stays byte-identical.
+            // Left out, that edit short-circuited past regeneration and check mode failed on the
+            // tree the build had just called current.
+            sb.append(e.path()).append('#').append(e.kind().name())
+              .append('=').append(attrs.extract(e)).append(';');
         }
         sb.append('}');
     }

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/EnforcementBaseline.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/EnforcementBaseline.java
@@ -149,7 +149,8 @@ public final class EnforcementBaseline {
 
     /**
      * Rewrites the baseline, replacing every line owned by {@code moduleId} with {@code current}
-     * and preserving every sibling module's. Written atomically and sorted.
+     * and preserving every sibling module's. Written atomically and sorted. Replaces the module's
+     * lines in every family; see the four-argument form for a partial update.
      *
      * <p>The merge re-reads the file under an exclusive lock instead of merging into whatever this
      * instance loaded. In a parallel reactor two enforcing modules record from separate javac
@@ -162,13 +163,30 @@ public final class EnforcementBaseline {
      * @param current family + path → signature for the compiling module
      */
     public void update(Path root, String moduleId, Map<String, String> current) throws IOException {
+        update(root, moduleId, null, current);
+    }
+
+    /**
+     * As above, replacing only the module's lines in {@code families} and keeping its lines in
+     * every other family as they are.
+     *
+     * <p>{@code -Avibetags.enforce=locked -Avibetags.baseline.update=true} is how a developer
+     * re-records one locked element they changed on purpose. Replacing the module's whole block
+     * on that run threw its {@code @AIContract} and {@code @AIPublicAPI} lines away, and the next
+     * {@code -Avibetags.enforce=all} build read a broken contract as "newly annotated, not yet
+     * approved" and stayed green. Only what was asked to be re-recorded may be dropped.
+     *
+     * @param families the families {@code current} was collected for; {@code null} means all
+     */
+    public void update(Path root, String moduleId, @Nullable Set<String> families,
+                       Map<String, String> current) throws IOException {
         Object monitor = ROOT_MONITORS.computeIfAbsent(
             root.toAbsolutePath().normalize().toString(), key -> new Object());
         synchronized (monitor) {
             try (FileChannel channel = openLockFile(root)) {
                 FileLock lock = acquire(channel);
                 try {
-                    updateLocked(root, moduleId, current);
+                    updateLocked(root, moduleId, families, current);
                 } finally {
                     release(lock);
                 }
@@ -216,11 +234,18 @@ public final class EnforcementBaseline {
     }
 
     /** The read-merge-write itself, run with the lock held. */
-    private void updateLocked(Path root, String moduleId, Map<String, String> current)
-            throws IOException {
+    private void updateLocked(Path root, String moduleId, @Nullable Set<String> families,
+                              Map<String, String> current) throws IOException {
         Map<String, String> merged = new LinkedHashMap<>(load(root).entries);
         String prefix = moduleId + "\t";
-        merged.keySet().removeIf(k -> k.startsWith(prefix));
+        if (families == null) {
+            merged.keySet().removeIf(k -> k.startsWith(prefix));
+        } else {
+            for (String family : families) {
+                String familyPrefix = prefix + family + "\t";
+                merged.keySet().removeIf(k -> k.startsWith(familyPrefix));
+            }
+        }
         current.forEach((familyAndPath, signature) -> merged.put(prefix + familyAndPath, signature));
 
         List<String> lines = new ArrayList<>(merged.size());

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GranularRulesWriter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GranularRulesWriter.java
@@ -475,6 +475,49 @@ public final class GranularRulesWriter {
     }
 
     /**
+     * Stems of the files in the active granular directories whose name begins with one of
+     * {@code prefixes}, in the form {@link #cleanupMirrored} takes as its exclusion set.
+     *
+     * <p>For a module whose mirror namespace is a prefix of a sibling's: {@code mirrored-core-}
+     * is how {@code mirrored-core-api-...} begins, so without this core's cleanup read every one
+     * of core-api's mirrored files as an orphan of its own. The extension is stripped per format
+     * here because only this class knows which of {@code .md} and {@code .instructions.md} a
+     * directory uses.
+     */
+    public Set<String> stemsWithPrefix(Map<String, Path> serviceFiles, Set<String> activeServices,
+                                       java.util.Collection<String> prefixes) {
+        Set<String> stems = new LinkedHashSet<>();
+        if (prefixes.isEmpty()) {
+            return stems;
+        }
+        for (GranularFormat f : FORMATS) {
+            Path dir = serviceFiles.get(f.serviceKey);
+            if (dir == null || !activeServices.contains(f.serviceKey)
+                    || !java.nio.file.Files.isDirectory(dir)) {
+                continue;
+            }
+            try (java.util.stream.Stream<Path> files = java.nio.file.Files.list(dir)) {
+                for (Path file : files.toList()) {
+                    String name = String.valueOf(file.getFileName());
+                    if (!name.endsWith(f.extension)) {
+                        continue;
+                    }
+                    for (String prefix : prefixes) {
+                        if (name.startsWith(prefix)) {
+                            stems.add(name.substring(0, name.length() - f.extension.length()));
+                            break;
+                        }
+                    }
+                }
+            } catch (java.io.IOException ignored) {
+                // A directory this build cannot list has nothing in it to protect; the cleanup
+                // that follows cannot list it either.
+            }
+        }
+        return stems;
+    }
+
+    /**
      * Per-platform granular file format: extension, frontmatter builder (from description + glob
      * list), and heading builder. A file is {@code frontmatter + heading + body}; the single-glob
      * case reproduces the historical per-class output byte-for-byte.

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailEnforcer.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailEnforcer.java
@@ -152,7 +152,7 @@ public final class GuardrailEnforcer {
         }
         if (update) {
             try {
-                baseline.update(root, moduleId, current);
+                baseline.update(root, moduleId, families, current);
                 messager.printMessage(Diagnostic.Kind.NOTE,
                     "VibeTags: enforcement baseline updated for module '" + moduleId + "' ("
                         + current.size() + " guarded element(s)). Commit " + EnforcementBaseline.FILE_NAME + ".");

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailFileWriter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailFileWriter.java
@@ -236,6 +236,26 @@ public final class GuardrailFileWriter {
         }
     }
 
+    /**
+     * Records a file this round found already current, so the cache owns it from here on.
+     *
+     * <p>A file the round never had to write is still a file the round is responsible for. The
+     * fresh-clone shape is the common case: every committed output is byte-identical to what the
+     * round renders, nothing is written, and before this nothing was recorded either. The next
+     * build's short-circuit then asked the cache whether every file it knew about was stable,
+     * and the cache knew about none of these — so a hand edit inside the generated block, or a
+     * CRLF checkout of it, survived every later build while check mode failed on the same tree.
+     * The entry records the file as it is on disk, line endings included, which is exactly what
+     * {@link WriteCache#isUnchanged} has to compare against next time. Nothing to record in
+     * dry-run, which must leave the cache as it found it.
+     */
+    private void noteCurrent(Path filePath, String bodyForCache) {
+        if (dryRun || writeCache == null) {
+            return;
+        }
+        writeCache.recordWrite(filePath, bodyForCache);
+    }
+
     private boolean writeWithMarkers(Path filePath, String fileName, String path, String content,
                                      String existing, boolean hasNewRules, String[] markers) throws IOException {
         String markerStart = markers[0];
@@ -263,6 +283,7 @@ public final class GuardrailFileWriter {
                 String finalContent = (before.isEmpty() ? "" : before + "\n\n") + wrappedBody + "\n";
                 if (contentMatches(existing, finalContent)) {
                     debug("write.skip file={} reason=identical-bytes markers=malformed", fileName);
+                    noteCurrent(filePath, content);
                     return false;
                 }
                 debug("write.update file={} reason=malformed-markers-repaired newBytes={}",
@@ -284,6 +305,7 @@ public final class GuardrailFileWriter {
             if (contentMatches(existing, finalContent)) {
                 debug("write.skip file={} reason=identical-bytes bytes={} markers=true",
                     fileName, finalContent.length());
+                noteCurrent(filePath, content);
                 return false;
             }
 
@@ -307,6 +329,7 @@ public final class GuardrailFileWriter {
             if (contentMatches(existing, finalContent)) {
                 debug("write.skip file={} reason=identical-bytes bytes={} markers=legacy",
                     fileName, finalContent.length());
+                noteCurrent(filePath, content);
                 return false;
             }
 
@@ -325,7 +348,10 @@ public final class GuardrailFileWriter {
             String updated = existing.isEmpty()
                 ? (frontMatter.isEmpty() ? "" : frontMatter + "\n\n") + wrappedBody + "\n"
                 : withRenderedFrontMatter(existing.stripTrailing(), frontMatter) + "\n\n" + wrappedBody + "\n";
-            if (contentMatches(existing, updated)) return false;
+            if (contentMatches(existing, updated)) {
+                noteCurrent(filePath, content);
+                return false;
+            }
 
             if (!hasNewRules && !existing.isEmpty()) {
                 skipUpdateMsg(fileName);
@@ -342,7 +368,10 @@ public final class GuardrailFileWriter {
     private boolean writeWithoutMarkers(Path filePath, String fileName, String content, String existing,
                                         boolean fileExists, long existingSize,
                                         boolean hasNewRules) throws IOException {
-        if (contentMatches(existing, content)) return false;
+        if (contentMatches(existing, content)) {
+            noteCurrent(filePath, content);
+            return false;
+        }
 
         if (!hasNewRules && fileExists && existingSize > 0) {
             skipUpdateMsg(fileName);

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailFileWriter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GuardrailFileWriter.java
@@ -369,7 +369,9 @@ public final class GuardrailFileWriter {
      *
      * <p>When the renderer emits no header ({@code frontMatter} is empty), a header the file
      * carries is a hand-written one — CLAUDE.md, a Junie or Void rules file — and is preserved
-     * untouched, as before.
+     * untouched, as before. When the renderer emits one and the file has none — a role file
+     * somebody wrote by hand before the build, or a file an earlier round left headerless — the
+     * rendered header is put in front of what is there.
      *
      * @param before      the file's content ahead of the start marker (or the whole file when
      *                    there is none), legacy block already stripped
@@ -381,7 +383,12 @@ public final class GuardrailFileWriter {
         }
         int close = frontMatterEnd(before);
         if (close == -1) {
-            return before; // no header, or an unterminated one that is not ours; leave it alone
+            // No header to replace, so the rendered one opens the file. It has to: the glob list
+            // in it is what the editor reads to decide when the rule loads at all, and appending
+            // the block beneath a hand-written file without it left a rule nothing ever applied.
+            // A leading block this parser does not read as YAML stays where it is, below ours;
+            // the next round then finds the rendered header first and replaces only that.
+            return before.isEmpty() ? frontMatter : frontMatter + "\n\n" + before;
         }
         String rest = before.substring(close).stripLeading();
         return rest.isEmpty() ? frontMatter : frontMatter + "\n\n" + rest;

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/MirrorConfig.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/MirrorConfig.java
@@ -48,7 +48,7 @@ public final class MirrorConfig {
     public static final String FILE_NAME = ".vibetags-mirror";
 
     /** Directory names never descended into while discovering mirror targets. */
-    private static final Set<String> SKIP_DIRS = Set.of(
+    static final Set<String> SKIP_DIRS = Set.of(
         "target", "build", "out", "bin", "src", "node_modules", ".git", ".idea", ".mvn", ".gradle");
 
     /** How far below the VibeTags root a mirror target may sit (covers {@code root/group/module}). */

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/MirrorWriter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/MirrorWriter.java
@@ -63,6 +63,28 @@ public final class MirrorWriter {
                              @Nullable RoleConfig roles,
                              GuardrailFileWriter writer,
                              @Nullable Messager messager) {
+        write(moduleRoot, vibetagsRoot, collector, projectName, generatedHeader, roles, writer, messager, "");
+    }
+
+    /**
+     * As above, for one source set of the module.
+     *
+     * @param sourceSetSuffix {@code ""} for the primary source set, otherwise the
+     *        {@code __<sourceSet>} suffix {@code ModuleSidecar.scopedModuleId} gives a sidecar id.
+     *        The test round of a module writes and cleans up under its own namespace,
+     *        {@code mirrored-<id>__test-}, because a namespace keyed on the module alone had each
+     *        round delete what the other had mirrored: the target's rules flapped between the two
+     *        halves of every build, and check mode failed on whichever half it ran after.
+     */
+    public static void write(Path moduleRoot,
+                             Path vibetagsRoot,
+                             AnnotationCollector collector,
+                             String projectName,
+                             String generatedHeader,
+                             @Nullable RoleConfig roles,
+                             GuardrailFileWriter writer,
+                             @Nullable Messager messager,
+                             String sourceSetSuffix) {
         if (moduleRoot == null || vibetagsRoot == null || moduleRoot.equals(vibetagsRoot)) {
             // No module identity (in-memory/non-javac compile) or the module IS the root: there is
             // no sibling to mirror into, and a root-scoped mirror would just duplicate root output.
@@ -73,7 +95,9 @@ public final class MirrorWriter {
             return;
         }
 
-        String moduleId = ModuleSidecar.computeModuleId(moduleRoot, vibetagsRoot);
+        String regionId = ModuleSidecar.computeModuleId(moduleRoot, vibetagsRoot);
+        String moduleId = regionId + sourceSetSuffix;
+        Set<String> shadowing = shadowingPrefixes(vibetagsRoot, regionId);
         int written = 0;
 
         for (MirrorConfig target : targets) {
@@ -87,6 +111,11 @@ public final class MirrorWriter {
             }
 
             String prefix = MIRROR_PREFIX + moduleId + "-";
+            GranularRulesWriter granular = new GranularRulesWriter(writer);
+            // A sibling whose id begins with this module's id and a dash — core-api beside core —
+            // mirrors under a prefix that begins with this module's prefix. Its files are not
+            // this module's orphans, and the cleanup below is told so by name.
+            Set<String> keep = granular.stemsWithPrefix(targetFiles, targetActive, shadowing);
             if (!target.accepts(moduleRoot)) {
                 // Not (or no longer) a source for this target. Anything under this module's own
                 // mirror prefix here was written while the config did name it, and is an orphan the
@@ -95,20 +124,19 @@ public final class MirrorWriter {
                 // has not compiled. Cleaning it is still self-cleanup — the prefix scopes it to this
                 // module's own files — so it never reaches a sibling's, which is what stops a cold
                 // reactor deleting work it merely has not seen yet (issue #383).
-                new GranularRulesWriter(writer)
-                    .cleanupMirrored(targetFiles, targetActive, prefix, Set.of());
+                granular.cleanupMirrored(targetFiles, targetActive, prefix, keep);
                 continue;
             }
 
             GuardrailContentBuilder.Result built =
                 new GuardrailContentBuilder(collector, targetActive, projectName, generatedHeader, roles).build();
 
-            GranularRulesWriter granular = new GranularRulesWriter(writer);
             Set<String> stems = granular.writeMirrored(
                 built.elementRules, targetFiles, targetActive, roles, prefix, target.globs());
             // Cleanup runs after write and only within this module's namespace, so a stale mirror
             // disappears when its annotations do while everything else in the directory survives.
-            granular.cleanupMirrored(targetFiles, targetActive, prefix, stems);
+            keep.addAll(stems);
+            granular.cleanupMirrored(targetFiles, targetActive, prefix, keep);
             written += stems.size();
         }
 
@@ -116,6 +144,67 @@ public final class MirrorWriter {
             messager.printMessage(Diagnostic.Kind.NOTE,
                 "VibeTags: mirrored " + written + " scoped rule file(s) from module " + moduleId
                     + " into " + targets.size() + " mirror target(s).");
+        }
+    }
+
+    /**
+     * Mirror prefixes of every module under {@code root} whose id begins with {@code regionId}
+     * and a dash, e.g. {@code mirrored-core-api} when {@code core} is compiling.
+     *
+     * <p>{@code mirrored-core-} is how {@code mirrored-core-api-...} begins, so core's cleanup
+     * read every one of core-api's mirrored files as an orphan of its own and deleted them; the
+     * next core-api compile put them back, and every build of core alone took them away again.
+     * The siblings are found from the module directories on disk, which is evidence a cold clone
+     * has before any sidecar exists (issue #383 forbids arguing from a sidecar's absence). The
+     * prefix stops at the sibling's id so that every source set of the sibling is covered.
+     */
+    static Set<String> shadowingPrefixes(Path root, String regionId) {
+        Set<String> prefixes = new LinkedHashSet<>();
+        String extended = regionId + "-";
+        for (Path dir : moduleDirectories(root)) {
+            String id = ModuleSidecar.computeModuleId(dir, root);
+            if (id.startsWith(extended)) {
+                prefixes.add(MIRROR_PREFIX + id);
+            }
+        }
+        return prefixes;
+    }
+
+    /** How deep below the root a sibling module is looked for; one level past mirror discovery. */
+    private static final int MODULE_SEARCH_DEPTH = 3;
+
+    /** Directories under {@code root} that carry a build file of their own, {@code root} excluded. */
+    private static List<Path> moduleDirectories(Path root) {
+        List<Path> modules = new java.util.ArrayList<>();
+        collectModules(root.toAbsolutePath().normalize(), 0, modules, new LinkedHashSet<>());
+        return modules;
+    }
+
+    private static void collectModules(Path dir, int depth, List<Path> out, Set<Path> seen) {
+        if (!seen.add(dir)) {
+            return; // symlink cycle guard
+        }
+        if (depth > 0 && dir.equals(ModuleRootResolver.nearestBuildFileAncestor(dir))) {
+            out.add(dir);
+        }
+        if (depth >= MODULE_SEARCH_DEPTH) {
+            return;
+        }
+        try (java.util.stream.Stream<Path> children = java.nio.file.Files.list(dir)) {
+            List<Path> dirs = children
+                .filter(java.nio.file.Files::isDirectory)
+                .filter(p -> {
+                    Path name = p.getFileName();
+                    return name != null && !MirrorConfig.SKIP_DIRS.contains(name.toString());
+                })
+                .sorted()
+                .toList();
+            for (Path child : dirs) {
+                collectModules(child, depth + 1, out, seen);
+            }
+        } catch (java.io.IOException | RuntimeException ignored) {
+            // A directory this build cannot list holds no sibling this build can protect; the
+            // ordinary prefix cleanup then behaves as it did before.
         }
     }
 

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleOutputWriter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleOutputWriter.java
@@ -39,6 +39,19 @@ public final class ModuleOutputWriter {
 
     private ModuleOutputWriter() {}
 
+    /**
+     * The {@code __<sourceSet>} part of a sidecar id, or {@code ""} for the primary source set or
+     * a caller that named neither. Read back off the two ids rather than passed in, because the
+     * call that has the source set is inside the step-order-locked {@code generateFiles()}.
+     */
+    static String sourceSetSuffix(@Nullable String regionId, @Nullable String moduleId) {
+        if (regionId == null || moduleId == null
+                || !moduleId.startsWith(regionId + ModuleSidecar.SOURCE_SET_SEPARATOR)) {
+            return "";
+        }
+        return moduleId.substring(regionId.length());
+    }
+
     /** Single-module / no-sidecar entry point: builds the module's content and writes it as-is. */
     public static void write(Path moduleRoot,
                              Path vibetagsRoot,
@@ -94,7 +107,7 @@ public final class ModuleOutputWriter {
         // that contributes only to the reactor-root aggregate still has guardrails worth mirroring
         // into a test module that asked for them (issue #312).
         MirrorWriter.write(moduleRoot, vibetagsRoot, collector, projectName, generatedHeader,
-            roles, writer, messager);
+            roles, writer, messager, sourceSetSuffix(regionId, moduleId));
 
         if (moduleRoot == null || moduleRoot.equals(vibetagsRoot) || moduleActive.isEmpty()) {
             return; // module is the root, or nothing opted in here

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/EnforcingModeEndToEndTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/EnforcingModeEndToEndTest.java
@@ -331,4 +331,55 @@ class EnforcingModeEndToEndTest {
         assertFalse(warns(diagnostics, "records nothing for module"),
             "an unreadable file is not an unrecorded one");
     }
+
+    private static final String TWO_FAMILIES = """
+        package com.example;
+        import se.deversity.vibetags.annotations.AIContract;
+        import se.deversity.vibetags.annotations.AILocked;
+        public interface PaymentGateway {
+            @AIContract(reason = "External gateway API")
+            double charge(String customerId, double amount);
+            @AILocked(reason = "settlement order is frozen")
+            void settle();
+        }
+        """;
+
+    private static final String TWO_FAMILIES_CONTRACT_BROKEN = """
+        package com.example;
+        import se.deversity.vibetags.annotations.AIContract;
+        import se.deversity.vibetags.annotations.AILocked;
+        public interface PaymentGateway {
+            @AIContract(reason = "External gateway API")
+            double charge(String customerId, long amount);
+            @AILocked(reason = "settlement order is frozen")
+            void settle();
+        }
+        """;
+
+    /**
+     * Re-approving one family must not throw the others away. {@code -Avibetags.enforce=locked}
+     * with {@code -Avibetags.baseline.update=true} is how a developer re-records a locked element
+     * they changed on purpose. The update replaced the module's whole block, so its
+     * {@code @AIContract} entries vanished; the next {@code -Avibetags.enforce=all} build then had
+     * nothing to compare the contracts against, read a broken one as "newly annotated", and stayed
+     * green.
+     */
+    @Test
+    void updatingOneFamilyKeepsTheOtherFamiliesApproved() throws IOException {
+        Files.createFile(root.resolve("CLAUDE.md"));
+        compile(TWO_FAMILIES, "-Avibetags.enforce=all", "-Avibetags.baseline.update=true");
+        String recorded = Files.readString(root.resolve(".vibetags-baseline"));
+        assertTrue(recorded.contains("\tcontract\t") && recorded.contains("\tlocked\t"),
+            "precondition: both families recorded:\n" + recorded);
+
+        compile(TWO_FAMILIES, "-Avibetags.enforce=locked", "-Avibetags.baseline.update=true");
+        String after = Files.readString(root.resolve(".vibetags-baseline"));
+        assertTrue(after.contains("\tcontract\t"),
+            "re-recording the locked family must leave the contract entries in place:\n" + after);
+
+        List<Diagnostic<? extends JavaFileObject>> broken =
+            compile(TWO_FAMILIES_CONTRACT_BROKEN, "-Avibetags.enforce=all");
+        assertTrue(errors(broken, "@AIContract violation"),
+            "the contract must still be enforced after an unrelated family was re-approved");
+    }
 }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/FingerprintShortCircuitTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/FingerprintShortCircuitTest.java
@@ -211,6 +211,41 @@ class FingerprintShortCircuitTest {
             "the module sidecar must be re-saved under the new -Avibetags.module id");
     }
 
+    /**
+     * The locks report records each element's kind, so a class that becomes an interface with
+     * nothing else moving — same name, same lines, same reason — changes what the file should say.
+     * The fingerprint hashed the path and the annotation attributes and nothing about the element
+     * itself, so this build short-circuited and left the report describing a class that no longer
+     * exists, while check mode on the same tree reported drift (issue #440's shape again).
+     */
+    @Test
+    void shortCircuit_doesNotFire_whenAnElementChangesKind(@TempDir Path tmp) throws Exception {
+        ProcessorTestHarness h1 = new ProcessorTestHarness(tmp);
+        h1.addSource("com.example.A",
+            "package com.example;\n" +
+            "import se.deversity.vibetags.annotations.AILocked;\n" +
+            "@AILocked(reason = \"frozen\")\n" +
+            "public class A {}\n");
+        h1.compile();
+        Path locks = tmp.resolve(".vibetags-locks");
+        assertTrue(Files.readString(locks).contains("\"kind\":\"CLASS\""),
+            "the first build reports a class");
+
+        ProcessorTestHarness.awaitFilesystemTick(tmp);
+
+        ProcessorTestHarness h2 = new ProcessorTestHarness(tmp);
+        h2.addSource("com.example.A",
+            "package com.example;\n" +
+            "import se.deversity.vibetags.annotations.AILocked;\n" +
+            "@AILocked(reason = \"frozen\")\n" +
+            "public interface A {}\n");
+        h2.compile();
+        String report = Files.readString(locks);
+        assertTrue(report.contains("\"kind\":\"INTERFACE\""),
+            "the report must follow the element's kind:\n" + report);
+        assertFalse(report.contains("\"kind\":\"CLASS\""), report);
+    }
+
     // -----------------------------------------------------------------------
     // Helper
     // -----------------------------------------------------------------------

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/MirrorEndToEndTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/MirrorEndToEndTest.java
@@ -325,4 +325,61 @@ class MirrorEndToEndTest {
         assertFalse(Files.exists(reactorRoot.resolve("app-tests/.claude")),
             "VibeTags never creates an opt-in directory that does not already exist");
     }
+
+    /**
+     * Module ids that prefix each other — {@code core} beside {@code core-api} is ordinary Maven
+     * naming — must keep their mirrored namespaces apart. The namespace is a filename prefix,
+     * {@code mirrored-core-}, and that is also how {@code mirrored-core-api-...} begins, so core's
+     * cleanup read every one of core-api's mirrored files as an orphan of its own and deleted
+     * them. The next core-api compile put them back; every build of core alone, and every
+     * check-mode run, took them away again.
+     */
+    @Test
+    void siblingWhoseIdExtendsMine_keepsItsMirroredFilesThroughMyCleanup() throws IOException {
+        mirrorTarget("app-tests", "");
+        compileModule("core-api", "com.example.runtime.KeyContext", RUNTIME_SOURCE);
+        Path fromApi = mirrored("app-tests", "core-api", "com-example-runtime-KeyContext");
+        assertTrue(Files.exists(fromApi), "precondition: core-api's mirror exists");
+
+        compileModule("core", "com.example.fhe.NativeBridge", FHE_SOURCE);
+
+        assertTrue(Files.exists(mirrored("app-tests", "core", "com-example-fhe-NativeBridge")),
+            "core mirrors its own rules");
+        assertTrue(Files.exists(fromApi),
+            "core's cleanup must not delete core-api's files: mirrored-core- is how mirrored-core-api- begins");
+    }
+
+    /**
+     * A module's test sources compile as a second source set under the same module id. The
+     * mirrored namespace was keyed on the module alone, so the test round (an
+     * {@code @AIParallelTests} fixture is enough to run the processor) cleaned up every mirrored
+     * file the main round had written and the main round returned the favour: the target's rules
+     * flapped between the two halves of every {@code mvn install}, and check mode failed on
+     * whichever half it ran after.
+     */
+    @Test
+    void testSourceSetOfTheSameModule_keepsTheMainSourceSetsMirroredFiles() throws IOException {
+        mirrorTarget("app-tests", "");
+        compileModuleSourceSet("app-fhe", "main", "com.example.fhe.NativeBridge", FHE_SOURCE);
+        Path fromMain = mirrored("app-tests", "app-fhe", "com-example-fhe-NativeBridge");
+        assertTrue(Files.exists(fromMain), "precondition: the main round mirrored its rule");
+
+        compileModuleSourceSet("app-fhe", "test", "com.example.tests.SharedFixtures", TEST_MODULE_SOURCE);
+
+        assertTrue(Files.exists(fromMain),
+            "the test round of the same module must not delete what its main round mirrored");
+        assertTrue(Files.exists(reactorRoot.resolve("app-tests/.claude/rules")
+                .resolve("mirrored-app-fhe__test-com-example-tests-SharedFixtures.md")),
+            "the test round mirrors under its own source-set namespace");
+    }
+
+    private void compileModuleSourceSet(String module, String sourceSet, String fqn, String source)
+            throws IOException {
+        ProcessorTestHarness harness = new ProcessorTestHarness(reactorRoot, false);
+        Files.createDirectories(reactorRoot.resolve(module));
+        Files.writeString(reactorRoot.resolve(module).resolve("pom.xml"),
+            "<project><artifactId>" + module + "</artifactId></project>", StandardCharsets.UTF_8);
+        harness.writeSourceFile(module + "/src/" + sourceSet + "/java/" + fqn.replace('.', '/') + ".java", source);
+        harness.compile();
+    }
 }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/WriteCacheProcessorIntegrationTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/WriteCacheProcessorIntegrationTest.java
@@ -109,4 +109,38 @@ class WriteCacheProcessorIntegrationTest {
         assertTrue(afterRecompile.contains("# user-added comment"),
             "user content above the marker block must be preserved");
     }
+
+    /**
+     * A marker file that is already current on the first cached build is still a file this
+     * processor owns. That is the fresh-clone shape: the committed CLAUDE.md is byte-identical to
+     * what the round renders, so nothing is written — and nothing was recorded either. The next
+     * build's short-circuit then asked the cache whether every file it knew about was stable, the
+     * cache knew nothing about this one, and a hand edit inside the generated block survived every
+     * later build while check mode reported drift on the same tree.
+     */
+    @Test
+    void fileFoundCurrentOnFirstCachedBuild_isStillRepairedWhenEditedInsideTheBlock(@TempDir Path tmp)
+            throws Exception {
+        ProcessorTestHarness h = ProcessorTestHarness.withExampleSources(tmp);
+        Path claude = h.root().resolve("CLAUDE.md");
+        String generated = Files.readString(claude, StandardCharsets.UTF_8);
+        assertTrue(generated.contains("<!-- VIBETAGS-START -->\n"), "fixture must carry a start marker");
+
+        // A fresh clone: the generated files are committed and current, the cache is not.
+        Files.delete(h.root().resolve(".vibetags-cache"));
+        ProcessorTestHarness.awaitFilesystemTick(tmp);
+        ProcessorTestHarness.withExampleSources(tmp);
+        assertEquals(generated, Files.readString(claude, StandardCharsets.UTF_8),
+            "a current file is not rewritten");
+
+        // Somebody edits inside the generated block.
+        ProcessorTestHarness.awaitFilesystemTick(tmp);
+        Files.writeString(claude, generated.replace("<!-- VIBETAGS-START -->\n",
+            "<!-- VIBETAGS-START -->\nHAND EDIT INSIDE THE BLOCK\n"), StandardCharsets.UTF_8);
+
+        ProcessorTestHarness.awaitFilesystemTick(tmp);
+        ProcessorTestHarness.withExampleSources(tmp);
+        assertFalse(Files.readString(claude, StandardCharsets.UTF_8).contains("HAND EDIT INSIDE THE BLOCK"),
+            "the next build must regenerate the block it owns, whether or not it ever wrote it before");
+    }
 }

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/WriteFileFrontMatterTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/WriteFileFrontMatterTest.java
@@ -201,4 +201,63 @@ class WriteFileFrontMatterTest {
             "a hand-written header the renderer knows nothing about must survive:\n" + result);
         assertTrue(result.contains("refreshed") && !result.contains("old rules"));
     }
+
+    /**
+     * A hand-written rule file with no YAML header — a role file somebody created ahead of the
+     * build, say — must still end up with the header VibeTags renders for it. The header is where
+     * Cursor, Windsurf and Copilot read the glob list that decides when the rule loads at all;
+     * appending the block beneath the hand text without it produced a rule no editor ever applied,
+     * and the only trace was the absence of four lines nobody had seen before.
+     */
+    @Test
+    void mdcFile_appendToHandFileWithoutHeader_addsTheRenderedFrontMatter(@TempDir Path tempDir)
+            throws IOException {
+        Path file = tempDir.resolve("security.mdc");
+        Files.writeString(file, "# Team notes\n\nKeep it small.\n", StandardCharsets.UTF_8);
+        String rendered =
+            "---\n" +
+            "description: \"AI rules for role security\"\n" +
+            "globs: [\"**/*Auth*.java\"]\n" +
+            "alwaysApply: false\n" +
+            "---\n\n" +
+            "# Rules for security\n\n## Locked Status\n- **Reason**: audited\n";
+        AIGuardrailProcessor p = new AIGuardrailProcessor();
+        assertTrue(p.writeFileIfChanged(file.toString(), rendered, true));
+        String result = Files.readString(file, StandardCharsets.UTF_8);
+        assertTrue(result.startsWith("---\ndescription: \"AI rules for role security\"\n"
+                + "globs: [\"**/*Auth*.java\"]\nalwaysApply: false\n---\n"),
+            "the rendered front matter must open the file:\n" + result);
+        int frontMatterEnd = result.indexOf("---", 3);
+        int hand = result.indexOf("# Team notes");
+        int marker = result.indexOf("<!-- VIBETAGS-START -->");
+        assertTrue(frontMatterEnd < hand && hand < marker,
+            "hand content stays between the header and the block:\n" + result);
+        assertTrue(result.contains("Keep it small."), "hand content survives:\n" + result);
+        assertFalse(p.writeFileIfChanged(file.toString(), rendered, true),
+            "the second round must find the file current");
+    }
+
+    /**
+     * The same header, for a file that opens directly on the marker block. That is what the
+     * append above left behind before it was fixed, so an already-affected file has to heal on
+     * its next round rather than stay headerless forever.
+     */
+    @Test
+    void mdcFile_updateOfHeaderlessMarkerFile_addsTheRenderedFrontMatter(@TempDir Path tempDir)
+            throws IOException {
+        Path file = tempDir.resolve("security.mdc");
+        Files.writeString(file, "<!-- VIBETAGS-START -->\nold rules\n<!-- VIBETAGS-END -->\n",
+            StandardCharsets.UTF_8);
+        String rendered =
+            "---\n" +
+            "globs: [\"**/*Auth*.java\"]\n" +
+            "---\n\n" +
+            "# Rules for security\n\n## Locked Status\n- **Reason**: audited\n";
+        AIGuardrailProcessor p = new AIGuardrailProcessor();
+        assertTrue(p.writeFileIfChanged(file.toString(), rendered, true));
+        String result = Files.readString(file, StandardCharsets.UTF_8);
+        assertTrue(result.startsWith("---\nglobs: [\"**/*Auth*.java\"]\n---\n\n<!-- VIBETAGS-START -->\n"),
+            "the rendered front matter must open the file:\n" + result);
+        assertFalse(result.contains("old rules"), result);
+    }
 }


### PR DESCRIPTION
## Why

Correctness hunt under the `correctness-hunt` work order, core first (processor, writer, sidecar,
cache, fingerprint), then the enforcement and mirror paths. Baseline on `f5fed68a`:
`mvn test -Pe2e` green, 2603 tests. Five bugs, each with a test that was red before its fix and
one commit per bug. One confirmed defect is not fixed here because the fix is a sidecar-format
decision; it is filed as an issue and listed below.

## Bugs fixed

### 1. Element kind missing from the build fingerprint (3b572ab5)

- **File**: `BuildFingerprint.java`
- **Defect**: an element contributed its path and attribute values, never its kind.
- **Failure**: `@AILocked public class A {}` becomes `public interface A {}` with the same lines and
  reason. The fingerprint matches, the generate phase short-circuits, `.vibetags-locks` keeps saying
  `"kind":"CLASS"`, and check mode fails on the same tree (issue #440's shape).
- **Fix**: each element now hashes path, kind and attributes. Every existing fingerprint changes
  once, which the processor version in the hash already forces on each release.
- **Test**: `FingerprintShortCircuitTest.shortCircuit_doesNotFire_whenAnElementChangesKind`.

### 2. Rendered front matter dropped on a header-less rule file (b20d1807)

- **File**: `GuardrailFileWriter.withRenderedFrontMatter`
- **Defect**: when the file had no YAML header, the header the renderer produced was discarded.
- **Failure**: a role file created by hand before the build (`.cursor/rules/security.mdc` with a
  note and no header) gets the generated block appended without `globs:`; Cursor, Windsurf and
  Copilot never load the rule and nothing says so. A file that opens on the marker block stayed
  headerless on every later round, so the damage never healed.
- **Fix**: the rendered header opens the file; hand content follows it, above the block. Renderers
  that emit no header (CLAUDE.md, Junie, Void) are unaffected.
- **Tests**: `WriteFileFrontMatterTest.mdcFile_appendToHandFileWithoutHeader_addsTheRenderedFrontMatter`
  and `mdcFile_updateOfHeaderlessMarkerFile_addsTheRenderedFrontMatter`.

### 3. A file found already current was never recorded in the write cache (b2474182)

- **File**: `GuardrailFileWriter` (every identical-skip path)
- **Defect**: the short-circuit trusts `WriteCache.allCachedFilesStable()`, which checks only the
  files the cache knows. A marker file found byte-identical was never written and never recorded.
- **Failure**: fresh clone, committed outputs current. After the first cached build the cache knows
  none of them. A hand edit inside CLAUDE.md's generated block survives every later build while
  check mode fails on the same tree. Whether a file was repaired depended on whether some earlier
  build had happened to rewrite it.
- **Fix**: each identical-skip records the file as it is on disk, as the non-marker fast path
  already did.
- **Test**: `WriteCacheProcessorIntegrationTest.fileFoundCurrentOnFirstCachedBuild_isStillRepairedWhenEditedInsideTheBlock`.

### 4. Baseline update for one family erased the module's other families (9d1a1c70)

- **File**: `EnforcementBaseline.update`, `GuardrailEnforcer`
- **Defect**: `-Avibetags.baseline.update=true` replaced the module's whole block regardless of
  which families `-Avibetags.enforce` named.
- **Failure**: re-approve one changed `@AILocked` element with `-Avibetags.enforce=locked`; the
  module's `@AIContract` and `@AIPublicAPI` lines vanish. The next `-Avibetags.enforce=all` build
  reads a broken contract as "newly annotated" and passes. (Suspicion from the 2026-08-16 hunt,
  now confirmed.)
- **Fix**: the update rewrites only the families it was collected for; the three-argument form
  keeps replacing everything for callers that mean that.
- **Test**: `EnforcingModeEndToEndTest.updatingOneFamilyKeepsTheOtherFamiliesApproved`.

### 5. Mirror cleanup deleted a sibling's files and the other source set's files (ad379441)

- **Files**: `MirrorWriter`, `ModuleOutputWriter`, `GranularRulesWriter.stemsWithPrefix`
- **Defect A**: the namespace `mirrored-core-` is how `mirrored-core-api-...` begins. With `core`
  beside `core-api` (ordinary Maven naming) every build of `core` alone deleted `core-api`'s
  mirrored rules; the next `core-api` build put them back; check mode failed on a correct tree.
  (Suspicion from the 2026-08-16 hunt, now confirmed.)
- **Defect B**: the prefix was keyed on the module, not the sidecar id, so the test source set of
  a module (an `@AIParallelTests` fixture is enough to run the processor) deleted what the main
  round had mirrored and the main round returned the favour, on every build.
- **Fix**: the cleanup leaves alone the prefix of any sibling module directory whose id extends
  this module's id, read off the module directories under the root (build file present, three
  levels deep), which a cold clone has before any sidecar exists. A non-primary source set now
  mirrors under `mirrored-<id>__<sourceSet>-`. Two defects, one cleanup site, so one commit.
- **Upgrade note** (in the CHANGELOG): a module whose test sources are annotated writes its
  test-round mirrors under the new name; the old ones are removed by the main round's cleanup.
- **Tests**: `MirrorEndToEndTest.siblingWhoseIdExtendsMine_keepsItsMirroredFilesThroughMyCleanup`
  and `testSourceSetOfTheSameModule_keepsTheMainSourceSetsMirroredFiles`.

## Confirmed, not fixed (escalated)

- **Cross-module case-collision heading flips with compile order.** Module `a` has
  `com.example.Payment`, module `b` has package `com.example.payment`, both routed to the root
  `.claude/rules`. `ModuleSidecar.mergeGranular` folds the two stems into one body, but the
  heading (`# Rules for Payment` vs `# Rules for payment`) and the description come from the
  compiling module's own plan, so on a case-insensitive filesystem the shared file changes with
  whichever module compiled last and check mode's verdict depends on build order. Reproduced with
  a throwaway probe on Windows (not committed). The fix needs `GranularContribution` to carry the
  display name, which changes the serialized sidecar value that older siblings parse, so it is a
  compatibility decision rather than a code fix. Issue: #579.

## Suspicions, unresolved

- `GranularRulesWriter.write` prefers the merged sidecar view over the fresh local rendering. If
  this module's sidecar save fails (the retry loop gives up, disk full), the merge carries the
  previous sidecar and the module's granular files are written from stale content while the
  aggregate is fresh. A NOTE is printed, but the files are wrong. Held back: needs a fault
  injection seam for the save to reproduce.
- `writeWithMarkers` on a file with a start marker and no end marker rewrites regardless of
  `hasNewRules`, so a test-compile round with no annotations can replace the rules a main round
  wrote until the next main compile. Held back: self-healing, and the file is already malformed.
- `scrubGranularFile` finds the front-matter close with a bare `indexOf("---", 3)` while every
  other reader is line-anchored. I could not construct a wrong deletion from it.
- The remaining 2026-08-16 suspicions (nested-type globs, mirrored files with no cleanup owner
  after config removal) were not re-probed.

## Verification

- [x] `mvn test -Pe2e` from `vibetags/`: green as part of `mvn verify -Pe2e` below: 2610 tests, 0 failures, 0 errors, 0 skipped (baseline was 2603; 7 new).
- [x] `mvn verify -Pe2e` (PMD, SpotBugs, Error Prone, coverage): BUILD SUCCESS on the final branch head. One earlier run failed PMD `DanglingJavadoc` on a javadoc my insertion had displaced in `MirrorWriter`; fixed and folded into the mirror commit, rerun green.
- [x] `mvn clean compile -Pself-annotate`: regenerated nothing, tree clean.
- [x] `action/locked-files/check_locked_diff.py` against `origin/main`: no locked code touched.
- [x] `pre-commit run --all-files` with `SKIP=checkstyle`: every other hook passed. The
  `checkstyle` hook is **not run** locally: it builds a Docker image and Docker Desktop is not
  running on this machine. `mvn verify` runs checkstyle through Maven, so it is covered there.
  The trailing-whitespace hook also flags one pre-existing blank line in `vibetags/pom.xml` on
  `main`; that fix is not in this PR.
- [x] Each new test was run red before its fix (failure text in the commit messages) and green after.
- [x] Docs: `docs/PROCESSOR.md` (fingerprint inputs), `docs/MULTI-MODULE.md` (mirror naming and
  sibling protection), `docs/CHANGELOG.md` (Unreleased: five Fixed entries, one Upgrading note).

## Provenance and prompt lineage

- Author: Claude Fable 5.1 (agent); no human review yet.
- Session: https://claude.ai/code/session_01S8fkdF6fQsSfey7ifW6YJq
- Load-bearing intent: "go on correct bugfixing hunt first in core and then more", run under the
  `correctness-hunt` skill's work order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8fkdF6fQsSfey7ifW6YJq
