### PR TITLE
chore(deps): async-test-lib 1.11.0 -> 1.11.2

### DIFF
--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -88,7 +88,7 @@
         <junit.platform.version>6.1.3</junit.platform.version>
         <mockito.version>5.23.0</mockito.version>
         <archunit.version>1.5.0</archunit.version>
-        <async-test-lib.version>1.11.0</async-test-lib.version>
+        <async-test-lib.version>1.11.2</async-test-lib.version>
         <snakeyaml.version>2.7</snakeyaml.version>
         <jmh.version>1.37</jmh.version>
 


### PR DESCRIPTION
Downstream regression sweep for the 1.11.2 release, verified against the artifact on Maven
Central rather than a local build.

One declaration, not two. The sweep's notes say vibetags pins the version in
vibetags-parent/pom.xml AND as a literal in vibetags/build.gradle, and warn to bump both or
neither. That is now stale: build.gradle reads
pomVersion('async-test-lib.version'), so the pom is the single source and editing the Gradle
file would have been wrong. Both tiers were still run, to confirm the Gradle side picked the
new version up.

  mvn test -Pe2e         2616 tests, 0 failures, 0 errors
  ./gradlew test -Pe2e   BUILD SUCCESSFUL

Six @AsyncTest classes ran in both tiers - one more than the sweep's notes record, since
EnforcementBaselineAsyncTest has been added since:

  EnforcementBaselineAsyncTest, GuardrailFileWriterAsyncTest, ModuleSidecarAsyncTest,
  VibeTagsLoggerAsyncTest, VibeTagsLoggerConcurrencyTest, WriteCacheAsyncTest

-Pe2e is what makes that true; a plain mvn test runs only WriteCacheAsyncTest.

No source change was needed.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgV1bAtmfW459JDNU6LLvE
