### PR TITLE
fix: read a sidecar written before the trailer existed instead of dropping its module

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A sidecar written before the `# end` trailer existed is read again instead of being skipped as
+  unreadable (issue #590). The trailer was appended without a format-version bump so that older
+  processors would keep reading newer files; the reverse direction was documented as "skipped until
+  its module recompiles", but a skipped sibling drops out of `readAll`, the round then sees one
+  region and merges as single-module, and every other module's region disappears from the aggregate
+  and from the granular role files. A project that commits its `.vibetags-mod-*` files therefore
+  lost whole modules from its generated output on the first build after upgrading, silently, and
+  nothing repaired them until each module happened to recompile. Measured on a consumer that
+  commits them: CLAUDE.md lost 30 lines, GEMINI.md 35, and a role file was emptied. The format
+  version now carries the promise instead - version 3 writes a trailer and is held to it, version 2
+  is the pre-trailer shape and is read in full without one - so a missing trailer is evidence of a
+  torn write only for a version that always writes one, and issue #553's protection is intact for
+  every file this processor writes. `ModuleSidecarResilienceTest` pins both directions.
+
 - Two modules whose granular stems differ only in capitalisation (`com.example.Payment` in one,
   package `com.example.payment` in another) share one rule file on Windows and macOS, and its heading
   and description came from whichever module compiled last, so check mode's verdict depended on

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
@@ -95,7 +95,16 @@ public final class ModuleSidecar {
      * names ({@code ~...}) match no service and are therefore never rendered. Bumping would have
      * discarded every sibling's contribution on the first mixed-version build for no gain.
      */
-    static final int FORMAT_VERSION = 2;
+    static final int FORMAT_VERSION = 3;
+
+    /**
+     * The oldest on-disk shape this reader still accepts, rather than prunes as stale.
+     *
+     * <p>Version 2 is the pre-trailer format. It is readable in full - the trailer is the only
+     * difference - so a reader that dropped it would take that module out of every sibling's
+     * output for no reason, which is exactly what issue #590 was.
+     */
+    static final int MIN_READABLE_VERSION = 2;
     private static final String KEY_FORMAT_VERSION = "# version";
     /**
      * Written last, checked first: the marker that says this file is whole.
@@ -106,13 +115,21 @@ public final class ModuleSidecar {
      * (issue #553). The format carries no length and no checksum, so a torn write is otherwise
      * indistinguishable from a complete file.
      *
-     * <p>Appended rather than version-bumped, because a bump discards every sibling's contribution
-     * on the first mixed-version build: a processor that predates this line skips any {@code #} key
-     * it does not recognise, so it reads a file carrying the trailer exactly as before
-     * ({@code anUnknownCommentLineIsSkippedRatherThanParsed} pins that rule). The cost is the other
-     * direction: a sidecar written by an older processor has no trailer and is skipped as
-     * unreadable until its module recompiles. Skipped, never deleted — the same treatment as a file
-     * this reader could not open.
+     * <p>Appended rather than version-bumped at first, because a bump makes an older processor
+     * skip a newer sibling's file: one that predates this line skips any {@code #} key it does not
+     * recognise, so it reads a file carrying the trailer exactly as before
+     * ({@code anUnknownCommentLineIsSkippedRatherThanParsed} pins that rule). The cost was
+     * described as the other direction being "skipped as unreadable until its module recompiles",
+     * and that cost was underestimated: skipping a sibling drops it from {@code readAll}, the round
+     * then sees one region and merges as single-module, and every other module's region vanishes
+     * from the aggregate and from the granular role files. On a project that commits its sidecars,
+     * the first build after upgrading did exactly that, silently (issue #590).
+     *
+     * <p>So the version carries the promise instead. {@link #FORMAT_VERSION} 3 writes a trailer and
+     * is held to it; {@link #MIN_READABLE_VERSION} 2 is the pre-trailer shape, read in full without
+     * one. A missing trailer is evidence of a torn write only for a version that always writes one,
+     * which keeps issue #553's protection intact for every file this processor writes while a file
+     * written before the trailer existed is read rather than discarded. Either way, never deleted.
      */
     static final String TRAILER = "# end";
     private static final String KEY_MODULE_ID = "moduleId";
@@ -551,6 +568,7 @@ public final class ModuleSidecar {
             String modulePath = "";
             String regionId = null;
             boolean sawCurrentVersion = false;
+            int loadedVersion = 0;
             Map<String, String> bodies = new LinkedHashMap<>();
             Map<String, String> moduleBodies = new LinkedHashMap<>();
             Map<String, String> indexDigests = new LinkedHashMap<>();
@@ -569,7 +587,8 @@ public final class ModuleSidecar {
                             int version = Integer.parseInt(
                                     line.substring(KEY_FORMAT_VERSION.length() + 1).trim());
                             if (version > FORMAT_VERSION) return FUTURE_VERSION;
-                            if (version < FORMAT_VERSION) return null;
+                            if (version < MIN_READABLE_VERSION) return null;
+                            loadedVersion = version;
                             sawCurrentVersion = true;
                         } catch (NumberFormatException malformed) {
                             return null;
@@ -624,7 +643,10 @@ public final class ModuleSidecar {
             // Before the checks below, because those delete: a file cut short can lose its
             // moduleId line as easily as its last body, and pruning a module's sidecar over a torn
             // write takes that module out of every sibling's output until it recompiles.
-            if (!isWhole(lines)) return UNREADABLE;
+            // Only a version that promises a trailer may be judged by one. A version-2 file has
+            // none to lose, so its absence says nothing about whether the write finished, and
+            // treating it as torn is what silently reduced a reactor to one region (issue #590).
+            if (loadedVersion >= FORMAT_VERSION && !isWhole(lines)) return UNREADABLE;
             if (moduleId == null || !sawCurrentVersion) return null;
             // Sidecars written before the source-set split carry no regionId; their module id IS
             // the region id, which is exactly what they meant.
@@ -1682,7 +1704,9 @@ public final class ModuleSidecar {
         if (version == null) {
             return "no-version-header";
         }
-        return version < FORMAT_VERSION ? "stale-format" : "malformed";
+        // MIN_READABLE_VERSION, not FORMAT_VERSION: a readable older format that failed to
+        // parse is corrupt, and saying "stale-format" would blame the version for it.
+        return version < MIN_READABLE_VERSION ? "stale-format" : "malformed";
     }
 
     /** The {@code # version} header of one sidecar, or {@code null} when absent or unparseable. */

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/internal/ModuleSidecarResilienceTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/internal/ModuleSidecarResilienceTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -265,6 +266,87 @@ class ModuleSidecarResilienceTest {
         assertNotNull(loaded);
         assertEquals("body", loaded.getBodies().get("claude"),
             "an unrecognised comment key must not become a body, and must not stop the parse");
+    }
+
+    // ---------------------------------------------------------------- the pre-trailer format
+
+    /**
+     * A sidecar written before the {@code # end} trailer existed must still be readable.
+     *
+     * <p>The trailer was appended by #572 without a format-version bump, deliberately, so that an
+     * older processor would keep reading a newer file. The other direction was documented as
+     * costing "skipped as unreadable until its module recompiles", and that cost turned out to be
+     * a silent module loss: {@code readAll} returns fewer sidecars than are on disk, the round
+     * therefore merges as single-module, and every sibling region disappears from the aggregate
+     * and from the granular role files. Measured on a real consumer (issue #590): the first build
+     * after upgrading dropped 30 lines from CLAUDE.md, 35 from GEMINI.md and emptied a role file,
+     * and because such sidecars are skipped rather than pruned, nothing repaired them until each
+     * module happened to recompile.
+     *
+     * <p>A file this reader could not open and a file written by a processor that never wrote
+     * trailers are not the same thing, and only the first is a reason to drop a module.
+     */
+    @Test
+    void aSidecarWrittenBeforeTheTrailerExistedIsStillRead(@TempDir Path root) throws IOException {
+        Files.createDirectories(root.resolve("core"));
+        // Byte-for-byte the shape written before the trailer existed: header, keys, body.
+        Files.writeString(root.resolve(".vibetags-mod-core"), """
+            # version=2
+            moduleId=core
+            modulePath=core
+            regionId=core
+            claude=%s
+            """.formatted(encoded("legacy body")));
+
+        ModuleSidecar loaded = ModuleSidecar.load(root.resolve(".vibetags-mod-core"));
+
+        assertNotNull(loaded, "a complete pre-trailer sidecar is not malformed");
+        assertNotSame(ModuleSidecar.UNREADABLE, loaded,
+            "a sidecar with no trailer was written by a processor that wrote none, not torn in half");
+        assertEquals("legacy body", loaded.getBodies().get("claude"));
+    }
+
+    /**
+     * The consequence the consumer actually saw: one module already recompiled under the new
+     * processor, its siblings still carrying pre-trailer sidecars, and the merge reduced to the one
+     * region it could read. Asserted through {@code readAll} because that is what decides
+     * {@code isMultiModule}, and a count of one is what turns a reactor aggregate into a
+     * single-module document.
+     */
+    @Test
+    void aReactorMixingPreTrailerAndCurrentSidecarsKeepsEveryRegion(@TempDir Path root) throws IOException {
+        Files.createDirectories(root.resolve("core"));
+        Files.createDirectories(root.resolve("app"));
+        // core has not recompiled yet, so it is still in the pre-trailer shape.
+        Files.writeString(root.resolve(".vibetags-mod-core"), """
+            # version=2
+            moduleId=core
+            modulePath=core
+            regionId=core
+            claude=%s
+            """.formatted(encoded("core body")));
+        // app recompiled under this processor, so it carries the trailer.
+        Files.writeString(root.resolve(".vibetags-mod-app"), """
+            # version=2
+            moduleId=app
+            modulePath=app
+            regionId=app
+            claude=%s
+            # end
+            """.formatted(encoded("app body")));
+
+        List<ModuleSidecar> all = ModuleSidecar.readAll(root);
+
+        assertEquals(List.of("app", "core"),
+            all.stream().map(ModuleSidecar::getModuleId).sorted().toList(),
+            "both modules must reach the merge; dropping one writes an aggregate missing its region");
+        assertTrue(Files.exists(root.resolve(".vibetags-mod-core")),
+            "and a pre-trailer sidecar is never pruned - deleting it would lose the module for good");
+    }
+
+    private static String encoded(String body) {
+        return java.util.Base64.getEncoder()
+            .encodeToString(body.getBytes(java.nio.charset.StandardCharsets.UTF_8));
     }
 
     // ---------------------------------------------------------------- unrepresentable module path


### PR DESCRIPTION
Closes #590. Found by the consumer regression sweep while preparing 1.3.2, which is held on this.

## The failure

A project that **commits** its `.vibetags-mod-*` files lost whole modules from every generated file on the first build after upgrading, and nothing said so.

Measured on `async-test-lib`, same repo, same fresh worktree, same `mvn clean verify`, only `<vibetags.version>` differing:

| VibeTags | exit | drift vs committed |
|---|---|---|
| 1.3.0 | 0 | none |
| 1.3.1 (published) | 1 | `CLAUDE.md` −30, `GEMINI.md` −35, `.gemini/rules/async-test-instrumentation.md` −28 |
| `main` | 1 | same |

Its own `GuardrailAggregateCoversEveryModuleTest` catches it: *"CLAUDE.md has no region for async-test-agent"*.

## The cause

The processor's own log named it once DEBUG was on:

```
sidecar.skip reason=unreadable path=.vibetags-mod-async-test-agent
sidecar.skip reason=unreadable path=.vibetags-mod-async-test-analysis
sidecar.read count=1 regions=1 ids=[async-test-lib]
merge.begin modules=1 regions=1 services=3
```

The `# end` trailer was appended in #572 without a format-version bump, deliberately, so an older processor would keep reading a newer file. The cost was documented as the other direction being "skipped as unreadable until its module recompiles" — and that understates it:

- a skipped sibling is absent from `readAll`,
- so the round sees one region and `isMultiModule` is false,
- so the merge writes the **single-module** shape.

Hence whole regions vanishing from the aggregate, and the granular role file losing its `VIBETAGS-MODULE` markers rather than just its content. And because such a file is skipped rather than pruned, nothing repaired it until that module happened to recompile.

**Why no fixture caught it:** every reactor fixture in this repo gitignores its sidecars, so none has ever had one on disk that the processor did not just write. `async-test-lib` commits them on purpose — its `.gitignore` says so.

## The fix

The version carries the promise instead of an appended line:

- `FORMAT_VERSION` 3 writes a trailer and is held to it.
- `MIN_READABLE_VERSION` 2 is the pre-trailer shape, read in full without one.

A missing trailer is evidence of a torn write only for a version that always writes one, so **#553's protection is intact for every file this processor writes**, while a file written before the trailer existed is read rather than discarded. `formatReason()` classifies against the new floor too — a readable older format that fails to parse is corrupt, and reporting `stale-format` would blame the version for it.

## Verification

| Gate | Result |
|---|---|
| New `ModuleSidecarResilienceTest` cases, failing first | Red against `main`: `readAll` returned `[app]` where `[app, core]` was on disk — the production symptom in miniature. Green after |
| `gradlew test -Pe2e` (JDK 21) | 2619 tests, 0 failures |
| `mvn test -Pe2e` (JDK 21) | 2619 tests, 0 failures, `BUILD SUCCESS`, Checkstyle 0 violations |
| `pre-commit` | gitleaks, end-of-file, whitespace pass. The `checkstyle` hook needs Docker and did not run here; Maven's `checkstyle:check` covered it |

Two failures surfaced along the way were mine and are fixed here rather than silenced: the logging contract caught `formatReason` still comparing against `FORMAT_VERSION`, and `ReleaseScriptCoverageTest` caught a release-version literal in the new javadoc.

## Known limit

A bump means an older processor treats a version-3 sidecar as `FUTURE_VERSION` and skips it, so a genuinely **mixed-version** reactor (some modules on an older processor, some on this one) can still write an aggregate missing the newer half. That is the pre-existing behaviour for any bump, it is skipped rather than deleted, and the newer module's round merges everything correctly. Tracked as a follow-up rather than claimed as solved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgL8sFtyN2GLGUsGYgCnAg
