### PR TITLE
fix: derive the example reset script's coverage from ServiceRegistry (#606)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `examples/basic/reset-ai-files.sh` now clears `.kiro/steering`, which it had left behind since
+  v0.9.7. The script exists so a following clean compile proves the processor regenerates
+  everything, and it worked from two hand-maintained copies of a `ServiceRegistry` subset. A rule
+  file for a class whose annotation had since been removed survived the reset, the next compile
+  did not rewrite it, and the stale file read as current output, so the check proved less than it
+  appeared to. `ExampleResetScriptCoverageTest` now derives both lists from the registry, in both
+  directions: every path the example opts into must be cleared, and every path the script names
+  must still be written by some service. It reported `.kiro/steering` before the fix.
+
 - A compilation shown only some of a module's sources no longer rewrites that module's guardrails
   from what it happened to see. Reported from a Gradle single-module build: touching one annotated
   file and running an ordinary incremental `compileJava` deleted 22 checked-in rule files and cut

--- a/examples/basic/reset-ai-files.sh
+++ b/examples/basic/reset-ai-files.sh
@@ -82,8 +82,10 @@ fi
 # The current writer never creates these, but old checkouts might.
 find "$SCRIPT_DIR" -type f -name "*.bak" -exec rm -v {} + 2>/dev/null || true
 
-# Cleanup granular rules in directories
-for dir in ".cursor/rules" ".trae/rules" ".roo/rules" ".windsurf/rules" ".continue/rules" ".tabnine/guidelines" ".amazonq/rules" ".ai/rules" ".pearai/rules" ".claude/rules" ".github/instructions" ".grok/rules"; do
+# Cleanup granular rules in directories. Kept in step with ServiceRegistry by
+# ExampleResetScriptCoverageTest: every directory this example opts into must appear here,
+# or a reset silently leaves the last build's rule files in place.
+for dir in ".cursor/rules" ".trae/rules" ".roo/rules" ".windsurf/rules" ".continue/rules" ".tabnine/guidelines" ".amazonq/rules" ".ai/rules" ".pearai/rules" ".claude/rules" ".github/instructions" ".kiro/steering" ".grok/rules"; do
   if [ -d "$SCRIPT_DIR/$dir" ]; then
     echo "  cleaning granular rules in: $dir"
     find "$SCRIPT_DIR/$dir" -type f \( -name "*.mdc" -o -name "*.md" \) -exec rm {} +

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ExampleResetScriptCoverageTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ExampleResetScriptCoverageTest.java
@@ -1,0 +1,142 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import se.deversity.vibetags.processor.internal.ServiceRegistry;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * {@code examples/basic/reset-ai-files.sh} must clear every output the example actually opts into.
+ *
+ * <p>The script empties files and deletes granular rule files so a following clean compile proves
+ * the processor regenerates everything from scratch. It does that from two hand-maintained lists:
+ * an {@code AI_FILES} array and a {@code for dir in ...} loop. Both are copies of a subset of
+ * {@link ServiceRegistry}, and a copy drifts.
+ *
+ * <p>It had already drifted. {@code .kiro/steering} was opted in under {@code examples/basic} from
+ * v0.9.7 and never added to the directory loop, so a reset left its 32 generated files in place.
+ * That failure is invisible in the worst way: a rule file for a class whose annotation was since
+ * removed survives the reset, the following compile does not rewrite it, and the stale file reads
+ * as current output. The reset then proves less than it appears to, which is the entire point of
+ * running it.
+ *
+ * <p>So the lists are derived here rather than trusted. Scope is what the example has opted into
+ * on disk, not everything {@code ServiceRegistry} can name: file presence is the opt-in, so a path
+ * the example does not create is a path the script has no business clearing.
+ */
+@DisplayName("The example reset script clears every output the example opts into")
+class ExampleResetScriptCoverageTest {
+
+    /** {@code vibetags/} is the surefire working directory; its parent is the repo root. */
+    private static final Path REPO_ROOT = Paths.get("").toAbsolutePath().getParent();
+
+    /**
+     * Paths the script deliberately does not clear, each with the reason it cannot be an omission.
+     * An entry here is a decision; anything else missing is drift.
+     */
+    private static final Map<String, String> DELIBERATE_OMISSIONS = Map.of(
+        "AGENTS.md",
+        "the sole-file fallback rule means VibeTags never regenerates AGENTS.md while this example "
+            + "ships other AI config files, so clearing it would blank a pointer permanently. The "
+            + "script says so at the AI_FILES entry it is missing from.");
+
+    @Test
+    void everyOptedInOutputIsClearedByTheResetScript() throws IOException {
+        Path example = REPO_ROOT.resolve("examples/basic");
+        Path script = example.resolve("reset-ai-files.sh");
+        assumeTrue(Files.isRegularFile(script), "repo layout not reachable; skipping");
+
+        String text = Files.readString(script, StandardCharsets.UTF_8);
+        List<String> missingFiles = new ArrayList<>();
+        List<String> missingDirectories = new ArrayList<>();
+
+        for (Map.Entry<String, Path> service : ServiceRegistry.buildServiceFileMap(example).entrySet()) {
+            Path target = service.getValue();
+            if (!Files.exists(target)) {
+                continue; // not opted into by this example; nothing for the script to reset
+            }
+            String relative = example.relativize(target).toString().replace('\\', '/');
+            if (DELIBERATE_OMISSIONS.containsKey(relative)) {
+                continue;
+            }
+            // The script quotes every entry, in both the array and the loop, so requiring the
+            // quotes keeps a substring of a longer path from passing as a match: ".claude/rules"
+            // must not be satisfied by ".claude/rules/nested" appearing somewhere else.
+            if (!text.contains("\"" + relative + "\"")) {
+                (Files.isDirectory(target) ? missingDirectories : missingFiles)
+                    .add(relative + "  (service key: " + service.getKey() + ")");
+            }
+        }
+
+        assertTrue(missingFiles.isEmpty() && missingDirectories.isEmpty(),
+            "examples/basic/reset-ai-files.sh does not clear outputs the example opts into, so a "
+                + "reset leaves stale generated content behind and the clean-compile check that "
+                + "follows it proves less than it claims.\n"
+                + "  Add to the AI_FILES array: " + missingFiles + "\n"
+                + "  Add to the granular 'for dir in' loop: " + missingDirectories + "\n"
+                + "If an omission is deliberate, record it in DELIBERATE_OMISSIONS with the reason "
+                + "rather than deleting this assertion.");
+    }
+
+    /**
+     * The reverse direction. An entry naming a path no service writes any more is not harmless: it
+     * is a line that reads as coverage, survives the platform being renamed or dropped, and quietly
+     * clears nothing.
+     */
+    @Test
+    void everyPathTheScriptNamesIsStillWrittenBySomeService() throws IOException {
+        Path example = REPO_ROOT.resolve("examples/basic");
+        Path script = example.resolve("reset-ai-files.sh");
+        assumeTrue(Files.isRegularFile(script), "repo layout not reachable; skipping");
+
+        Set<String> known = new java.util.LinkedHashSet<>();
+        for (Path target : ServiceRegistry.buildServiceFileMap(example).values()) {
+            known.add(example.relativize(target).toString().replace('\\', '/'));
+        }
+        // The cache is not a service output but is legitimately removed by the script.
+        known.add(".vibetags-cache");
+
+        List<String> unknown = new ArrayList<>();
+        java.util.regex.Matcher m = java.util.regex.Pattern
+            .compile("\"([.A-Za-z0-9][^\"\\n]*/[^\"\\n]+|\\.[A-Za-z0-9][^\"\\n/]*|[A-Z][A-Za-z]*\\.md)\"")
+            .matcher(stripComments(Files.readString(script, StandardCharsets.UTF_8)));
+        while (m.find()) {
+            String candidate = m.group(1);
+            if (candidate.startsWith("$") || candidate.contains("*") || candidate.contains("{")) {
+                continue; // shell expansion, not a literal path
+            }
+            if (!known.contains(candidate)) {
+                unknown.add(candidate);
+            }
+        }
+
+        assertTrue(unknown.isEmpty(),
+            "examples/basic/reset-ai-files.sh names paths no service in ServiceRegistry writes. "
+                + "Each is a line that looks like coverage and clears nothing: " + unknown);
+    }
+
+    /** Comments carry example paths and prose; only executable lines are checked. */
+    private static String stripComments(String script) {
+        StringBuilder sb = new StringBuilder();
+        for (String line : script.split("\n", -1)) {
+            String trimmed = line.stripLeading();
+            if (!trimmed.startsWith("#")) {
+                sb.append(line).append('\n');
+            }
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
Closes #606. **Stacked on #605** — merge that one first; this PR's base is `feat/grok-granular-rules`, and its diff is only the three files below.

## The bug

`examples/basic/reset-ai-files.sh` clears generated output so a following clean compile proves the processor regenerates everything from scratch. It did that from two hand-maintained copies of a `ServiceRegistry` subset, and one had drifted: `.kiro/steering` has been opted in under `examples/basic` since v0.9.7 and was never added to the directory loop.

The failure mode is quiet, and it defeats the reason the script exists. A rule file for a class whose annotation was since removed survives the reset, the next compile does not rewrite it, and the stale file reads as current output. The check then proves less than it appears to.

## The fix

`ExampleResetScriptCoverageTest` derives both lists rather than trusting them, in **both directions**:

- Every path the example opts into on disk must be cleared by the script.
- Every path the script names must still be written by some service. An entry for a dropped or renamed platform is not harmless: it reads as coverage and clears nothing.

Scope is what the example has actually opted into, not everything the registry can name — file presence is the opt-in, so a path the example does not create is a path the script has no business clearing. `AGENTS.md` is recorded in `DELIBERATE_OMISSIONS` with its reason (the sole-file fallback means VibeTags never regenerates it here, so clearing it would blank a pointer permanently) rather than asserted around.

## One correction to the issue

#606 also named `.gemini/rules`. That was wrong, and I checked before acting on it: `examples/basic` never opts into Gemini granular, so nothing accumulates there. The new test correctly does not ask for it, and will start asking the moment the example does opt in.

## Verification

- **Failing first.** The test ran before the script was changed and reported exactly one omission:
  ```
  Add to the AI_FILES array: []
  Add to the granular 'for dir in' loop: [.kiro/steering  (service key: kiro_granular)]
  ```
  The reverse-direction test passed at the same time, so the script had no dead entries.
- Full e2e suite after the fix: **2646 tests, 0 failures**.
- `pre-commit`: 3 hooks passed; `checkstyle` **skipped**, not passed (it is Docker-based and the daemon was down locally). Checkstyle runs in the Maven build regardless, 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8d5YdgdCxYBwrwKgNiAbC