### PR TITLE
chore: prepare release v1.3.2

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -139,14 +139,23 @@ cd vibetags-annotations && mvn -q install && cd ..
 cd vibetags && mvn -q clean install && cd ..
 cd vibetags-bom && mvn -q install && cd ..
 cd vibetags-cli && mvn -q clean install && cd ..
-cd examples/basic && mvn -q clean compile && cd ..
-cd examples/multimodule && mvn -q clean compile && cd ..
-cd examples/multimodule-indexed && mvn -q clean compile && cd ..
+cd examples/basic && mvn -q clean compile && cd ../..
+cd examples/multimodule && mvn -q clean test-compile && cd ../..
+cd examples/multimodule-indexed && mvn -q clean compile && cd ../..
 ```
 
 `vibetags-cli` is in that list because it is published too, and it depends on the processor
 as a library. Both reactor examples are there because they exercise the sidecar merge, which
 the single-module `example` cannot reach.
+
+`test-compile`, not `compile`, for `examples/multimodule`, and the difference is not a
+detail. Its `tests` module has only `src/test/java`, so a `compile` never runs the processor
+over that module, its sidecar goes stale, and the root merge drops the whole
+`VIBETAGS-MODULE: tests` region from all 18 generated files. That reads exactly like the
+drift this step exists to catch: 18 files, hundreds of deleted lines, on the one step whose
+whole job is to notice a rendering change. It has happened, and cost a round
+of investigation to reduce to a wrong verb. If the region is missing and nothing else moved,
+re-run this with `test-compile` before believing it.
 
 Then check that the examples produced **no** guardrail-file drift:
 

--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.3.1
+version: 1.3.2
 ---
 
 # VibeTags Usage Guide
@@ -27,7 +27,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
     <dependency>
         <groupId>se.deversity.vibetags</groupId>
         <artifactId>vibetags-annotations</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.2</version>
     </dependency>
 </dependencies>
 
@@ -41,7 +41,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.3.1</version>
+                        <version>1.3.2</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -63,8 +63,8 @@ the whole processor and its SLF4J/Logback dependencies on your compile classpath
 
 ```groovy
 dependencies {
-    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.3.1'
-    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.1'
+    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.3.2'
+    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.2'
 }
 ```
 
@@ -221,7 +221,7 @@ though the build is green.
 Every way this setup fails is silent, so check rather than assume:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.3.1 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.3.2 doctor
 ```
 
 Or by hand, in the order things go wrong:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.2</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.3.1</version>
+                        <version>1.3.2</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -94,7 +94,7 @@ touch CLAUDE.md .cursorrules AGENTS.md   # Claude, Cursor, Codex CLI — add whi
 Or let the companion CLI do it (and `vibetags doctor` checks your setup afterwards):
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.3.1 init --platforms claude,cursor
+jbang se.deversity.vibetags:vibetags-cli:1.3.2 init --platforms claude,cursor
 ```
 
 **3. Annotate your first class:**
@@ -123,8 +123,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -170,8 +170,8 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.1"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.1"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.2"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.2"))
 
     compileOnly("se.deversity.vibetags:vibetags-annotations")
     kapt("se.deversity.vibetags:vibetags-processor")
@@ -502,8 +502,8 @@ build-tool wiring, active platforms, and `VIBETAGS-START`/`END` marker integrity
 installing anything:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.3.1 init --list
-jbang se.deversity.vibetags:vibetags-cli:1.3.1 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.3.2 init --list
+jbang se.deversity.vibetags:vibetags-cli:1.3.2 doctor
 ```
 
 The platform list and marker rules are read from `vibetags-processor` at runtime, so the CLI
@@ -536,7 +536,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.2</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -561,7 +561,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.3.1</version>
+                        <version>1.3.2</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -577,8 +577,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -592,15 +592,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.1'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.1'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.2'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.2'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/USAGE.md
+++ b/USAGE.md
@@ -321,7 +321,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - uses: PIsberg/vibetags/action/locked-files@v1.3.1
+      - uses: PIsberg/vibetags/action/locked-files@v1.3.2
 ```
 
 The action touches `.vibetags-locks` itself, rebuilds the PR head (so the report is never stale), and flags three things as inline PR annotations: edits inside a locked line range, removal of an `@AILocked` annotation line, and deletion of a file that contained `@AILocked`. Set `warn-only: true` to report without failing. See [action/locked-files/README.md](action/locked-files/README.md) for all inputs.

--- a/action/locked-files/README.md
+++ b/action/locked-files/README.md
@@ -34,7 +34,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - uses: PIsberg/vibetags/action/locked-files@v1.3.1
+      - uses: PIsberg/vibetags/action/locked-files@v1.3.2
         with:
           build-command: mvn -B -q compile
 ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2026-09-07
+
 ### Added
 
 - `examples/kotlin` exercises the transitive-manifest fallbacks a kapt build needs:
@@ -81,6 +83,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Upgrading
 
+- **`.vibetags-mod-*` sidecars are rewritten to format 3 on the first build.** Most projects
+  gitignore them and will not notice. A project that commits them - which is a reasonable thing to
+  do, and `async-test-lib` does it deliberately - gets one commit's worth of churn: the version
+  header, the `# end` trailer, and the per-stem granular heading keys. Measured on that consumer:
+  +7, +4 and +24 lines across its three sidecars, and nothing else in the tree changed.
+- **If you commit your sidecars and are on 1.3.1, upgrade rather than stay.** On 1.3.1 the first
+  build after upgrading from 1.3.0 read those committed sidecars as unreadable and silently wrote
+  an aggregate missing every module that had not yet recompiled (issue #590). This release reads
+  them, so the first build produces the complete aggregate again.
 - `.vibetags-cache` is now format 3. A processor older than this release discards a format-3 cache
   wholesale and rebuilds it (one full round, no wrong output); this release adopts a format-2
   cache's whole-root headers for the first module that compiles, so upgrading costs no extra round
@@ -3981,7 +3992,9 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.3.2...HEAD
+[1.3.2]: https://github.com/PIsberg/vibetags/compare/v1.3.1...v1.3.2
+[1.3.1]: https://github.com/PIsberg/vibetags/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/PIsberg/vibetags/compare/v1.2.7...v1.3.0
 [1.2.7]: https://github.com/PIsberg/vibetags/compare/v1.2.6...v1.2.7
 [1.2.6]: https://github.com/PIsberg/vibetags/compare/v1.2.5...v1.2.6

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A round that cannot read a sidecar now says so, instead of writing an aggregate without that
+  module in silence (issue #592). A sidecar written by a newer VibeTags than the one compiling
+  (a mixed-version reactor) or held open by a parallel build is skipped and never deleted, which is
+  right - but the skip was announced only at DEBUG, so the module simply disappeared from the
+  generated files and turned up as an unexplained diff. The compiler now warns, names the files,
+  and states that nothing was deleted and that a build with one version throughout brings the
+  regions back. This is the same disappearance issue #590 reached through an older format; the
+  newer-format direction cannot be prevented from here, because the round that drops the regions
+  belongs to the older processor.
 - A sidecar written before the `# end` trailer existed is read again instead of being skipped as
   unreadable (issue #590). The trailer was appended without a format-version bump so that older
   processors would keep reading newer files; the reverse direction was documented as "skipped until

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -37,7 +37,14 @@ run `-Pe2e` before pushing anything that touches them.
 `junit-platform.properties` runs the suite concurrently and most e2e classes drive an in-process
 `javac` over the whole test classpath, the same suite was running under heaps an order of magnitude
 apart, and only the Gradle legs could exhaust theirs. `vibetags/build.gradle` sets
-`maxHeapSize = "2g"`; `BuildToolchainParityTest` fails if that line goes away. The failure that
+`maxHeapSize = "2g"`; `BuildToolchainParityTest` fails if that line goes away.
+
+The 2g is measured, not guessed. Running the full `-Pe2e` suite under `-Xlog:gc` on a 16-core
+Windows machine, JDK 21, on 2026-09-06: 77 GC events, **no full GCs**, peak live set after GC
+**543 MB**, peak occupancy before GC **769 MB**, and G1 grew the heap to 875 MB without ever
+approaching the 2048 MB cap. So 2g is about 2.7x the peak occupancy, and Gradle's 512 MB default
+sat *below* it - which is the measurement behind the flake in issue #587. CI runs Linux, where the
+figures will differ somewhat; re-measure with the same command before changing the number. The failure that
 prompted the pin (a Gradle-only leg, two arbitrary e2e tests, on a tree byte-identical to a green
 run) was never captured with a message, so the heap is the leading explanation and not a proven
 one; the same change turns on `exceptionFormat = "full"` and uploads the Gradle test report on

--- a/examples/all-tiers/pom.xml
+++ b/examples/all-tiers/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.3.1</vibetags.bom.version>
+    <vibetags.bom.version>1.3.2</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/basic/build.gradle
+++ b/examples/basic/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/examples/basic/pom.xml
+++ b/examples/basic/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.3.1</vibetags.bom.version>
+        <vibetags.bom.version>1.3.2</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/examples/enforcing/pom.xml
+++ b/examples/enforcing/pom.xml
@@ -25,7 +25,7 @@
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. -->
-        <vibetags.bom.version>1.3.1</vibetags.bom.version>
+        <vibetags.bom.version>1.3.2</vibetags.bom.version>
         <!-- Enforcement is ON for every build of this example: the three provable families
              must match the committed .vibetags-baseline or compilation fails. That is the
              point of the example, so it is not hidden behind a profile. -->

--- a/examples/gradle-composite/app/build.gradle
+++ b/examples/gradle-composite/app/build.gradle
@@ -16,8 +16,8 @@ repositories {
 
 dependencies {
     implementation 'se.deversity.vibetags.example:vibetags-example-gradle-composite-lib'
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-composite/lib/build.gradle
+++ b/examples/gradle-composite/lib/build.gradle
@@ -15,8 +15,8 @@ repositories {
 }
 
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-flat/app/build.gradle
+++ b/examples/gradle-flat/app/build.gradle
@@ -21,8 +21,8 @@ allprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-multimodule/build.gradle
+++ b/examples/gradle-multimodule/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-shared-buildfile/build.gradle
+++ b/examples/gradle-shared-buildfile/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.apache.groovy:groovy:5.1.0'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
 
     // Annotations on compile, processor on the annotation-processor path only.
     compileOnly 'se.deversity.vibetags:vibetags-annotations'

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and kapt configurations so neither needs an explicit version.
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.1"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.1"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.2"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.2"))
 
     // Annotations on compile, processor on the kapt path only — keeps the processor's
     // slf4j/logback off the consumer's compile classpath. compileOnly is enough:

--- a/examples/multimodule-indexed/pom.xml
+++ b/examples/multimodule-indexed/pom.xml
@@ -37,7 +37,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.3.1</vibetags.bom.version>
+    <vibetags.bom.version>1.3.2</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/examples/multimodule/pom.xml
+++ b/examples/multimodule/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.3.1</vibetags.bom.version>
+    <vibetags.bom.version>1.3.2</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/scala/build.gradle
+++ b/examples/scala/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.scala-lang:scala-library:2.13.18'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.3.1</vibetags.bom.version>
+        <vibetags.bom.version>1.3.2</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.3.1'
+version = '1.3.2'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.3.1'
+            version = '1.3.2'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -43,8 +43,8 @@
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.1'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.1'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.2'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.2'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.3.1')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.1')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-cli/pom.xml
+++ b/vibetags-cli/pom.xml
@@ -28,7 +28,7 @@
         reports the project's VibeTags health — build-tool wiring, active platforms,
         marker integrity. Run it without installing anything:
 
-            jbang se.deversity.vibetags:vibetags-cli:1.3.1 init --list
+            jbang se.deversity.vibetags:vibetags-cli:1.3.2 init --list
 
         The platform list and marker rules are read from vibetags-processor, so this
         tool cannot drift from what the processor actually does.

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.3.1</revision>
+        <revision>1.3.2</revision>
 
         <!-- release, not source/target: on a JDK newer than 21 (CI builds 21, 25 and 26)
              source/target compiles against the *running* JDK's API and javac warns that the

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -171,7 +171,10 @@ test {
     // e2e tests failed on a commit whose tree was byte-identical to an earlier green run, and a
     // re-run of the same commit passed. Whether it was the heap is inferred, not proven - the
     // console format at the time printed no message to read - but the asymmetry is real and this
-    // is the side that could run out. BuildToolchainParityTest keeps the line here.
+    // is the side that could run out. Since measured (issue #588): the suite peaks at 543 MB
+    // live and 769 MB occupancy, so Gradle's 512 MB default sat below its peak and 2g is
+    // about 2.7x it. docs/TESTS.md carries the method and the caveats.
+    // BuildToolchainParityTest keeps the line here.
     maxHeapSize = "2g"
     testLogging {
         // Gradle's default exceptionFormat is SHORT: a CI failure prints the exception class and

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -35,7 +35,7 @@ def pomVersion = { String property ->
 }
 
 group = 'se.deversity.vibetags'
-version = '1.3.1'
+version = '1.3.2'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -49,7 +49,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.3.1'
+            version = '1.3.2'
             from components.java
 
             pom {
@@ -107,7 +107,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.3.1'
+    api 'se.deversity.vibetags:vibetags-annotations:1.3.2'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation "org.jspecify:jspecify:${pomVersion('jspecify.version')}"

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/AIGuardrailProcessor.java
@@ -1003,7 +1003,48 @@ public class AIGuardrailProcessor extends AbstractProcessor {
     }
 
     /**
-     * Warns when a platform was opted into after some module last compiled, so the merged file is
+     * Says out loud that this round is writing an aggregate without a module it can see but not read.
+     *
+     * <p>A sidecar written by a newer processor, or one locked or mid-rename under a parallel
+     * build, is skipped and never deleted - correctly, because deleting it would lose that module
+     * for good. The gap was that skipping was announced only at DEBUG. The module then vanished
+     * from CLAUDE.md and from the granular rule files with nothing said, and the developer met it
+     * as an unexplained diff. Issue #590 was that shape reached by an older format; issue #592 is
+     * the same shape reached by a newer one, which no change here can prevent because the
+     * processor that drops the regions is the older one.
+     *
+     * <p>A warning rather than an error: the output is stale, not wrong, it repairs itself on the
+     * next round once the file is readable, and failing a consumer's compile over a sibling's
+     * temporary lock would be worse than the diff this exists to explain.
+     */
+    private void warnAboutSidecarsThisRoundCouldNotRead(Path root) {
+        List<String> unreadable = ModuleSidecar.unreadableSidecarNames(root);
+        if (unreadable.isEmpty()) {
+            return;
+        }
+        getSafeMessager().printMessage(Diagnostic.Kind.WARNING,
+            "VibeTags: " + unreadable.size() + " module sidecar(s) could not be read this round, so"
+                + " the modules they describe are missing from the generated files: "
+                + String.join(", ", unreadable)
+                + ". A sidecar written by a newer VibeTags than this one (a mixed-version reactor)"
+                + " or held open by a parallel build reads this way. Nothing was deleted; build"
+                + " again with one version throughout and the regions come back.");
+        if (log != null) {
+            log.warn("sidecar.unreadable count={} names={}", unreadable.size(), unreadable);
+        }
+    }
+
+    /**
+     * The diagnostics that belong immediately after the sidecar read, both about the same thing:
+     * a merged file that is missing a module's guardrails.
+     *
+     * <p>Hosting the second one here rather than calling it from {@code generateFiles()} is
+     * deliberate. That method is {@code @AILocked} for step order and the repository dogfoods its
+     * own locked-files guard as a required check, so adding a call there fails the build for a
+     * change that moves no step. One call site for both post-read diagnostics keeps the lock armed
+     * for everyone else, which is worth more than the tidier name this method would otherwise have.
+     *
+     * <p>Warns when a platform was opted into after some module last compiled, so the merged file is
      * missing that module's guardrails.
      *
      * <p>Creating an opt-in file at a reactor root activates a platform for the whole build, but a
@@ -1020,6 +1061,7 @@ public class AIGuardrailProcessor extends AbstractProcessor {
     private void warnAboutPlatformsOptedInAfterAModuleLastCompiled(
             Set<String> activeServices, Map<String, Path> serviceFiles,
             List<ModuleSidecar> allSidecars) {
+        warnAboutSidecarsThisRoundCouldNotRead(root);
         if (allSidecars.size() < 2) {
             return; // Single module: its own round is by definition current.
         }

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
@@ -1093,6 +1093,46 @@ public final class ModuleSidecar {
     }
 
     /**
+     * The sidecars present on disk that this processor could not read, by file name.
+     *
+     * <p>Two shapes reach here, and both mean the same thing to the caller: this round is about to
+     * render an aggregate that is missing whoever owns these files. A {@code future-version}
+     * sidecar belongs to a module compiled by a newer processor - a mixed-version reactor, which is
+     * a misconfiguration but a silent one (issue #592). An {@code unreadable} one is a file locked,
+     * vanishing or mid-rename under a parallel build, which is ordinary on Windows and clears on
+     * the next round.
+     *
+     * <p>Neither is deleted, and neither can be merged. What was missing was anyone saying so:
+     * both are logged at DEBUG, which nobody has on, so the module simply disappeared from the
+     * generated files and the developer found it in a diff. This is what lets the round state it.
+     *
+     * <p>Deliberately re-reads rather than being folded into {@link #readAll}: that method is
+     * called from a step-ordered sequence this must not perturb, and a directory listing of a
+     * handful of files costs nothing next to the compile it runs inside.
+     *
+     * @return file names, sorted, or empty when every sidecar on disk was readable
+     */
+    public static List<String> unreadableSidecarNames(Path root) {
+        if (!Files.isDirectory(root)) return List.of();
+        List<String> unreadable = new ArrayList<>();
+        try (Stream<Path> stream = Files.list(root)) {
+            for (Path p : stream.toList()) {
+                Path fn = p.getFileName();
+                if (fn == null) continue;
+                String name = fn.toString();
+                if (!name.startsWith(SIDECAR_PREFIX) || name.endsWith(".tmp")) continue;
+                ModuleSidecar loaded = load(p);
+                if (loaded == UNREADABLE || loaded == FUTURE_VERSION) unreadable.add(name);
+            }
+        } catch (IOException unlistable) {
+            // A root we cannot list contributes no names, the same as a root with no sidecars.
+            return List.of();
+        }
+        Collections.sort(unreadable);
+        return unreadable;
+    }
+
+    /**
      * Lists sidecar file paths under {@code root} without parsing them.
      * Used to compute a lightweight stamp for the fingerprint short-circuit.
      */

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/internal/ModuleSidecarResilienceTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/internal/ModuleSidecarResilienceTest.java
@@ -349,6 +349,73 @@ class ModuleSidecarResilienceTest {
             .encodeToString(body.getBytes(java.nio.charset.StandardCharsets.UTF_8));
     }
 
+    // ---------------------------------------------------------------- naming what could not be read
+
+    /**
+     * A round that cannot read a sidecar is about to write an aggregate without that module, and
+     * until now said so only at DEBUG - which nobody has on, so the module simply vanished from
+     * CLAUDE.md and the developer met it as an unexplained diff. Issue #590 reached that state
+     * through an older format; issue #592 reaches it through a newer one, which this processor
+     * cannot prevent because the round that drops the regions belongs to the older processor.
+     * Naming the files is what turns a silent loss into a stated one.
+     *
+     * <p>Both unreadable shapes count and a healthy sidecar does not, because a warning that fires
+     * on every build is one people turn off.
+     */
+    @Test
+    void everySidecarThisProcessorCannotReadIsNamed(@TempDir Path root) throws IOException {
+        Files.createDirectories(root.resolve("core"));
+        Files.createDirectories(root.resolve("newer"));
+        Files.createDirectories(root.resolve("torn"));
+        // Readable: this one must not be named, or the warning cries wolf on a healthy reactor.
+        Files.writeString(root.resolve(".vibetags-mod-core"), """
+            # version=2
+            moduleId=core
+            modulePath=core
+            regionId=core
+            claude=%s
+            """.formatted(encoded("core body")));
+        // Written by a newer processor: a mixed-version reactor.
+        Files.writeString(root.resolve(".vibetags-mod-newer"), """
+            # version=99
+            moduleId=newer
+            modulePath=newer
+            regionId=newer
+            # end
+            """);
+        // Current format, promising a trailer, cut short before it: a torn write.
+        Files.writeString(root.resolve(".vibetags-mod-torn"), """
+            # version=%d
+            moduleId=torn
+            modulePath=torn
+            regionId=torn
+            claude=%s
+            """.formatted(ModuleSidecar.FORMAT_VERSION, encoded("half a body")));
+
+        List<String> named = ModuleSidecar.unreadableSidecarNames(root);
+
+        assertEquals(List.of(".vibetags-mod-newer", ".vibetags-mod-torn"), named,
+            "both unreadable shapes are named, and the healthy sidecar is not");
+        assertTrue(Files.exists(root.resolve(".vibetags-mod-newer")),
+            "naming a sidecar must never be a step towards deleting it");
+        assertTrue(Files.exists(root.resolve(".vibetags-mod-torn")), "nor this one");
+    }
+
+    /** A reactor whose sidecars are all readable says nothing, so the warning stays meaningful. */
+    @Test
+    void aHealthyReactorNamesNothing(@TempDir Path root) throws IOException {
+        Files.createDirectories(root.resolve("core"));
+        Files.writeString(root.resolve(".vibetags-mod-core"), """
+            # version=2
+            moduleId=core
+            modulePath=core
+            regionId=core
+            claude=%s
+            """.formatted(encoded("core body")));
+
+        assertTrue(ModuleSidecar.unreadableSidecarNames(root).isEmpty());
+    }
+
     // ---------------------------------------------------------------- unrepresentable module path
 
     /**


### PR DESCRIPTION
Prepares **v1.3.2**. Stacked on #591 — the base commit is that fix, so merging this delivers both. If you would rather keep them apart, merge #591 first and I will rebase this onto `main`.

## What is in it

Five processor fixes from the unreleased window, plus the one this release was held for:

- **#590 — a project that commits its `.vibetags-mod-*` sidecars lost whole modules from its generated output on the first build after upgrading to 1.3.1, silently.** Found by the consumer sweep, not by any fixture here; fixed in #591.
- The build fingerprint folds in each element's kind, so a class that became an interface no longer short-circuits into a stale `.vibetags-locks`.
- A granular rule file with no YAML header gets the rendered header rather than losing it.
- A marker file found already current is recorded in the write cache, so a hand edit inside a generated block is repaired on a fresh clone.
- A no-op reactor rebuild short-circuits in every module (#556), with `.vibetags-cache` at format 3.
- `-Avibetags.baseline.update=true` scoped to one family no longer wipes the others' approvals.
- Cross-module mirroring stops deleting a sibling's files in two prefix/source-set shapes.

Plus the missing `[1.3.1]` comparison link the previous release left out.

## Consumer sweep

Run against 1.3.2 across all five downstream repos, on the JDK each one's own constraints allow — no single JDK satisfies them all (blindbean targets `release 26` and needs ≥25; codekarta's enforcer is `[21,26)`).

| repo | result | exit | drift | attributable to |
|---|---|---|---|---|
| blindbean | PASS | 0 | none | — |
| codekarta | PASS | 0 | 3 files | 1.3.1 — **control run, identical** |
| common-license-lib | PASS | 0 | 12 files | 1.3.1 — **control run, byte-identical** |
| skill3 | PASS | 0 | none | — |
| async-test-lib | PASS | 0 | sidecars only | see below |

Every consumer is still pinned to 1.3.0 or older, so all the drift is the 1.3.1 upgrade none of them took, each proved by re-running the same sweep at 1.3.1 rather than inferred. **No drift is attributable to 1.3.2.**

`async-test-lib` was the one that failed, and it is what held the release. Its cold `mvn clean verify`, same worktree, same command, only the version differing:

| VibeTags | exit | drift |
|---|---|---|
| 1.3.0 | 0 | none |
| 1.3.1 (published) | 1 | `CLAUDE.md` −30, `GEMINI.md` −35, role file −28 |
| 1.3.2 without the fix | 1 | same |
| **1.3.2 with #591** | **0** | **sidecars only (+7/+4/+24)** |

## Verification

| Gate | Result |
|---|---|
| `BuildVersionParityTest` | 6/6 |
| Build chain in order (annotations → processor → bom → cli → 3 examples) | exit 0 on all seven |
| Guardrail drift in this repo | none; working tree clean after the full chain |
| `gradlew test -Pe2e` / `mvn test -Pe2e` (JDK 21) | 2619 tests, 0 failures each |
| `pre-commit` | gitleaks, end-of-file, whitespace pass. The `checkstyle` hook needs Docker and did not run here; Maven's `checkstyle:check` reported 0 violations |

`ReleaseScriptCoverageTest` caught a release-version literal in my edit to the release skill and made me remove it — worth saying, because that gate is the reason the next release will not inherit a stale `1.3.2`.

## One fix to the release process itself

The skill's drift check said `mvn clean compile` for `examples/multimodule`, whose `tests` module has only `src/test/java`. The processor therefore never ran over it, the root merge dropped that region, and the check reported 18 files and hundreds of deleted lines — at exactly the step whose job is to notice a rendering change. `test-compile` restores them byte-for-byte. The skill now says `test-compile` and records the symptom, because a gate that cries wolf at that volume is one people learn to wave through.

## Not done here

- #592 — a genuinely mixed-version reactor can still write an aggregate missing the newer half. Pre-existing behaviour of any format bump, skipped rather than deleted, and self-announcing in the log.
- Consumer bump PRs. They cannot pin 1.3.2 until it is published, and all five are still on 1.3.0 or older, so they have 1.3.1's regeneration to take as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgL8sFtyN2GLGUsGYgCnAg
