### PR TITLE
fix: carry the granular heading through the cross-module merge (#579)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Two modules whose granular stems differ only in capitalisation (`com.example.Payment` in one,
+  package `com.example.payment` in another) share one rule file on Windows and macOS, and its heading
+  and description came from whichever module compiled last, so check mode's verdict depended on
+  build order. Each sidecar contribution now carries its heading name and description under a key
+  of its own (`~granname~<stem>`, ignored by older siblings), and the cross-module merge joins them
+  the way the single-module fold already did. `MultiModuleCaseCollisionTest` pins it (issue #579).
+
 ## [1.3.1] - 2026-09-04
 
 ### Upgrading

--- a/docs/MULTI-MODULE.md
+++ b/docs/MULTI-MODULE.md
@@ -271,10 +271,15 @@ written differently). `ModuleSidecar.mergeGranular` then groups those contributi
 hands the writer one body per file: a lone contributor's body verbatim — which is what keeps the
 single-module output byte-for-byte unchanged — and several wrapped in `VIBETAGS-MODULE` sub-markers,
 with their globs unioned. The union is taken whole rather than per module, so every module writes
-the same bytes and reactor order cannot churn the diff.
+the same bytes and reactor order cannot churn the diff. The heading name and front-matter description
+travel with each contribution under `~granname~<stem>` (a key of its own, so an older sibling that
+does not know it leaves it unstored instead of reading it as glob or body text) and are joined the
+way the single-module case-collision fold joins them: two modules whose stems differ only in
+capitalisation, one physical file on Windows and macOS, get `# Rules for Payment, payment` from
+either module rather than a heading that flips with compile order (issue #579).
 
 The module's own nested rules (`module-a/.claude/rules/`) merge through the same machinery, under
-`~modgran~<stem>` and scoped to one region: no cross-module merge and no sub-markers there, but a
+`~modgran~<stem>` (naming under `~modgranname~<stem>`) and scoped to one region: no cross-module merge and no sub-markers there, but a
 role matched by both a module's main and test sources still needs both rounds' contributions —
 without them the second source set to compile replaced the first's file.
 

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GranularRulesWriter.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/GranularRulesWriter.java
@@ -129,7 +129,8 @@ public final class GranularRulesWriter {
             Map<TaggedElement, GranularBody> elementRules, @Nullable RoleConfig roles) {
         Map<String, GranularContribution> contributions = new LinkedHashMap<>();
         plan(elementRules, roles, "", List.of())
-            .forEach((stem, unit) -> contributions.put(stem, unit.content()));
+            .forEach((stem, unit) -> contributions.put(stem,
+                unit.content().named(unit.displayName(), unit.description())));
         return contributions;
     }
 
@@ -165,9 +166,19 @@ public final class GranularRulesWriter {
             GranularContribution merged = mergedByStem.get(stem);
             List<String> globs = unit.content().globs();
             String body = unit.content().body();
+            String displayName = unit.displayName();
+            String description = unit.description();
             if (merged != null && !merged.isEmpty() && !merged.globs().isEmpty()) {
                 globs = merged.globs();
                 body = merged.body();
+                // The heading follows the merged view too, or a file two modules write under
+                // two spellings of one name is headed by whichever compiled last (issue #579).
+                // A merge assembled from sidecars that carry no naming (an older sibling's)
+                // keeps this module's own heading, as before.
+                if (merged.isNamed()) {
+                    displayName = merged.displayName();
+                    description = merged.description();
+                }
             }
             for (GranularFormat f : formats) {
                 Path serviceDir = serviceFiles.get(f.serviceKey);
@@ -176,7 +187,7 @@ public final class GranularRulesWriter {
                 }
                 fileWriter.writeFileIfChanged(
                     serviceDir.resolve(stem + f.extension).toString(),
-                    f.render(unit.description(), unit.displayName(), globs, body), true);
+                    f.render(description, displayName, globs, body), true);
             }
         }
 

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
@@ -137,6 +137,15 @@ public final class ModuleSidecar {
     private static final String KEY_GRANULAR_UNIT_PREFIX = "~gran~";
     /** As above, for the module's own (nested) granular output; merged across source sets only. */
     private static final String KEY_MODULE_GRANULAR_UNIT_PREFIX = "~modgran~";
+    /**
+     * Key prefix for a granular contribution's heading name and description, keyed by stem. A key
+     * of its own rather than a field inside the {@code ~gran~} value: that value's shape is what an
+     * older sibling parses, and a field added to it would be read as glob or body text, whereas an
+     * unknown reserved key is one such a reader leaves unstored (issue #579).
+     */
+    private static final String KEY_GRANULAR_NAMING_PREFIX = "~granname~";
+    /** As above, for the module's own (nested) granular output. */
+    private static final String KEY_MODULE_GRANULAR_NAMING_PREFIX = "~modgranname~";
 
     /** Windows path separator, folded to '/' before any module path is compared. */
     private static final char BACKSLASH = (char) 92;
@@ -326,9 +335,17 @@ public final class ModuleSidecar {
         }
         for (Map.Entry<String, GranularContribution> entry : granularUnits.entrySet()) {
             appendEncoded(sb, KEY_GRANULAR_UNIT_PREFIX + entry.getKey(), entry.getValue().serialize());
+            if (entry.getValue().isNamed()) {
+                appendEncoded(sb, KEY_GRANULAR_NAMING_PREFIX + entry.getKey(),
+                    entry.getValue().serializeNaming());
+            }
         }
         for (Map.Entry<String, GranularContribution> entry : moduleGranularUnits.entrySet()) {
             appendEncoded(sb, KEY_MODULE_GRANULAR_UNIT_PREFIX + entry.getKey(), entry.getValue().serialize());
+            if (entry.getValue().isNamed()) {
+                appendEncoded(sb, KEY_MODULE_GRANULAR_NAMING_PREFIX + entry.getKey(),
+                    entry.getValue().serializeNaming());
+            }
         }
         if (!granularStems.isEmpty()) {
             appendEncoded(sb, KEY_GRANULAR_STEMS, String.join("\n", granularStems));
@@ -524,6 +541,8 @@ public final class ModuleSidecar {
             Set<String> elementIds = new LinkedHashSet<>();
             Map<String, GranularContribution> granularUnits = new LinkedHashMap<>();
             Map<String, GranularContribution> moduleGranularUnits = new LinkedHashMap<>();
+            Map<String, String> granularNaming = new LinkedHashMap<>();
+            Map<String, String> moduleGranularNaming = new LinkedHashMap<>();
             for (String line : lines) {
                 if (line.startsWith("#")) {
                     // Enforce the format-version header: refuse to (mis-)parse future formats,
@@ -561,6 +580,10 @@ public final class ModuleSidecar {
                     for (String id : decode(val).split("\n", -1)) {
                         if (!id.isBlank()) elementIds.add(id);
                     }
+                } else if (key.startsWith(KEY_MODULE_GRANULAR_NAMING_PREFIX)) {
+                    moduleGranularNaming.put(key.substring(KEY_MODULE_GRANULAR_NAMING_PREFIX.length()), decode(val));
+                } else if (key.startsWith(KEY_GRANULAR_NAMING_PREFIX)) {
+                    granularNaming.put(key.substring(KEY_GRANULAR_NAMING_PREFIX.length()), decode(val));
                 } else if (key.startsWith(KEY_MODULE_GRANULAR_UNIT_PREFIX)) {
                     // Checked before the ~mod~ prefix below: "~modgran~" does not start with
                     // "~mod~", but the two read alike and the order is what keeps that true.
@@ -595,6 +618,11 @@ public final class ModuleSidecar {
             s.indexDigests.putAll(indexDigests);
             s.granularStems.addAll(granularStems);
             s.elementIds.addAll(elementIds);
+            // Naming lines may precede or follow their contribution; attach once both are in.
+            granularNaming.forEach((stem, naming) ->
+                granularUnits.computeIfPresent(stem, (k, c) -> c.withNaming(naming)));
+            moduleGranularNaming.forEach((stem, naming) ->
+                moduleGranularUnits.computeIfPresent(stem, (k, c) -> c.withNaming(naming)));
             s.granularUnits.putAll(granularUnits);
             s.moduleGranularUnits.putAll(moduleGranularUnits);
             return s;
@@ -1300,17 +1328,30 @@ public final class ModuleSidecar {
                 });
             }
             Set<String> globs = new LinkedHashSet<>();
+            // The heading and description travel with each contribution and are joined here the
+            // way the single-module fold joins them, so a file two modules write under two
+            // spellings of one name is headed the same whichever compiled last (issue #579).
+            // Deduplicated by value: a role file spanning modules names the role once.
+            Set<String> displayNames = new LinkedHashSet<>();
+            Set<String> subjects = new LinkedHashSet<>();
             List<Map.Entry<String, String>> regionBodies = new ArrayList<>();
             byRegion.forEach((region, contributions) -> {
                 List<String> parts = new ArrayList<>();
                 for (GranularContribution c : contributions) {
                     globs.addAll(c.globs());
                     parts.add(c.body().strip());
+                    if (c.isNamed()) {
+                        displayNames.add(c.displayName());
+                        subjects.add(c.subject());
+                    }
                 }
                 regionBodies.add(new AbstractMap.SimpleEntry<>(region, String.join("\n\n", parts)));
             });
             GranularContribution shared = new GranularContribution(new ArrayList<>(globs),
-                joinRegions(regionBodies, subMarkers));
+                joinRegions(regionBodies, subMarkers),
+                String.join(", ", displayNames),
+                displayNames.isEmpty() ? ""
+                    : GranularContribution.DESCRIPTION_PREFIX + String.join(", ", subjects));
             for (Map.Entry<String, Map<String, List<GranularContribution>>> stemEntry : group) {
                 merged.put(stemEntry.getKey(), shared);
             }

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/GranularContribution.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/content/GranularContribution.java
@@ -22,7 +22,54 @@ import java.util.List;
  * body underneath. Globs are single-line by construction (they come from a config line or from a
  * class name), so the first newline is an unambiguous separator.
  */
-public record GranularContribution(List<String> globs, String body) {
+public record GranularContribution(List<String> globs, String body, String displayName, String description) {
+
+    /** Prefix every planned description starts with; what the merge joins subjects behind. */
+    public static final String DESCRIPTION_PREFIX = "AI rules for ";
+
+    /** A contribution with no naming of its own; the writer falls back to its local plan. */
+    public GranularContribution(List<String> globs, String body) {
+        this(globs, body, "", "");
+    }
+
+    /** The description's subject: what follows {@link #DESCRIPTION_PREFIX}, or the whole text. */
+    public String subject() {
+        return description.startsWith(DESCRIPTION_PREFIX)
+            ? description.substring(DESCRIPTION_PREFIX.length()) : description;
+    }
+
+    /** Whether this contribution names itself (heading and description travel with it). */
+    public boolean isNamed() {
+        return !displayName.isEmpty();
+    }
+
+    /**
+     * The heading name and description, serialized for the sidecar under their own key.
+     *
+     * <p>Kept apart from {@link #serialize()} on purpose: that value's shape is what an older
+     * sibling's {@link #parse} reads, and a field added to it would be read back as part of the
+     * glob line or the body. A key of its own is one an older reader recognises as reserved and
+     * leaves unstored.
+     */
+    public String serializeNaming() {
+        return displayName + "\n" + description;
+    }
+
+    /** {@code this}, named as {@code serializedNaming} says; unchanged when it is malformed. */
+    public GranularContribution withNaming(String serializedNaming) {
+        int newline = serializedNaming.indexOf('\n');
+        if (newline < 0) {
+            return this;
+        }
+        return new GranularContribution(globs, body,
+            serializedNaming.substring(0, newline), serializedNaming.substring(newline + 1));
+    }
+
+    /** {@code this} under another name; the fold across modules builds its joined heading here. */
+    public GranularContribution named(String newDisplayName, String newDescription) {
+        return new GranularContribution(globs, body, newDisplayName, newDescription);
+    }
+
 
     /** Separator between globs on the serialized header line; illegal inside a glob pattern. */
     private static final String GLOB_SEPARATOR = "\t";

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/MultiModuleCaseCollisionTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/MultiModuleCaseCollisionTest.java
@@ -1,0 +1,107 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Two modules whose granular stems differ only in capitalisation share one rule file on a
+ * case-insensitive filesystem, and the file must not depend on which module compiled last
+ * (issue #579).
+ *
+ * <p>{@code ModuleSidecar.mergeGranular} already folds the two stems into one body, but the
+ * heading and the front-matter description were rendered from the compiling module's own plan:
+ * {@code # Rules for Payment} after module {@code a}, {@code # Rules for payment} after module
+ * {@code b}. On Windows and macOS the two names are one file, so it flipped with every compile
+ * and check mode's verdict depended on build order. The single-module fold already produces a
+ * joined heading; the cross-module merge has to produce the same one.
+ */
+@Tag("e2e")
+class MultiModuleCaseCollisionTest {
+
+    private static final String CLASS_SOURCE = """
+        package com.example;
+        import se.deversity.vibetags.annotations.AILocked;
+        @AILocked(reason = "wire format")
+        public class Payment {}
+        """;
+
+    private static final String PACKAGE_SOURCE = """
+        @se.deversity.vibetags.annotations.AIContext(focus = "settlement timing")
+        package com.example.payment;
+        """;
+
+    @TempDir
+    Path reactorRoot;
+
+    @AfterEach
+    void tearDown() {
+        VibeTagsLogger.shutdown();
+    }
+
+    private void compileModule(String module, String fqn, String source) throws IOException {
+        ProcessorTestHarness harness = new ProcessorTestHarness(reactorRoot, false);
+        Files.createDirectories(reactorRoot.resolve(module));
+        Files.writeString(reactorRoot.resolve(module).resolve("pom.xml"),
+            "<project><artifactId>" + module + "</artifactId></project>", StandardCharsets.UTF_8);
+        harness.writeSourceFile(module + "/src/main/java/" + fqn.replace('.', '/') + ".java", source);
+        harness.compile();
+    }
+
+    /** Every rule file whose name folds to the colliding stem, by name, with its content. */
+    private Map<String, String> collidingFiles() throws IOException {
+        Map<String, String> files = new TreeMap<>();
+        try (var entries = Files.list(reactorRoot.resolve(".cursor/rules"))) {
+            for (Path p : entries.toList()) {
+                String name = String.valueOf(p.getFileName());
+                // Keyed case-folded: on a case-insensitive filesystem the one file's entry takes
+                // the case of whichever name last wrote it, and that is not what is under test.
+                String folded = name.toLowerCase(Locale.ROOT);
+                if (folded.equals("com-example-payment.mdc")) {
+                    files.put(folded, Files.readString(p, StandardCharsets.UTF_8));
+                }
+            }
+        }
+        return files;
+    }
+
+    @Test
+    void sharedFileDoesNotDependOnWhichModuleCompiledLast() throws IOException {
+        Files.createFile(reactorRoot.resolve(".cursorrules"));
+        Files.createDirectories(reactorRoot.resolve(".cursor/rules"));
+        Files.createFile(reactorRoot.resolve(".cursor/rules/.vibetags"));
+
+        compileModule("a", "com.example.Payment", CLASS_SOURCE);
+        compileModule("b", "com.example.payment.package-info", PACKAGE_SOURCE);
+        Map<String, String> afterB = collidingFiles();
+        assertFalse(afterB.isEmpty(), "no rule file written for the colliding stems at all");
+
+        compileModule("a", "com.example.Payment", CLASS_SOURCE);
+        Map<String, String> afterA = collidingFiles();
+
+        assertEquals(afterB, afterA,
+            "recompiling the other module must leave every colliding file byte-identical");
+        for (Map.Entry<String, String> file : afterA.entrySet()) {
+            String content = file.getValue();
+            assertTrue(content.contains("# Rules for Payment, payment"),
+                file.getKey() + " covers both elements, so its heading must name both: " + content);
+            assertTrue(content.contains("description: \"AI rules for com.example.Payment, com.example.payment\""),
+                file.getKey() + "'s description must name both: " + content);
+            assertTrue(content.contains("wire format") && content.contains("settlement timing"),
+                file.getKey() + " must carry both guardrails: " + content);
+        }
+    }
+}


### PR DESCRIPTION
## Why

Closes #579. Two modules whose granular stems differ only in capitalisation (`com.example.Payment`
in module `a`, package `com.example.payment` in module `b`) share one rule file on Windows and
macOS. `ModuleSidecar.mergeGranular` already folded their bodies into one, but the heading and the
front-matter description were rendered from the compiling module's own plan, so the file read
`# Rules for Payment` after `a` and `# Rules for payment` after `b`, and check mode's verdict
depended on which module compiled last. The single-module fold (`foldCaseCollisions`) already
produced a joined heading; the cross-module merge now produces the same one.

## How

- `GranularContribution` gains `displayName` and `description`. They are serialized in the sidecar
  under a key of their own, `~granname~<stem>` (`~modgranname~<stem>` for the module's nested
  output), rather than as a field inside the `~gran~` value. That value's shape is what an older
  sibling's `parse` reads, and an extra field there would come back as glob or body text; an
  unknown reserved key is one such a reader leaves unstored, so a mixed-version reactor keeps
  working and the older module simply keeps its own heading. Format version stays 2, per the
  documented rule for additive keys.
- `mergeGranularUnits` joins the names and subjects of every contribution in a fold group,
  deduplicated by value (a role file spanning modules names the role once), and
  `GranularRulesWriter.write` renders from the merged naming when the merge carries one.
- A single-module, single-stem file is byte-identical to before: its merged naming is its own.

## Verification

- [x] `mvn verify -Pe2e` from `vibetags/`: BUILD SUCCESS, 2604 tests, 0 failures (2603 on main; 1 new).
- [x] `MultiModuleCaseCollisionTest.sharedFileDoesNotDependOnWhichModuleCompiledLast` was red
  before the fix (heading and even the file-name case flipped on the third compile, `files=1` on
  Windows) and is green after.
- [x] `mvn clean compile -Pself-annotate`: regenerated nothing, tree clean.
- [x] `action/locked-files/check_locked_diff.py` against `origin/main`: no locked code touched.
- [x] `pre-commit run --all-files` with `SKIP=checkstyle` (Docker not running here; Maven runs
  checkstyle in verify): passed apart from a pre-existing trailing-whitespace line in
  `vibetags/pom.xml` on `main`, reverted and not in this PR.
- [x] Docs: `docs/MULTI-MODULE.md` (the naming key and the joined heading), `docs/CHANGELOG.md`.

## Provenance and prompt lineage

- Author: Claude Fable 5.1 (agent); no human review yet.
- Session: https://claude.ai/code/session_01S8fkdF6fQsSfey7ifW6YJq
- Load-bearing intent: "fix open issues", after the 2026-09-05 correctness hunt (PR #580) filed
  this one as escalated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8fkdF6fQsSfey7ifW6YJq
