### PR TITLE
chore: prepare release v1.3.3

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.3.2
+version: 1.3.3
 ---
 
 # VibeTags Usage Guide
@@ -27,7 +27,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
     <dependency>
         <groupId>se.deversity.vibetags</groupId>
         <artifactId>vibetags-annotations</artifactId>
-        <version>1.3.2</version>
+        <version>1.3.3</version>
     </dependency>
 </dependencies>
 
@@ -41,7 +41,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.3.2</version>
+                        <version>1.3.3</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -63,8 +63,8 @@ the whole processor and its SLF4J/Logback dependencies on your compile classpath
 
 ```groovy
 dependencies {
-    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.3.2'
-    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.2'
+    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.3.3'
+    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.3'
 }
 ```
 
@@ -226,7 +226,7 @@ though the build is green.
 Every way this setup fails is silent, so check rather than assume:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.3.2 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.3.3 doctor
 ```
 
 Or by hand, in the order things go wrong:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.3.2</version>
+            <version>1.3.3</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.3.2</version>
+                        <version>1.3.3</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -94,7 +94,7 @@ touch CLAUDE.md .cursorrules AGENTS.md   # Claude, Cursor, Codex CLI — add whi
 Or let the companion CLI do it (and `vibetags doctor` checks your setup afterwards):
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.3.2 init --platforms claude,cursor
+jbang se.deversity.vibetags:vibetags-cli:1.3.3 init --platforms claude,cursor
 ```
 
 **3. Annotate your first class:**
@@ -123,8 +123,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -170,8 +170,8 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.2"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.2"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.3"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.3"))
 
     compileOnly("se.deversity.vibetags:vibetags-annotations")
     kapt("se.deversity.vibetags:vibetags-processor")
@@ -507,8 +507,8 @@ build-tool wiring, active platforms, and `VIBETAGS-START`/`END` marker integrity
 installing anything:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.3.2 init --list
-jbang se.deversity.vibetags:vibetags-cli:1.3.2 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.3.3 init --list
+jbang se.deversity.vibetags:vibetags-cli:1.3.3 doctor
 ```
 
 The platform list and marker rules are read from `vibetags-processor` at runtime, so the CLI
@@ -541,7 +541,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.3.2</version>
+            <version>1.3.3</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -566,7 +566,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.3.2</version>
+                        <version>1.3.3</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -582,8 +582,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -597,15 +597,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.2'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.2'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.3'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.3'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/USAGE.md
+++ b/USAGE.md
@@ -321,7 +321,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - uses: PIsberg/vibetags/action/locked-files@v1.3.2
+      - uses: PIsberg/vibetags/action/locked-files@v1.3.3
 ```
 
 The action touches `.vibetags-locks` itself, rebuilds the PR head (so the report is never stale), and flags three things as inline PR annotations: edits inside a locked line range, removal of an `@AILocked` annotation line, and deletion of a file that contained `@AILocked`. Set `warn-only: true` to report without failing. See [action/locked-files/README.md](action/locked-files/README.md) for all inputs.

--- a/action/locked-files/README.md
+++ b/action/locked-files/README.md
@@ -34,7 +34,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - uses: PIsberg/vibetags/action/locked-files@v1.3.2
+      - uses: PIsberg/vibetags/action/locked-files@v1.3.3
         with:
           build-command: mvn -B -q compile
 ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.3] - 2026-09-10
+
+### Upgrading
+
+One build outcome changes under you, and it changes in the safe direction. A compilation
+that was shown only part of a module's sources now writes nothing at all, warns, and names
+the sources it never read. The build that hits this most often is an ordinary incremental
+Gradle `compileJava` after touching one annotated file: before this release that round
+rewrote the module's guardrails from the one element it could see, deleting rule files for
+every element it was not shown. If your workflow relied on an incremental compile to
+regenerate guardrails, it no longer does; run a full compile (`clean compileJava`, or
+`gradle --rerun-tasks`) when you want the files refreshed. Nothing is deleted either way.
+
 ### Added
 
 - Four platforms from a sweep of the AI tool landscape on 2026-09-08, taking the totals to 41
@@ -4066,7 +4079,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.3.2...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.3.3...HEAD
+[1.3.3]: https://github.com/PIsberg/vibetags/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/PIsberg/vibetags/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/PIsberg/vibetags/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/PIsberg/vibetags/compare/v1.2.7...v1.3.0

--- a/examples/all-tiers/pom.xml
+++ b/examples/all-tiers/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.3.2</vibetags.bom.version>
+    <vibetags.bom.version>1.3.3</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/basic/build.gradle
+++ b/examples/basic/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/examples/basic/pom.xml
+++ b/examples/basic/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.3.2</vibetags.bom.version>
+        <vibetags.bom.version>1.3.3</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/examples/enforcing/pom.xml
+++ b/examples/enforcing/pom.xml
@@ -25,7 +25,7 @@
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. -->
-        <vibetags.bom.version>1.3.2</vibetags.bom.version>
+        <vibetags.bom.version>1.3.3</vibetags.bom.version>
         <!-- Enforcement is ON for every build of this example: the three provable families
              must match the committed .vibetags-baseline or compilation fails. That is the
              point of the example, so it is not hidden behind a profile. -->

--- a/examples/gradle-composite/app/build.gradle
+++ b/examples/gradle-composite/app/build.gradle
@@ -16,8 +16,8 @@ repositories {
 
 dependencies {
     implementation 'se.deversity.vibetags.example:vibetags-example-gradle-composite-lib'
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-composite/lib/build.gradle
+++ b/examples/gradle-composite/lib/build.gradle
@@ -15,8 +15,8 @@ repositories {
 }
 
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-flat/app/build.gradle
+++ b/examples/gradle-flat/app/build.gradle
@@ -21,8 +21,8 @@ allprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-multimodule/build.gradle
+++ b/examples/gradle-multimodule/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-shared-buildfile/build.gradle
+++ b/examples/gradle-shared-buildfile/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.apache.groovy:groovy:5.1.0'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
 
     // Annotations on compile, processor on the annotation-processor path only.
     compileOnly 'se.deversity.vibetags:vibetags-annotations'

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and kapt configurations so neither needs an explicit version.
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.2"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.2"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.3"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.3"))
 
     // Annotations on compile, processor on the kapt path only — keeps the processor's
     // slf4j/logback off the consumer's compile classpath. compileOnly is enough:

--- a/examples/multimodule-indexed/pom.xml
+++ b/examples/multimodule-indexed/pom.xml
@@ -37,7 +37,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.3.2</vibetags.bom.version>
+    <vibetags.bom.version>1.3.3</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/examples/multimodule/pom.xml
+++ b/examples/multimodule/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.3.2</vibetags.bom.version>
+    <vibetags.bom.version>1.3.3</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/scala/build.gradle
+++ b/examples/scala/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.scala-lang:scala-library:2.13.18'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.3.2</vibetags.bom.version>
+        <vibetags.bom.version>1.3.3</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.3.2'
+version = '1.3.3'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.3.2'
+            version = '1.3.3'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -43,8 +43,8 @@
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.2'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.2'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.3'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.3'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.3.2')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.2')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-cli/pom.xml
+++ b/vibetags-cli/pom.xml
@@ -28,7 +28,7 @@
         reports the project's VibeTags health — build-tool wiring, active platforms,
         marker integrity. Run it without installing anything:
 
-            jbang se.deversity.vibetags:vibetags-cli:1.3.2 init --list
+            jbang se.deversity.vibetags:vibetags-cli:1.3.3 init --list
 
         The platform list and marker rules are read from vibetags-processor, so this
         tool cannot drift from what the processor actually does.

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.3.2</revision>
+        <revision>1.3.3</revision>
 
         <!-- release, not source/target: on a JDK newer than 21 (CI builds 21, 25 and 26)
              source/target compiles against the *running* JDK's API and javac warns that the

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -35,7 +35,7 @@ def pomVersion = { String property ->
 }
 
 group = 'se.deversity.vibetags'
-version = '1.3.2'
+version = '1.3.3'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -49,7 +49,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.3.2'
+            version = '1.3.3'
             from components.java
 
             pom {
@@ -107,7 +107,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.3.2'
+    api 'se.deversity.vibetags:vibetags-annotations:1.3.3'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation "org.jspecify:jspecify:${pomVersion('jspecify.version')}"


### PR DESCRIPTION
Bumps `<revision>` from 1.3.2 to 1.3.3 and closes the `[Unreleased]` section as
`[1.3.3] - 2026-09-10`.

## Why now

The release exists to ship #604. Until it is published, an ordinary incremental Gradle
`compileJava` in a consumer still rewrites that module's guardrails from the one element the
round happened to see: the reported case deleted 22 checked-in rule files and cut 27 lines out
of `CLAUDE.md`, including a whole `<security_elements>` block, with exit code 0 and nothing on
the console. That fix is on `main` and unreleased, so no consumer has it.

Riding along: four platforms from the 2026-09 sweep (Antigravity, JetBrains AI Assistant,
Augment Code, goose), the Grok Build scoped-rules directory, the `examples/basic` opt-in to
`.gemini/rules`, and the `reset-ai-files.sh` and orphan-sweep fixes.

The new CHANGELOG section carries an `### Upgrading` note, because the partial-round refusal is
an observable change: a build that used to regenerate from a partial round now writes nothing
and warns. It changes in the safe direction, and nothing is deleted either way.

## Verification

Everything below ran before the bump was committed. A skipped gate is listed as skipped.

| Gate | Result |
|---|---|
| `vibetags` `mvn clean verify -Pe2e` (via `install`) | 2669 tests, 0 failures, 0 errors, 1 skipped |
| `vibetags-annotations`, `vibetags-bom`, `vibetags-cli` | BUILD SUCCESS |
| `examples/basic` `compile`, `examples/multimodule` `test-compile`, `examples/multimodule-indexed` `compile` | BUILD SUCCESS, `git diff --numstat` empty |
| `.github/actions/verify-generated-files`, run locally from `examples/basic` | exit 0 |
| `pre-commit` | gitleaks, end-of-file-fixer, trailing-whitespace passed; `checkstyle` **skipped** (Docker hook, no daemon on this host). Checkstyle binds to Maven `validate` and ran green in the build above. |
| Consumer sweep against 1.3.3 | see below |

The example rebuild is the one worth reading twice. The processor version feeds
`BuildFingerprint`, so cutting a release invalidates every consumer's fingerprint and reruns
the whole generate phase. An empty `git diff --numstat` afterwards is what justifies saying the
rendering is unchanged.

### Consumer sweep

`tools/consumer-sweep.sh 1.3.3`, against a locally installed 1.3.3, then two rows completed by
hand for reasons that are about this machine and this script rather than about VibeTags.

| repo | build | result | guardrail drift |
|---|---|---|---|
| blindbean | Maven `verify` | pass | none |
| codekarta | Maven `verify` + Gradle `build` | pass | none |
| common-license-lib | Maven `verify` + Gradle `build` | pass | none |
| skill3 | Gradle `build` | pass | none |
| async-test-lib | Maven `verify` + Gradle `build` | pass | none |

Drift is counted from `git diff --numstat`, never from `git status`, which on Windows lists a
file whose line endings moved even when its text did not.

`async-test-lib` is the load-bearing row: it is the only consumer that commits its
`.vibetags-mod-*` sidecars, which is how #590 was found. `git status` listed all three as
modified after the sweep and all three are byte-identical to `HEAD` once CRLF is stripped.

Two rows needed hand-finishing:

- **codekarta** first reported FAIL exit 1. Its enforcer requires JDK 21 through 25 and this
  host's `JAVA_HOME` is JDK 26, so it died in `validate` before the compiler ran. Rerun with
  `JAVA_HOME` pointed at the installed JDK 21: Maven exit 0, Gradle exit 0.
- **async-test-lib** first reported SKIP. That is a bug in the sweep script, filed as #617:
  the dirty-tree guard runs before the `WORKTREE_REPOS` branch, so the one consumer whose sweep
  provably cannot touch its checkout is the one that gets skipped for having a dirty checkout.
  Completed by hand in a worktree off `origin/main`, which is what the script would have done.

## Left behind

- #617, the sweep-script dirty-guard bug above. It matters beyond this release: the footer
  prints identically whether the loop covered five consumers or four, so a partial sweep reads
  exactly like a complete one.

## Not done here

Creating the GitHub release is the step that publishes to Maven Central and is not reversible,
so it is left for a human after this merges. `docs/RELEASING.md` step 6 has the command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lp3ZaoNQYPv9NWdXQuLEn
