### PR TITLE
docs: say what invariant 4 now costs, and how to opt AGENTS.md back in (#610)

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -512,7 +512,7 @@ touch CLAUDE.md .claudeignore                # Claude
 touch QWEN.md .qwenignore                   # Qwen
 touch .aiexclude gemini_instructions.md GEMINI.md  # Gemini
 mkdir -p .github && touch .github/copilot-instructions.md .copilotignore  # GitHub Copilot
-touch AGENTS.md                              # Codex CLI
+touch AGENTS.md                              # Codex CLI, and 20+ other agents (see note below)
 touch llms.txt llms-full.txt                 # Windsurf Cascade / llms.txt standard
 
 mvn compile                                  # VibeTags populates all opted-in files
@@ -739,6 +739,29 @@ Critical Vulnerabilities to Prevent:
 ```
 
 **Codex CLI (AGENTS.md):**
+
+> **`AGENTS.md` is generated only when it is the sole AI config file in the project.** It is
+> the most widely read agent-instructions file there is (Codex, Amp, OpenCode, Jules, Factory
+> Droid, Devin, Ona, Mistral Vibe and Pi read it, and so do Cursor, Windsurf, Gemini CLI, Qwen,
+> Roo, Zed, Kilo, Warp and Copilot's coding agent alongside their own files), and it is also
+> the file people most often hand-write. VibeTags will not overwrite your prose, so if any
+> other AI config file exists it leaves `AGENTS.md` alone entirely.
+>
+> **To have VibeTags maintain it anyway, mark the region once by hand:**
+>
+> ```markdown
+> # Our project
+> Whatever you have already written stays here, untouched.
+>
+> <!-- VIBETAGS-START -->
+> <!-- VIBETAGS-END -->
+> ```
+>
+> From the next compile on, VibeTags owns what is between those two markers and nothing else
+> in the file. This is the only way to get generated guardrails into `AGENTS.md` in a project
+> that also uses Claude, Cursor or any other platform, and it matters most for the agents in
+> the first group above, which read no other file VibeTags writes.
+
 ```markdown
 ## 🛡️ MANDATORY SECURITY AUDITS
 * `com.example.database.DatabaseConnector`

--- a/docs/LOAD-BEARING.md
+++ b/docs/LOAD-BEARING.md
@@ -187,6 +187,13 @@ and this section seem to disagree, the enforcing test decides.
   configs are whole-file overwrites.
 - **`AGENTS.md` is a write target only when it is the sole AI config file present,** or when it
   already carries a marker pair. Otherwise `codex` is dropped, and so is the Codex sidecar config.
+  Worth knowing what this now costs: `AGENTS.md` has become the default rules file for 20+ tools,
+  so in the common case, a project that also uses Claude or Cursor, VibeTags writes none. Most of
+  those tools also read a file VibeTags does write, but Amp, OpenCode, Jules, Factory Droid,
+  Devin, Mistral Vibe, Pi and Ona read no other one. The rule still stands, because overwriting a
+  hand-authored `AGENTS.md` is the most destructive thing this processor could do; the marker-pair
+  escape hatch is the answer, and `USAGE.md` documents how to use it. Issue #610 holds the
+  reasoning and the options that were rejected.
 - **All 44 `@AI*` annotations are `RetentionPolicy.SOURCE`.** They must not leak into runtime.
 - **When a platform has both an aggregate and a granular directory opted in, the aggregate collapses
   to a scoped-rules index:** only the safety buckets (`@AILocked`, `@AICore`, `@AIPrivacy`,


### PR DESCRIPTION
Closes #610 by taking its **option 1** (the docs answer) and rejecting both code options. **Fourth in a stack — merge #605, #608, #612, then this.**

## The decision

`AGENTS.md` has become the default rules file for 20+ tools. Invariant 4 means VibeTags writes none in the common case: a project that also uses Claude or Cursor. Reach is not zero, because most of those tools also read a file VibeTags does write — but **Amp, OpenCode, Jules, Factory Droid, Devin, Mistral Vibe, Pi and Ona read no other one.**

**The rule stays.** Overwriting a hand-authored `AGENTS.md` is the most destructive thing this processor could do, and that has not become less true because the file got popular. #610's option 2 (a separate opt-in key) founders on the fact that `AGENTS.md` existing is exactly the signal the fallback rule keys on; option 3 (widening the fallback) is the destructive one.

What was actually missing is that **the marker-pair escape hatch already solves this completely**, and was documented only in `LOAD-BEARING.md` — where someone setting a project up never looks.

## The change

- **`USAGE.md`** gains the two-line block to paste, right next to the `AGENTS.md` output example, plus which agents it matters most for. This is where a reader decides what to opt into.
- **`docs/LOAD-BEARING.md`** keeps the invariant and adds what it now costs, so the next person reading it is not missing the context this issue gathered.

## No behaviour change, and the claim is already pinned

The documented escape hatch is covered by `AgentsMdSoleFallbackTest.markedAgentsMdIsWrittenAlongsideClaude`, which asserts both halves of what `USAGE.md` now promises: a marked `AGENTS.md` keeps updating alongside Claude, **and** hand-authored prose outside the markers survives regeneration. I checked that before writing the instruction rather than after.

## Verification

`AgentsMdSoleFallbackTest`, `DocsIndexCompletenessTest`, `DocumentationLinksTest`, `ProjectFactsConsistencyTest` — 18 tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8d5YdgdCxYBwrwKgNiAbC