### PR TITLE
fix(build): pin the Gradle test worker's heap, and print enough to read the next failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1366,6 +1366,21 @@ jobs:
           cd vibetags
           ./gradlew test -Pe2e --no-daemon
 
+      # A failing test here used to leave nothing behind: Gradle's console output names the
+      # exception class and a line number, and the reports that carry the assertion message and
+      # the processor diagnostics live in a build directory the runner throws away. build.gradle
+      # now prints the full exception; this keeps the report too, so an intermittent failure can
+      # be read after the fact instead of re-run until it hides.
+      - name: Upload the Gradle test report (on failure)
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gradle-test-report-jdk${{ matrix.java }}
+          path: |
+            vibetags/build/reports/tests/test
+            vibetags/build/test-results/test
+          retention-days: 7
+
       - name: Verify Generated AI Config Files
         uses: ./.github/actions/verify-generated-files
         with:

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -32,6 +32,17 @@ fingerprinting, multi-module reactors and mirroring, international characters, a
 loops. Those are exactly the areas where "it compiled and the file looked right" is not evidence, so
 run `-Pe2e` before pushing anything that touches them.
 
+**The Gradle test worker's heap is pinned, and has to be.** Gradle defaults a test worker to
+`-Xmx512m`; surefire's fork inherits the JVM default, a quarter of RAM. Since
+`junit-platform.properties` runs the suite concurrently and most e2e classes drive an in-process
+`javac` over the whole test classpath, the same suite was running under heaps an order of magnitude
+apart, and only the Gradle legs could exhaust theirs. `vibetags/build.gradle` sets
+`maxHeapSize = "2g"`; `BuildToolchainParityTest` fails if that line goes away. The failure that
+prompted the pin (a Gradle-only leg, two arbitrary e2e tests, on a tree byte-identical to a green
+run) was never captured with a message, so the heap is the leading explanation and not a proven
+one; the same change turns on `exceptionFormat = "full"` and uploads the Gradle test report on
+failure so the next occurrence can be read rather than guessed at.
+
 **Naming a test overrides the tag.** `mvn test -Dtest=WriteCacheProcessorIntegrationTest` runs that
 class even though it is tagged, and so does `gradlew test --tests '*WriteCacheProcessorIntegrationTest'`.
 Both build files special-case this deliberately: without it the command prints `Tests run: 0` and

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -148,7 +148,13 @@ Mirror of `build-maven` but with Gradle. Matrix over **JDK 21, 25, 26**. Differe
   check reported `UP-TO-DATE` and exited 0. The second step drifts `CLAUDE.md` deliberately and
   requires a non-zero exit, then asserts the drift is still there, since check mode must never
   write. Every other check-mode gate in the pipeline is Maven.
-- Tests use `cd vibetags && ./gradlew test --no-daemon`.
+- Tests: the library build above runs the fast tier, and a later step runs the whole suite with
+  `cd vibetags && ./gradlew test -Pe2e --no-daemon`. That step is followed by an `if: failure()`
+  upload of `vibetags/build/reports/tests/test` and `vibetags/build/test-results/test`. Before
+  that upload existed, a failing Gradle test left only an exception class and a line number in
+  the console, and the report carrying the assertion message died with the runner;
+  `build.gradle` now also sets `exceptionFormat = "full"`. See `docs/TESTS.md` for why the
+  Gradle worker's heap is pinned rather than left at Gradle's 512m default.
 - Codecov reads `vibetags/build/reports/jacoco/test/jacocoTestReport.xml`, uploads under flag `unittests-gradle`, and passes `fail_ci_if_error: false`.
 
 The same `.github/actions/verify-generated-files` composite action runs after the Gradle build, so any divergence between Maven and Gradle output paths is caught.

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -162,6 +162,26 @@ compileJava {
 test {
     useJUnitPlatform()
     jvmArgs "-Dnet.bytebuddy.experimental=true", "-Dlicense.mock.mode=true"
+    // Measured: a Gradle test worker for this task started with -Xmx512m. Surefire's fork takes
+    // the JVM default instead, a quarter of RAM, so the same suite ran under heaps an order of
+    // magnitude apart depending on which build system launched it. That matters here because
+    // junit-platform.properties runs the suite concurrently and most e2e classes drive an
+    // in-process javac holding the whole test classpath, with the JaCoCo agent attached on top.
+    // The failure that prompted this was Gradle-only and intermittent: two arbitrary transitive
+    // e2e tests failed on a commit whose tree was byte-identical to an earlier green run, and a
+    // re-run of the same commit passed. Whether it was the heap is inferred, not proven - the
+    // console format at the time printed no message to read - but the asymmetry is real and this
+    // is the side that could run out. BuildToolchainParityTest keeps the line here.
+    maxHeapSize = "2g"
+    testLogging {
+        // Gradle's default exceptionFormat is SHORT: a CI failure prints the exception class and
+        // a line number and nothing else, which is how the flake above cost a full investigation
+        // to say no more than "it failed here". The assertion messages in this suite carry the
+        // generated file and the processor's own diagnostics; print them.
+        exceptionFormat = "full"
+        showStackTraces = true
+        events "failed"
+    }
     finalizedBy jacocoTestReport
 }
 

--- a/vibetags/pom.xml
+++ b/vibetags/pom.xml
@@ -557,7 +557,7 @@
                                  PIT varies a little run to run, and a gate that fails on noise is
                                  one people learn to rerun rather than read. Raise it when the
                                  score rises, and record the new number in docs/WORKFLOW.md. -->
-                            
+
                             <mutationThreshold>80</mutationThreshold>
                             <coverageThreshold>90</coverageThreshold>
                         </configuration>

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/BuildToolchainParityTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/BuildToolchainParityTest.java
@@ -125,6 +125,28 @@ class BuildToolchainParityTest {
         }
     }
 
+    /**
+     * Gradle gives a test worker {@code -Xmx512m} unless the build file says otherwise. Surefire
+     * gives its fork the JVM default, a quarter of the machine's RAM. Left to the defaults the two
+     * build systems therefore run this suite, concurrently and with the JaCoCo agent attached,
+     * under heaps that differ by roughly an order of magnitude, and only one of them can run out.
+     *
+     * <p>What was observed: a Gradle leg failed two arbitrary transitive end-to-end tests on a
+     * commit whose tree was byte-identical to an earlier green run, every Maven leg stayed green,
+     * and a re-run of the same commit passed. The console format at the time printed no assertion
+     * message, so the heap is the leading explanation rather than a proven one. Pinning it is what
+     * makes the Gradle legs test the same thing the Maven legs do, rather than also testing how
+     * close Gradle's default sits to this suite's peak footprint.
+     */
+    @Test
+    void theGradleTestWorker_pinsAnExplicitHeapRatherThanTakingGradlesDefault() {
+        String gradle = read(repoRoot().resolve("vibetags/build.gradle"));
+        assertTrue(gradle.contains("maxHeapSize"),
+            "vibetags/build.gradle no longer pins maxHeapSize on the test task, so Gradle's 512m"
+                + " default is back and the Gradle legs run this suite under a heap Maven's legs"
+                + " never see. See the javadoc on this test for what that failure looks like.");
+    }
+
     // -----------------------------------------------------------------------
 
     private static Path repoRoot() {


### PR DESCRIPTION
## What broke

`main` went red on run [34002850103](https://github.com/PIsberg/vibetags/actions/runs/34002850103): the **Gradle Build (JDK 21)** leg failed two transitive end-to-end tests, and nothing else in the run failed.

```
TransitiveGuardrailLifecycleE2ETest > nothingIsInheritedWithoutTheConsumerOptIn() FAILED
    org.opentest4j.AssertionFailedError at TransitiveGuardrailLifecycleE2ETest.java:793
TransitiveGuardrailLifecycleE2ETest > theAdvisoryCapDropsAdvisoryRulesButNeverSafetyOnes() FAILED
    org.opentest4j.AssertionFailedError at TransitiveGuardrailLifecycleE2ETest.java:793
2616 tests completed, 2 failed, 1 skipped
```

It was not a regression. `def7fda2` is an empty merge over `56e7e769`: `git diff 56e7e769 def7fda2` prints nothing, and `56e7e769` had gone green four hours earlier. Re-running the failed job on the same commit passed, and `main` is green now. The two Maven legs, the two other Gradle legs and both cross-platform legs were green on the failing run.

Line 793 is `assertTrue(errors.isEmpty(), "compilation failed: ...")` in the class's own javac harness, so a fixture compilation returned not-OK. Which of the two branches produced it, a real `ERROR` diagnostic or the harness's synthetic `"compilation reported failure with no ERROR diagnostic"`, is unknowable from the log: Gradle's default `exceptionFormat` is `SHORT`, so the console gets an exception class and a line number, and the HTML/XML report that carries the assertion message dies with the runner.

## What is measured

A Gradle test worker for `vibetags:test` starts with **`-Xmx512m`** (Gradle's default for a `Test` task; observed on the live process). Surefire's fork takes the JVM default instead, a quarter of RAM. `junit-platform.properties` runs the suite concurrently, most e2e classes drive an in-process `javac` holding the whole test classpath, and the JaCoCo agent is attached on top. So the two build systems were running the same 2617 tests under heaps an order of magnitude apart, and only one of them could run out.

That the heap is what failed here is **inferred, not proven** - no message survived to prove it. The asymmetry is measured, this is the side that can exhaust, and the same change makes the next occurrence readable instead of guessable.

## Changes

- `vibetags/build.gradle`: `maxHeapSize = "2g"`, and `testLogging { exceptionFormat = "full"; showStackTraces = true; events "failed" }`.
- `.github/workflows/build.yml`: `if: failure()` upload of `vibetags/build/reports/tests/test` and `vibetags/build/test-results/test` after the full-suite step.
- `BuildToolchainParityTest`: a new case pinning the heap line, in the class that already exists to stop the two build systems diverging silently.
- `docs/TESTS.md`, `docs/WORKFLOW.md`: the heap and the new upload; the `build-gradle` bullet also said tests run as `./gradlew test --no-daemon`, which has not been the whole story since the `-Pe2e` step was added.
- `vibetags/pom.xml`: one line of trailing whitespace the repo's own pre-commit hook removes.

## Verification

| Gate | Result |
|---|---|
| Worker heap before / after | `-Xmx512m` → `-Xmx2g`, read off the live `GradleWorkerMain` process |
| New test, failing first | Red against the previous `build.gradle` ("no longer pins maxHeapSize"), green with it |
| `gradlew test -Pe2e` (JDK 21) | 2617 tests, 0 failures |
| `mvn test -Pe2e` (JDK 21) | 2617 tests, 0 failures, `BUILD SUCCESS`, Checkstyle 0 violations |
| Full exception format | Confirmed by breaking the new test on purpose: the assertion message and stack trace now print |
| `pre-commit run --all-files` | Passed except the `checkstyle` hook, which needs Docker and did not run here; Maven's `checkstyle:check` covered it |
| `TransitiveGuardrailLifecycleE2ETest` alone, JDK 21 | Green; the flake did not reproduce locally on Windows |

PMD and SpotBugs both set `includeTests=false`, and the only Java change is a test, so neither analyses it.

## Known limits

- #587 - the root cause is unconfirmed. If the Gradle leg fails this way again, the uploaded report
  is what settles it; the issue says what to record and when to close it either way.
- #588 - `2g` is headroom, not a measured peak. The issue says what one instrumented run would cost
  and where the number belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgL8sFtyN2GLGUsGYgCnAg
