### PR TITLE
docs(examples): exercise the manifest fallbacks in the kotlin example (#534)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -853,6 +853,17 @@ jobs:
           # files must name the annotated Kotlin elements, stub signatures included.
           grep -qF "com.example.kotlin.PaymentService.chargeKey(java.lang.String,int)" CLAUDE.md
           grep -qF "com.example.kotlin.CustomerVault" .cursorrules
+          # The transitive-manifest fallbacks a kapt build needs (issue #534): the manifest under
+          # vibetags-manifests/ is read through -Avibetags.manifest.dir and rendered under its
+          # origin coordinate; -Avibetags.manifest.max=1 keeps the first advisory rule and drops
+          # the second, while the safety-tier rule survives the cap regardless.
+          grep -qF "(from se.deversity.vibetags.example:multimodule-core:1.0)" CLAUDE.md
+          grep -qF "@AISecure: aspect=Node identity is a security boundary" CLAUDE.md
+          grep -qF "@AIContext: avoids=Adding mutable state" CLAUDE.md
+          if grep -qF "@AIThreadSafe: note=Every type in this package" CLAUDE.md; then
+            echo "::error::-Avibetags.manifest.max=1 must drop the second advisory rule."
+            exit 1
+          fi
 
       - name: Verify The Kotlin Example's Committed Guardrails Match Its Annotations
         if: matrix.java == '21'

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `examples/kotlin` exercises the transitive-manifest fallbacks a kapt build needs:
+  `-Avibetags.manifest.dir` reads a manifest copied from what `examples/multimodule/core`
+  publishes, `-Avibetags.manifest.max=1` caps the inherited advisory rules, and CI asserts the
+  origin coordinate, the surviving safety rule and the dropped advisory rule in the regenerated
+  files. `manifest.packages` stays documented only; it needs a dependency JAR on the classpath
+  that no example carries. (#534)
+
 ## [1.3.1] - 2026-09-04
 
 ### Upgrading

--- a/examples/INDEX.md
+++ b/examples/INDEX.md
@@ -1,7 +1,7 @@
 # Examples coverage index
 
 What each example exercises and how CI verifies it, audited against
-`.github/workflows/build.yml` on 2026-08-31. [README.md](README.md) is the narrative guide for
+`.github/workflows/build.yml` on 2026-08-31, manifest row updated 2026-09-05. [README.md](README.md) is the narrative guide for
 picking an example to read; this file is the coverage ledger. When the two disagree, the workflow
 file wins: every gate named below is a step that exists there.
 
@@ -21,7 +21,7 @@ date. "Drift gate" is what CI does to the example's committed generated files af
 | [`gradle-shared-buildfile/`](gradle-shared-buildfile/) | Gradle | 2 | 2 | `CLAUDE.md` only | both module identities survive |
 | [`gradle-flat/`](gradle-flat/) | Gradle | 2 | 2 | `CLAUDE.md` only | module ids are names, not path hashes |
 | [`gradle-composite/`](gradle-composite/) | Gradle, `includeBuild` | 2 builds | 2 | `CLAUDE.md` only | both builds land in one root file |
-| [`kotlin/`](kotlin/) | Gradle + kapt | 1 | 4 | byte for byte, whole directory | Kotlin elements appear, stub signatures included |
+| [`kotlin/`](kotlin/) | Gradle + kapt | 1 | 4 | byte for byte, whole directory | Kotlin elements appear, stub signatures included; inherited rules from a pre-extracted manifest render under their origin, the `manifest.max` cap drops exactly the advisory rule |
 | [`groovy/`](groovy/) | Gradle | 1 | 3 | byte for byte, whole directory | annotated class and method appear; the `@AIPrivacy` field does NOT (groovyc stubs carry no fields) |
 | [`scala/`](scala/) | Gradle | 1 | 2 | byte for byte, whole directory | annotated Java class appears, Scala class does not |
 
@@ -48,7 +48,7 @@ Which example to read for a given processor feature.
 | Groovy joint-compilation stubs, field drop gated | `groovy` |
 | scalac's missing JSR 269 support, gated not claimed | `scala` |
 | Processor options exercised by a build file | `root`, `module`, `check`, `enforce`, `baseline.update`, `cache`, `log.level`, `log.path`, `project` |
-| Manifest fallback options (`manifest.dir`, `manifest.packages`, `manifest.max`) | documented in the `.vibetags-transitive` comments; no build passes them |
+| Manifest fallback options (`manifest.dir`, `manifest.max`) | `kotlin` (kapt reads a pre-extracted manifest from `vibetags-manifests/` and caps advisory rules at 1; CI asserts the origin, the safety rule and the dropped advisory rule). `manifest.packages` is still documented only, in the `.vibetags-transitive` comments |
 | The companion CLI, run | CI runs `doctor --dir examples/groovy` (it must name the dropped `contactEmail` field) and `init --list --dir examples/basic` (it must print the platform keys and create nothing) — issue #533 |
 
 ## Not covered by any example
@@ -56,7 +56,8 @@ Which example to read for a given processor feature.
 Verified absent by grep over `examples/` on 2026-08-31. Each entry says what a reader cannot
 currently see demonstrated.
 
-1. **Manifest tuning options.** `manifest.dir`, `manifest.packages` and `manifest.max` exist for
-   builds where classpath discovery cannot work (kapt, ECJ, JPMS). They are documented where a
-   reader will meet them, in the `.vibetags-transitive` comments, and exercised by library tests
-   only.
+1. **`manifest.packages`.** The explicit-lookup-key variant of the manifest fallbacks needs a
+   dependency JAR that carries manifests on the compile classpath, which no example has;
+   `manifest.dir` and `manifest.max` are exercised by `kotlin/` since issue #534. It is documented
+   where a reader will meet it, in the `.vibetags-transitive` comments, and exercised by library
+   tests only.

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,7 +48,7 @@ matrix is maintained.
 
 | Example | Build | What it shows |
 |---|---|---|
-| [`kotlin/`](kotlin/) | Gradle, Kotlin DSL | kapt runs the processor over Kotlin sources. CI asserts the generated files name the Kotlin elements, stub signatures included. |
+| [`kotlin/`](kotlin/) | Gradle, Kotlin DSL | kapt runs the processor over Kotlin sources. CI asserts the generated files name the Kotlin elements, stub signatures included. Also the fixture for the transitive-manifest fallbacks: `-Avibetags.manifest.dir` reads a pre-extracted manifest and `-Avibetags.manifest.max` caps the inherited advisory rules. |
 | [`groovy/`](groovy/) | Gradle | Joint compilation with `javaAnnotationProcessing = true`, the Groovy analogue of kapt. Also gates Groovy's own trap: a deliberate `@AIPrivacy` field, and CI asserts it reaches no generated file, because groovyc stubs carry no fields |
 | [`scala/`](scala/) | Gradle | The limitation, gated. scalac has no JSR 269 support, so CI asserts the annotated Java class appears and the annotated Scala class does not. If that ever changes, the build goes red and the docs are wrong, not the code. |
 

--- a/examples/kotlin/.cursorrules
+++ b/examples/kotlin/.cursorrules
@@ -22,4 +22,18 @@ test fixtures, mock data, or code suggestions.
 The following elements are well-tested core components. Make changes with extreme caution.
 
 * `com.example.kotlin.CustomerVault.findCustomer(java.lang.String)` - Sensitivity: critical. Note: Primary lookup path for every checkout; covered by the vault contract suite
+
+## Inherited Guardrails (dependencies)
+
+These come from packages this project depends on. They constrain how the dependency may be used; they are not editable from here.
+
+- `com.example.multimodule.core` (from se.deversity.vibetags.example:multimodule-core:1.0)
+  - @AISecure: aspect=Node identity is a security boundary: never build an IrNode from unvalidated external input, and never expose its raw id in a URL or log line.
+
+## Inherited Context (dependencies)
+
+Conventions the dependency's authors documented. Follow them unless this project's own rules above say otherwise.
+
+- `com.example.multimodule.core` (from se.deversity.vibetags.example:multimodule-core:1.0)
+  - @AIContext: avoids=Adding mutable state, framework annotations, or a dependency on any sibling module.; focus=Immutable IR data model shared across every module of the reactor.
 # VIBETAGS-END

--- a/examples/kotlin/.vibetags-transitive
+++ b/examples/kotlin/.vibetags-transitive
@@ -1,0 +1,17 @@
+# Opts this project into reading guardrails published by its dependencies.
+#
+# Presence of this file is the opt-in; it needs no content. On a plain javac build VibeTags derives
+# lookup keys from the packages the sources import and reads the matching vibetags/manifests/
+# entries off the compile classpath. kapt compiles generated Java stubs, and the classpath
+# discovery that works under javac is not something to rely on there, so this example uses the
+# fallback documented for builds where discovery cannot work (kapt, ECJ, JPMS):
+#
+#   -Avibetags.manifest.dir=<dir>        read pre-extracted manifests from a directory
+#   -Avibetags.manifest.packages=a.b,c.d supply lookup keys explicitly (classpath lookup)
+#   -Avibetags.manifest.max=<n>          cap inherited advisory rules (safety rules are never cut)
+#
+# build.gradle.kts passes manifest.dir pointing at vibetags-manifests/, which holds one manifest
+# copied verbatim from what examples/multimodule/core publishes into its JAR
+# (target/classes/vibetags/manifests/com.example.multimodule.core.json), and manifest.max=1 so the
+# cap is visible in the output: of the manifest's two advisory rules only the first survives, while
+# its @AISecure rule is kept regardless because safety-tier rules are never dropped.

--- a/examples/kotlin/CLAUDE.md
+++ b/examples/kotlin/CLAUDE.md
@@ -32,4 +32,18 @@
 </project_guardrails>
 
 <rule>Never propose edits to files listed in <locked_files>.</rule>
+
+## Inherited Guardrails (dependencies)
+
+These come from packages this project depends on. They constrain how the dependency may be used; they are not editable from here.
+
+- `com.example.multimodule.core` (from se.deversity.vibetags.example:multimodule-core:1.0)
+  - @AISecure: aspect=Node identity is a security boundary: never build an IrNode from unvalidated external input, and never expose its raw id in a URL or log line.
+
+## Inherited Context (dependencies)
+
+Conventions the dependency's authors documented. Follow them unless this project's own rules above say otherwise.
+
+- `com.example.multimodule.core` (from se.deversity.vibetags.example:multimodule-core:1.0)
+  - @AIContext: avoids=Adding mutable state, framework annotations, or a dependency on any sibling module.; focus=Immutable IR data model shared across every module of the reactor.
 <!-- VIBETAGS-END -->

--- a/examples/kotlin/README.md
+++ b/examples/kotlin/README.md
@@ -36,6 +36,28 @@ kapt {
 }
 ```
 
+## Inherited guardrails under kapt
+
+`.vibetags-transitive` opts this project into guardrails published by its dependencies. A javac
+build finds them by looking up the packages the sources import on the compile classpath; kapt
+compiles generated stubs, and that discovery is not something to rely on there. The fallback the
+processor documents for such builds is what this example uses:
+
+```kotlin
+kapt {
+    arguments {
+        arg("vibetags.manifest.dir", file("vibetags-manifests").absolutePath)
+        arg("vibetags.manifest.max", "1")
+    }
+}
+```
+
+`vibetags-manifests/com.example.multimodule.core.json` is a manifest copied verbatim from what
+`examples/multimodule/core` publishes into its JAR. The generated `CLAUDE.md` and `.cursorrules`
+render its rules under the origin coordinate the manifest carries. `manifest.max=1` keeps one of
+the manifest's two advisory rules and drops the other, which the build reports as a note; the
+`@AISecure` rule is kept regardless, because safety-tier rules are never cut by the cap.
+
 ## Kotlin-specific limitations
 
 kapt runs annotation processors over generated **Java stubs**, not the Kotlin sources.

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -33,5 +33,11 @@ kapt {
         // kapt compiles from generated Java stubs, so the JVM working directory is not
         // the project directory — the root must be passed explicitly.
         arg("vibetags.root", projectDir.absolutePath)
+        // Transitive guardrails (.vibetags-transitive) under kapt: the classpath discovery a
+        // javac build uses is not something to rely on from stub compilation, so the manifests
+        // are read from a directory of pre-extracted files instead. manifest.max=1 caps the
+        // inherited advisory rules so the cap is visible in CLAUDE.md; safety rules are never cut.
+        arg("vibetags.manifest.dir", file("vibetags-manifests").absolutePath)
+        arg("vibetags.manifest.max", "1")
     }
 }

--- a/examples/kotlin/vibetags-manifests/com.example.multimodule.core.json
+++ b/examples/kotlin/vibetags-manifests/com.example.multimodule.core.json
@@ -1,0 +1,31 @@
+{
+  "manifestVersion": 1,
+  "origin": "se.deversity.vibetags.example:multimodule-core:1.0",
+  "package": "com.example.multimodule.core",
+  "producedBy": "vibetags/1.3.0",
+  "rules": [
+    {
+      "annotation": "@AIContext",
+      "tier": "ADVISORY",
+      "members": {
+        "avoids": "Adding mutable state, framework annotations, or a dependency on any sibling module.",
+        "focus": "Immutable IR data model shared across every module of the reactor."
+      }
+    },
+    {
+      "annotation": "@AISecure",
+      "tier": "SAFETY",
+      "members": {
+        "aspect": "Node identity is a security boundary: never build an IrNode from unvalidated external input, and never expose its raw id in a URL or log line."
+      }
+    },
+    {
+      "annotation": "@AIThreadSafe",
+      "tier": "ADVISORY",
+      "members": {
+        "note": "Every type in this package is safe to publish across threads without synchronization.",
+        "strategy": "IMMUTABLE"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Why

Closes #534. `-Avibetags.manifest.dir`, `-Avibetags.manifest.packages` and `-Avibetags.manifest.max`
exist for builds where classpath discovery cannot work (kapt, ECJ, JPMS), but no example build
passed any of them; `examples/INDEX.md` recorded the gap. `examples/kotlin` is the natural host,
since kapt is exactly such a build.

## What

- `examples/kotlin/.vibetags-transitive` opts the example in and explains the three options.
- `examples/kotlin/vibetags-manifests/com.example.multimodule.core.json` is a manifest copied
  verbatim from what `examples/multimodule/core` publishes into its JAR.
- `build.gradle.kts` passes `manifest.dir` pointing at that directory and `manifest.max=1`, so the
  regenerated `CLAUDE.md` and `.cursorrules` carry the inherited sections under the origin
  coordinate, keep the `@AISecure` rule (safety-tier rules are never cut), keep the first advisory
  rule and drop the second.
- CI's kotlin step greps for the origin, the surviving safety rule, the surviving advisory rule,
  and fails if the dropped advisory rule appears.
- `manifest.packages` stays documented only: it needs a dependency JAR carrying manifests on the
  compile classpath, which no example has. `examples/INDEX.md` says so in its "not covered" list.

## Verification

- [x] `./gradlew clean build --no-daemon` in `examples/kotlin`: BUILD SUCCESSFUL; the processor
  reported `inherited 2 guardrail(s) from dependencies (1 advisory rule(s) dropped by
  -Avibetags.manifest.max=1) after 0 classpath lookup(s)`.
- [x] The four new CI greps pass locally against the committed files.
- [x] `mvn test` (fast tier) from `vibetags/` with the changes staged: 1906 tests, 0 failures.
  `-Pe2e` not run: no processor source changed.
- [x] `pre-commit run --all-files` with `SKIP=checkstyle` (Docker not running here): passed
  apart from the pre-existing trailing-whitespace line in `vibetags/pom.xml` on `main`, reverted.
- [x] Docs: `examples/INDEX.md`, `examples/README.md`, `examples/kotlin/README.md`,
  `docs/CHANGELOG.md`.

## Provenance and prompt lineage

- Author: Claude Fable 5.1 (agent); no human review yet.
- Session: https://claude.ai/code/session_01S8fkdF6fQsSfey7ifW6YJq
- Load-bearing intent: "fix open issues".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8fkdF6fQsSfey7ifW6YJq
