### PR TITLE
Suite health: churn heat-map, event-vs-time audit, chaos-monkey session, ACC-matrix-lite

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -79,6 +79,36 @@ same problem beside it; it now calls the harness method instead. `VibeTagsLogger
 sleep widens a thread-interleaving window in a concurrency stress test — nothing there depends on
 the sleep's duration for correctness, so it stayed.
 
+**Manual chaos-monkey session, 2026-09-07** ("Let the chaos monkey out periodically", ch. 4): a
+time-boxed, risk-driven mutation pass on three of the four `core_elements` from CLAUDE.md
+(`AIGuardrailProcessor.generateFiles()` is off-limits — it's in `locked_files`), picking mutations
+from the exact failure shape of a real incident rather than an exhaustive or random one. Every
+mutation below was applied to the real source, run against the suite, confirmed red, and reverted;
+none of the three source files carry any trace of the session.
+
+- `WriteCache.isUnchanged()`: `&&` → `||` between the mtime and hash comparison — the false-positive
+  shape the class's own `@AICore` note names ("false positives would silently corrupt generated
+  files"). Caught by 4 tests in `WriteCacheTest`, including `differentBody_misses`, which happens to
+  construct the exact failing scenario (same mtime, different hash) without needing explicit
+  mtime manipulation.
+- `GuardrailFileWriter.ownsItsLine()`: disabled the leading-whitespace check — the corruption class
+  the method's own javadoc documents by name ("this repository's own CLAUDE.md was corrupted
+  exactly that way"). Caught, but by only 1 of 55 tests run (`GuardrailFileWriterEdgeCaseTest`, via
+  `hasLegacyHeaderLine` rather than the marker-ownership path directly) — `MarkerInProseTest`, the
+  class named for this exact scenario, did not fail, because its fixtures all place non-whitespace
+  on *both* sides of the cited marker on its line, never leading-only. The regression is still
+  caught, so this is a precision gap, not a coverage gap: worth knowing before trusting
+  `MarkerInProseTest` alone to guard this invariant, not urgent enough to add a fixture for on its
+  own.
+- `ModuleSidecar` readAll's stale-module check: `dir != ModuleDir.EXISTS` → `dir == ModuleDir.EXISTS`,
+  inverting which modules get pruned — a realistic flipped-condition slip next to the #383/#384
+  departed-module logic. Caught immediately and loudly: 14 failures across `ModuleSidecarLogContractTest`,
+  `ModuleSidecarResilienceTest` and `ProjectLifecycleEndToEndTest`.
+
+All three held. The finding isn't "add tests" — it's a verified answer to "would today's suite
+actually catch this again if reintroduced by hand", which PIT's blind mutation can't ask because it
+doesn't know which mutants correspond to a real incident.
+
 ## Index
 
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -109,6 +109,29 @@ All three held. The finding isn't "add tests" — it's a verified answer to "wou
 actually catch this again if reintroduced by hand", which PIT's blind mutation can't ask because it
 doesn't know which mutants correspond to a real incident.
 
+**ACC-matrix-lite, 2026-09-07** ("Organise test ideas using an ACC matrix", ch. 1): most edge-case
+tests in this index exist because an issue found the edge case first — the Coverage descriptions
+above cite #547, #549, #556, #591 and others by number. That is coverage earned reactively. A
+components × quality-attributes grid, filled in only where actually checked rather than guessed at,
+is a cheap way to ask "what's the next #591" before it ships instead of after. Not a full matrix —
+just enough cells, checked for real, to show the shape of what a fuller pass would look like.
+
+| Component | Correctness | Byte-stability | Hostile/malformed input | Cross-module merge |
+|---|---|---|---|---|
+| `AIGuardrailProcessor` | `AIGuardrailProcessorUnitTest` + generation e2e | `ProjectLifecycleEndToEndTest` (3 rebuilds, byte-identical) | `PathOptionRobustnessTest` (NUL bytes), `BooleanOptionTest` | n/a (orchestrator) |
+| `GuardrailFileWriter` | `GuardrailFileRecoveryEndToEndTest` | same (marker-aware write path) | `MarkerInjectionTest`, `MarkerInProseTest` | n/a |
+| `ModuleSidecar` | `MultiModuleProcessorTest` | `ModuleSidecarResilienceTest` | `ModuleSidecarLogContractTest` (unrepresentable paths) | `MultiModuleAggregationTest`, `AncestorModuleDuplicateRegionTest` |
+| `WriteCache` | `WriteCacheTest` | `WriteCacheMutationTest` (PIT-survivor hardened) | not audited this session | `WriteCacheProcessorIntegrationTest` |
+| `content/` renderers (37 platforms) | `AllAnnotationsAllPlatformsEndToEndTest` | not audited this session | **`OutputEscapingSecurityTest` end-to-end covers 4 of 37 platforms** (Claude XML, Sweep YAML, Plandex YAML, Mentat JSON) — the escaping *primitive* itself (`Escape.xml`/`.json`/`.tomlMultiline`) is fully covered by `EscapeTest`, so this is a wiring gap (does every renderer call it), not a logic gap | `MultiModuleWholeFileMergeTest`, `YamlMergeShapeContractTest` |
+
+The renderer row is the one finding worth acting on: `PlatformRendererRegistryCoverageTest` already
+proves the pattern this needs — `@ParameterizedTest @EnumSource(Platform.class)` — for a different
+property (every platform resolves to a renderer). The same shape, driving a hostile `reason` string
+through every renderer and asserting no unescaped metacharacter reaches the output, would turn this
+row from "4 of 37, chosen ad hoc" into "37 of 37, chosen because they exist." Not built here — this
+pass is the matrix, not the fix — but it is the concrete next candidate the matrix was for. Tracked
+as issue #598.
+
 ## Index
 
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -65,6 +65,12 @@ the numbers from a full-suite run, and trust wall clock over the sum.
 `TestTagVocabularyTest` fails the build if a tag is misspelled, or if `pom.xml` and `build.gradle`
 stop excluding the same one.
 
+**Suite health, separate from what each test asserts.** `tools/test-half-life.sh` heat-maps which
+test files have changed most often recently — a maintenance-cost signal, not a correctness one. A
+central class churning because every new annotation touches it (`AIGuardrailProcessorUnitTest`,
+`AnnotationProcessorEndToEndTest`) is expected; the same count on a narrower class is worth reading
+`git log` on before assuming either an evolving feature or a fragile test.
+
 ## Index
 
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -71,6 +71,14 @@ central class churning because every new annotation touches it (`AIGuardrailProc
 `AnnotationProcessorEndToEndTest`) is expected; the same count on a narrower class is worth reading
 `git log` on before assuming either an evolving feature or a fragile test.
 
+**Audited every `Thread.sleep` in the suite** (three total, 2026-09-07) against "wait for events,
+not time": `ProcessorTestHarness.awaitFilesystemTick()` already polls the real filesystem mtime
+with a safety cap rather than guessing a duration — the correct pattern, used as the harness's
+shared helper. `AIGuardrailProcessorUnitTest` had a hand-rolled fixed 50ms sleep solving the exact
+same problem beside it; it now calls the harness method instead. `VibeTagsLoggerConcurrencyTest`'s
+sleep widens a thread-interleaving window in a concurrency stress test — nothing there depends on
+the sleep's duration for correctness, so it stayed.
+
 ## Index
 
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -17,6 +17,12 @@ apart. "manual" means nothing runs it automatically; it exists for a human (or t
 | `bump-dependencies.sh` | Reports third-party pins that have a newer stable release (read-only) | `bump-dependencies` skill | manual |
 | `ecj-degradation-check.sh` | Compiles `examples/basic` under javac and ECJ, compares the locks output | `ecj` job in `build.yml` | that CI job |
 
+## Suite health
+
+| Tool | What it does | Run by | Enforced by |
+|---|---|---|---|
+| `test-half-life.sh` | Heat-maps which test files have needed the most changes recently — a maintenance-cost signal, not a correctness one | manual, ahead of a release | manual |
+
 ## Architecture diagrams
 
 | Tool | What it does | Run by | Enforced by |

--- a/tools/test-half-life.sh
+++ b/tools/test-half-life.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Heat-map how often each test file has needed a change — a maintenance-cost signal,
+# not a correctness one. ("Measure your tests' half-life", 50 Quick Ideas to Improve
+# Your Tests, ch. 4.)
+#
+# Usage:
+#   tools/test-half-life.sh [--since <git-log-date-spec>] [--top N]
+#
+#   tools/test-half-life.sh                       # last 6 months, top 15
+#   tools/test-half-life.sh --since "1 year ago"   # wider window
+#   tools/test-half-life.sh --top 30
+#
+# A high count here means one of three things, and the script cannot tell you which:
+# the feature under test is still evolving (expected), the area it covers is genuinely
+# fragile (a real signal), or the test itself is poorly isolated and breaks on unrelated
+# changes (a test smell). Read the commits before concluding either way — this is a
+# pointer to where to look, not a verdict.
+#
+# Renamed test files undercount here: git log's default doesn't follow renames across
+# a pathspec-filtered walk. Good enough for a heat-map; not a precise history.
+
+set -u
+
+SINCE="6 months ago"
+TOP=15
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --since) SINCE="$2"; shift 2 ;;
+    --top) TOP="$2"; shift 2 ;;
+    *) echo "usage: $0 [--since <date-spec>] [--top N]" >&2; exit 2 ;;
+  esac
+done
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+TESTROOT="vibetags/src/test/java"
+if [ ! -d "$TESTROOT" ]; then
+  echo "expected $TESTROOT from repo root" >&2
+  exit 1
+fi
+
+TMPFILE="$(mktemp)"
+trap 'rm -f "$TMPFILE"' EXIT
+
+git log --since="$SINCE" --name-only --pretty=format: -- "$TESTROOT" \
+  | grep -E '\.java$' \
+  | sort \
+  | uniq -c \
+  | sort -rn > "$TMPFILE"
+
+TOTAL_COMMITS=$(git log --since="$SINCE" --oneline -- "$TESTROOT" | wc -l | tr -d ' ')
+TOTAL_FILES=$(wc -l < "$TMPFILE" | tr -d ' ')
+
+echo "test half-life — commits touching a test file, since \"$SINCE\""
+echo "window: $TOTAL_COMMITS commits touched $TOTAL_FILES distinct test files"
+echo
+printf '%6s  %-55s  %s\n' "count" "file" "last changed"
+printf '%6s  %-55s  %s\n' "-----" "----" "------------"
+
+head -n "$TOP" "$TMPFILE" | while read -r count path; do
+  [ -z "$path" ] && continue
+  last=$(git log -1 --format=%ad --date=short -- "$path")
+  name="${path##*/}"
+  printf '%6s  %-55s  %s\n' "$count" "$name" "$last"
+done
+
+echo
+echo "top $TOP of $TOTAL_FILES changed test files in the window. A file here every run of" \
+     "this script, release over release, is the one worth reading git log on."

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/AIGuardrailProcessorUnitTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/AIGuardrailProcessorUnitTest.java
@@ -327,14 +327,14 @@ class AIGuardrailProcessorUnitTest {
     }
 
     @Test
-    void testWriteFileIfChanged_sameContent_returnsFalseAndDoesNotWrite(@TempDir Path tempDir) throws IOException {
+    void testWriteFileIfChanged_sameContent_returnsFalseAndDoesNotWrite(@TempDir Path tempDir) throws IOException, InterruptedException {
         Path file = tempDir.resolve("test.md");
         String markedContent = "<!-- VIBETAGS-START -->\nsame content\n<!-- VIBETAGS-END -->";
         Files.writeString(file, markedContent);
         long before = Files.getLastModifiedTime(file).toMillis();
 
-        // Small sleep to ensure mtime would differ if written
-        try { Thread.sleep(50); } catch (InterruptedException ignored) {}
+        // Wait for a real filesystem mtime tick rather than a fixed-duration guess
+        ProcessorTestHarness.awaitFilesystemTick(tempDir);
 
         AIGuardrailProcessor processor = new AIGuardrailProcessor();
         // Passing "same content" should result in the same markedContent being compared


### PR DESCRIPTION
## Summary

Four independent suite-health improvements from *50 Quick Ideas to Improve Your Tests*, applied to
this codebase specifically rather than as generic advice — each verified against the real suite,
not asserted.

- **`tools/test-half-life.sh`** (ch. 4, "measure your tests' half-life"): heat-maps which test
  files have changed most often recently. Verified against real history: `WriteCacheTest` surfaces
  in the current top 15, matching the recent sidecar/write-cache fixes in #591/#595.
- **Wait-for-events audit** (ch. 3): audited all three `Thread.sleep` calls in the suite.
  `AIGuardrailProcessorUnitTest` hand-rolled a fixed 50ms sleep for a problem
  `ProcessorTestHarness.awaitFilesystemTick()` already solves correctly (poll the real mtime, not a
  guess) — switched it over. The other two sleeps were reviewed and left alone: one *is* the
  correct event-polling helper, the other widens a thread-interleaving window in a stress test
  rather than gating an assertion on elapsed time.
- **Manual chaos-monkey session** (ch. 4): three real mutations applied to `WriteCache`,
  `GuardrailFileWriter`, and `ModuleSidecar` (`AIGuardrailProcessor.generateFiles()` is locked, so
  out of scope), each picked from the exact failure shape of a real past incident, run against the
  suite, confirmed red, then reverted. All three were caught. One precision note recorded: the test
  class named for the marker-in-prose corruption scenario didn't itself catch that mutation — a
  different test did, via a related path — so the regression is covered, just not by the test
  whose name most directly promises to.
- **ACC-matrix-lite** (ch. 1): a small components × quality-attributes grid over five core pieces,
  filled in only where actually checked. Surfaced one real, verified gap: hostile-input escaping is
  checked end-to-end for 4 of the 37 generated platform renderers, even though the escaping
  primitive itself is fully unit-tested and this codebase already has the exact
  `@ParameterizedTest @EnumSource(Platform.class)` pattern needed to close it for all 37. Tracked as
  #598 rather than built here — this pass was the matrix, not the fix.

All findings and their evidence are recorded in `docs/TESTS.md`.

## Test plan

- [x] `mvn test -Dtest=AIGuardrailProcessorUnitTest` green after the sleep→event-wait change
- [x] Full fast tier (`mvn test`, 88 classes / 957 tests) green
- [x] Each chaos-monkey mutation applied to real source, confirmed red on its targeted tests, then
      reverted — `git status` clean before each commit
- [x] Every test class cited in the ACC-matrix-lite table confirmed to exist on disk

Closes nothing directly; opens #598 for the one gap found and not fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197expQTknrk1FYy4PQYVwn