### PR TITLE
docs: correct the kapt status claim, which its own citations no longer support (#496)

### DIFF
--- a/docs/JVM-LANGUAGES.md
+++ b/docs/JVM-LANGUAGES.md
@@ -85,22 +85,33 @@ private var billingEmail: String? = null
 
 ### The strategic risk, stated plainly
 
-Kotlin support rests entirely on kapt, and **kapt is in maintenance mode**: JetBrains keeps it
-current with new Kotlin and Java releases but has no plans to add features, and recommends KSP for
-annotation processing ([kapt](https://kotlinlang.org/docs/kapt.html),
-[KSP overview](https://kotlinlang.org/docs/ksp-overview.html),
-[migration guide](https://kotlinlang.org/docs/ksp-kapt-migration.html)).
+Kotlin support rests entirely on kapt. This page previously called kapt "in maintenance mode",
+citing three kotlinlang.org pages. **Re-checked on 2026-09-08 against the docs' own source**
+([`kapt.md`](https://github.com/JetBrains/kotlin-web-site/blob/master/docs/topics/compiler-plugins/kapt.md)
+in `JetBrains/kotlin-web-site`, rather than the rendered page), and none of the three carries that
+statement. The kapt page opens with the opposite of a wind-down notice:
 
-KSP is not a route for VibeTags as it stands. KSP defines its own processor interface
-(`SymbolProcessor`) rather than implementing `javax.annotation.processing.Processor`, so a JSR 269
-processor is not loadable by it. A Kotlin project that has migrated fully to KSP cannot run
-VibeTags at all.
+> Use **kapt** if:
+> * You have a Maven project.
+> * You have a Gradle project, but the required Java annotation processor doesn't support KSP yet.
 
-This is the largest single exposure in the matrix. Kotlin support does not degrade gradually if
-kapt is ever withdrawn; it goes from "one level lost" to nothing, and the only in-principle fix is
-a separate KSP processor reading the same annotations. Nothing about that is imminent, and no
-deprecation has been announced. It is written down here because the alternative is finding out
-from a release note.
+The first bullet is this project's own case. JetBrains does recommend KSP where a processor supports
+it, and kapt's stub generation is genuinely expensive, but "recommended against for Gradle projects
+whose processors support KSP" is a different claim from "being wound down", and only the first is
+sourced. No deprecation has been announced and no removal date exists.
+
+**The structural half of the risk is unchanged, and it is the half that matters.** KSP defines its
+own processor interface (`SymbolProcessor`) rather than implementing
+`javax.annotation.processing.Processor`, so a JSR 269 processor is not loadable by it. That is not a
+policy that might soften; it is how KSP is built. A Kotlin project that has migrated *fully* to KSP
+cannot run VibeTags at all, today, and that is already true for teams whose remaining processors
+(Hilt, Room, Moshi, Glide) all support KSP and who therefore have no reason to keep the kapt plugin.
+
+So the exposure is real but differently shaped than it was written: not "the mechanism is being
+withdrawn", but "the mechanism is fine and a growing share of Kotlin projects no longer load it".
+Kotlin support does not degrade gradually in that case, it goes from one level lost to nothing, and
+the only in-principle fix is a separate KSP front end reading the same annotations. Issue #496
+holds that analysis, including why the compiler-free rendering layer makes it tractable.
 
 ---
 


### PR DESCRIPTION
Addresses the "do not let the docs drift" half of #496. **Fifth in a stack — merge #605, #608, #612, #613, then this.** The issue itself stays open; see below.

## The drift

`docs/JVM-LANGUAGES.md` called kapt **"in maintenance mode"** and cited three kotlinlang.org pages. Re-checked on 2026-09-08 against the docs' own git source ([`kapt.md` in `JetBrains/kotlin-web-site`](https://github.com/JetBrains/kotlin-web-site/blob/master/docs/topics/compiler-plugins/kapt.md)) rather than the rendered pages, and **none of the three carries that statement.** The kapt page opens with the opposite of a wind-down notice:

> Use **kapt** if:
> * You have a Maven project.
> * You have a Gradle project, but the required Java annotation processor doesn't support KSP yet.

The first bullet is this project's own case. The only "maintenance" hit anywhere in the KSP docs is `ksp-why-ksp.md` describing how KSP minimises maintenance effort *for processor authors* — an unrelated use of the word.

## Method note

The rendered pages were checked first and came back without the statement, which I did not treat as sufficient, since a banner can be client-rendered and missed. The GitHub source of the docs settles it: this is verified, not read.

## What the correction does not do

It does not dismiss the risk, it sharpens it. **KSP defines `SymbolProcessor` rather than implementing `javax.annotation.processing.Processor`, so a JSR 269 processor is not loadable by it.** That is structural, not a policy that might soften, and it is the half that actually bites.

The accurate framing is not *"the mechanism is being withdrawn"* but *"the mechanism is fine and a growing share of Kotlin projects no longer load it"* — already true today for teams whose remaining processors (Hilt, Room, Moshi, Glide) all support KSP and who therefore have no reason to keep the kapt plugin at all.

## Why #496 stays open

Its trigger for actually building a KSP front end is "a consumer asking for KSP, or any signal that kapt is being wound down". This finding is the **opposite** of the second, and the first has not happened. Building a second front end speculatively is not something to do off the back of a docs correction.

## Verification

`DocsIndexCompletenessTest`, `DocumentationLinksTest`, `ProjectFactsConsistencyTest` — 11 tests, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8d5YdgdCxYBwrwKgNiAbC