### PR TITLE
fix: stop the consumer sweep skipping its most informative repo, and the release notes truncating (#617, #619)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -250,17 +250,26 @@ create the release before the PR is merged — the release tags `main`.
 
 ## Step 7 — Create the GitHub release (after the PR is merged)
 
-Only once the user confirms the PR is merged. Extract the release notes from the
-CHANGELOG and rewrite the relative image paths to absolute raw URLs pinned to the tag
-— GitHub resolves `changelog-assets/…` from the repo root on a release page, so
-without the `sed` every embedded image 404s:
+Only once the user confirms the PR is merged. `tools/release-notes.sh` extracts the
+section from the CHANGELOG and rewrites the relative image paths to absolute raw URLs
+pinned to the tag, because GitHub resolves `changelog-assets/…` from the repo root on a
+release page and an unrewritten link 404s there:
 
 ```bash
 TAG=v<version>
-awk "/^## \[${TAG#v}\]/,/^## \[/{if (\$0 ~ /^## \[/ && \$0 !~ /\[${TAG#v}\]/) exit; print}" docs/CHANGELOG.md \
-  | sed "s|](changelog-assets/${TAG#v}/|](https://github.com/PIsberg/vibetags/raw/${TAG}/docs/changelog-assets/${TAG#v}/|g" \
-  > "$SCRATCHPAD/release-notes-${TAG}.md"
+tools/release-notes.sh "${TAG#v}" > "$SCRATCHPAD/release-notes-${TAG}.md"
 ```
+
+Do not inline the extraction here. It was an `awk` range in this file until #619, and an
+awk range tests its end pattern against the line that opened it, so `/^## \[/` closed the
+range on the heading and the command emitted one line: the correct release title with the
+whole body missing. `gh release create --notes-file` accepts that without complaint, and by
+the time anyone reads the release page the tag exists and the Central deploy has fired.
+`docs/RELEASING.md` had already hit this at 1.2.3 and had already been corrected, with a
+warning against the range form; this file kept the broken copy, and this file is the one an
+agent follows. One script, called from both, is why that cannot drift a third time. The
+script refuses to emit fewer than five lines rather than let a truncated file reach an
+irreversible step.
 
 Show the user the generated notes and get an explicit go-ahead before publishing —
 this step is irreversible and pushes artifacts to Maven Central:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -275,14 +275,8 @@ Go to [GitHub Releases](https://github.com/PIsberg/vibetags/releases) and click 
 Before uploading the release notes, rewrite the relative paths to absolute raw-content URLs pinned to the tag. From the repo root:
 
 ```bash
-TAG=v0.7.1
-awk -v v="[${TAG#v}]" '
-  index($0, "## " v) == 1 { f=1; print; next }
-  f && /^## \[/ { exit }
-  f { print }
-' docs/CHANGELOG.md \
-  | sed "s|](changelog-assets/${TAG#v}/|](https://github.com/PIsberg/vibetags/raw/${TAG}/docs/changelog-assets/${TAG#v}/|g" \
-  > /tmp/release-notes-${TAG}.md
+TAG=v<version>
+tools/release-notes.sh "${TAG#v}" > /tmp/release-notes-${TAG}.md
 
 gh release create $TAG \
   --target main \
@@ -291,11 +285,15 @@ gh release create $TAG \
   --latest
 ```
 
-> **Do not use an `awk` range here.** `awk '/^## \[1.2.3\]/,/^## \[/'` returns the header
-> line and nothing else: when a range's start and end patterns both match the same record, awk
-> closes the range on that record, so the `exit` guard inside it never runs. That form shipped in
-> this document and produced a one-line release note for 1.2.3. The flag-driven version above
-> starts on the header and stops at the *next* `## [`.
+> **Do not inline the extraction, in any form.** `awk '/^## \[1.2.3\]/,/^## \[/'` returns the
+> header line and nothing else: when a range's start and end patterns both match the same
+> record, awk closes the range on that record, so the `exit` guard inside it never runs. That
+> form shipped in this document and produced a one-line release note for 1.2.3. It was
+> corrected here, with this warning, and the release skill kept its own broken copy and
+> produced the same one-line extract again at 1.3.3 (#619). Two copies of a subtle command is
+> the defect, so `tools/release-notes.sh` is now the only implementation: it starts on the
+> header, stops at the *next* `## [`, and refuses to emit fewer than five lines so a
+> truncated file cannot reach a step that cannot be undone.
 
 If you forget the `sed`, the release will publish with broken image links. Fix afterward via:
 

--- a/tools/consumer-sweep.sh
+++ b/tools/consumer-sweep.sh
@@ -143,9 +143,26 @@ while IFS=: read -r repo tool mvncmd gradlecmd; do
   want "$repo" "$@" || continue
   [ -d "$ROOT/$repo/.git" ] || { printf '%-22s %-8s %-9s %s\n' "$repo" SKIP - "not a git repo under $ROOT"; continue; }
 
-  # Refuse to sweep a repo with uncommitted work. Branching off origin/main under someone's
-  # edits either fails or drags them along, and neither is this script's call to make.
-  if [ -n "$(git -C "$ROOT/$repo" status --porcelain)" ]; then
+  # Is this repo swept in a worktree? Answered before the dirty check, because the answer
+  # decides whether that check applies at all.
+  contended=0
+  case " $WORKTREE_REPOS " in
+    *" $repo "*) contended=1 ;;
+  esac
+
+  # Refuse to sweep a repo with uncommitted work. `checkout -B` switches the branch of the
+  # very checkout those edits live in, so it either fails or drags them along, and neither
+  # is this script's call to make.
+  #
+  # A worktree repo is exempt, and that exemption is the point rather than a loophole:
+  # `git worktree add` builds a separate directory from origin/main and never touches the
+  # contended checkout or its index. A dirty checkout is the *expected* state there, since a
+  # repo lands in WORKTREE_REPOS precisely because someone else is working in it. With the
+  # guard applied to them, async-test-lib was skipped on every sweep (#617), and it is the
+  # only consumer that commits its .vibetags-mod-* sidecars, the file class #590 was found
+  # through. The footer prints identically either way, so a sweep covering four repos of
+  # five read exactly like a complete one.
+  if [ "$contended" -eq 0 ] && [ -n "$(git -C "$ROOT/$repo" status --porcelain)" ]; then
     printf '%-22s %-8s %-9s %s\n' "$repo" SKIP - "working tree dirty; commit or stash first"
     continue
   fi
@@ -155,24 +172,21 @@ while IFS=: read -r repo tool mvncmd gradlecmd; do
   # A contended repo is swept in a detached worktree so its checkout is never touched.
   work="$ROOT/$repo"
   wt=""
-  case " $WORKTREE_REPOS " in
-    *" $repo "*)
-      wt="$LOGDIR/wt-$repo"
-      rm -rf "$wt"
-      git -C "$ROOT/$repo" worktree prune
-      # -B, not -b: the branch survives the worktree being removed, so a second sweep of the
-      # same version died with "a branch named ... already exists" and reported ERROR for a
-      # repo whose build was never attempted. The non-worktree path already used checkout -B
-      # for exactly this reason.
-      git -C "$ROOT/$repo" worktree add -q -B "$BRANCH" "$wt" origin/main || {
-        printf '%-22s %-8s %-9s %s\n' "$repo" ERROR - "worktree add failed"; continue; }
-      work="$wt"
-      ;;
-    *)
-      git -C "$work" checkout -q -B "$BRANCH" origin/main || {
-        printf '%-22s %-8s %-9s %s\n' "$repo" ERROR - "checkout failed"; continue; }
-      ;;
-  esac
+  if [ "$contended" -eq 1 ]; then
+    wt="$LOGDIR/wt-$repo"
+    rm -rf "$wt"
+    git -C "$ROOT/$repo" worktree prune
+    # -B, not -b: the branch survives the worktree being removed, so a second sweep of the
+    # same version died with "a branch named ... already exists" and reported ERROR for a
+    # repo whose build was never attempted. The non-worktree path already used checkout -B
+    # for exactly this reason.
+    git -C "$ROOT/$repo" worktree add -q -B "$BRANCH" "$wt" origin/main || {
+      printf '%-22s %-8s %-9s %s\n' "$repo" ERROR - "worktree add failed"; continue; }
+    work="$wt"
+  else
+    git -C "$work" checkout -q -B "$BRANCH" origin/main || {
+      printf '%-22s %-8s %-9s %s\n' "$repo" ERROR - "checkout failed"; continue; }
+  fi
 
   if ! bump "$work" "$VERSION"; then
     printf '%-22s %-8s %-9s %s\n' "$repo" ERROR - "no version declaration matched; update this script"

--- a/tools/release-notes.sh
+++ b/tools/release-notes.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Extract one release's notes from docs/CHANGELOG.md, for `gh release create --notes-file`.
+#
+# Usage: tools/release-notes.sh <version>            # writes the section to stdout
+#
+# This exists because the extraction used to be an inline awk range in the release skill and in
+# docs/RELEASING.md:
+#
+#     awk "/^## \[$V\]/,/^## \[/{...}" docs/CHANGELOG.md
+#
+# An awk range tests its end pattern against the very line that opened it, and `^## \[` matches
+# the section heading itself, so the range opened and closed on one line. On GNU awk 5.4.1 that
+# emitted the heading and nothing else: 1 line where the section was 84 (#619).
+#
+# It failed in the direction that looks correct. The output was not empty and not an error, it
+# was a file containing exactly the right release heading with the whole body missing, and
+# `gh release create --notes-file` accepts that without complaint. By the time anyone reads the
+# release page the tag exists and the Maven Central deploy has already fired, and a tag that
+# publishes cannot be re-cut. Hence the guard below: this script fails loudly rather than
+# handing a truncated file to an irreversible step.
+#
+# Deliberately no release version appears anywhere in this file. ReleaseScriptCoverageTest fails
+# the build for a version literal in a tracked file that tools/set-version.sh does not rewrite.
+set -eu
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+  echo "usage: $0 <version>" >&2
+  exit 2
+fi
+
+CHANGELOG="${CHANGELOG:-docs/CHANGELOG.md}"
+if [ ! -f "$CHANGELOG" ]; then
+  echo "release-notes.sh: no changelog at $CHANGELOG (run from the repository root)" >&2
+  exit 2
+fi
+
+# index($0, want) == 1 rather than a regex, so the [ and ] in the heading need no escaping.
+# The heading is printed, matching every release body from 1.2.x on, and `next` moves past it
+# so the stop rule below cannot fire on the very line that started the section.
+notes=$(awk -v want="## [$VERSION]" '
+  index($0, want) == 1 { on = 1; print; next }
+  on && /^## \[/       { exit }
+  on                   { print }
+' "$CHANGELOG")
+
+# Drop leading blank lines so the release page opens on the first heading. Command substitution
+# has already stripped the trailing ones.
+notes=$(printf '%s
+' "$notes" | sed -e '/./,$!d')
+
+# A section that is present but nearly empty is as dangerous as a missing one, so the guard is a
+# line count and not a null check. Five lines is well below any real entry and well above the
+# one-line truncation this is here to catch.
+count=$(printf '%s\n' "$notes" | grep -c '' || true)
+if [ "$count" -lt 5 ]; then
+  echo "release-notes.sh: extracted only $count line(s) for $VERSION from $CHANGELOG." >&2
+  echo "  Either the heading '## [$VERSION]' is absent, or the section is empty. Refusing to" >&2
+  echo "  emit notes for a release, because the publish step it feeds cannot be undone." >&2
+  exit 1
+fi
+
+# GitHub resolves a relative image path from the repository root on a release page, so an
+# unrewritten changelog-assets link 404s there while rendering correctly in the CHANGELOG.
+printf '%s\n' "$notes" \
+  | sed "s|](changelog-assets/$VERSION/|](https://github.com/PIsberg/vibetags/raw/v$VERSION/docs/changelog-assets/$VERSION/|g"

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ConsumerSweepWorktreeExemptionTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ConsumerSweepWorktreeExemptionTest.java
@@ -1,0 +1,124 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * The dirty-tree guard in {@code tools/consumer-sweep.sh} must not apply to a repo swept in a
+ * worktree.
+ *
+ * <p>The guard refuses to sweep a consumer with uncommitted work, and for the checkout path that
+ * is right: {@code git checkout -B} switches the branch of the very checkout those edits live
+ * in. The worktree path does no such thing. {@code git worktree add} builds a separate directory
+ * from {@code origin/main} and never touches the contended checkout or its index.
+ *
+ * <p>A repo is in {@code WORKTREE_REPOS} precisely because somebody else works in it, so a dirty
+ * checkout is its normal state rather than an exception. With the guard applied to it,
+ * {@code async-test-lib} was skipped on every sweep (#617). That is the consumer worth losing
+ * least: it is the only one that commits its {@code .vibetags-mod-*} sidecars, which is the file
+ * class #590 was found through.
+ *
+ * <p>The failure is silent, which is why this is a test rather than a comment. The sweep's footer
+ * prints the same words whether the loop covered five consumers or four, so a partial sweep reads
+ * exactly like a complete one.
+ */
+@DisplayName("The consumer sweep exempts worktree repos from the dirty-tree guard")
+class ConsumerSweepWorktreeExemptionTest {
+
+    /** {@code vibetags/} is the surefire working directory; its parent is the repo root. */
+    private static final Path REPO_ROOT = Paths.get("").toAbsolutePath().getParent();
+
+    @Test
+    @DisplayName("a dirty checkout skips an ordinary consumer but not one swept in a worktree")
+    void aDirtyCheckoutDoesNotSkipAWorktreeConsumer() throws Exception {
+        Path script = REPO_ROOT.resolve("tools/consumer-sweep.sh");
+        assumeTrue(Files.isRegularFile(script), "consumer-sweep.sh not reachable; skipping");
+
+        // blindbean is swept by checkout, async-test-lib by worktree. Both start dirty.
+        Path root = Files.createTempDirectory("sweep-consumer-root");
+        dirtyRepoAt(root.resolve("blindbean"));
+        dirtyRepoAt(root.resolve("async-test-lib"));
+
+        List<String> rows = runSweep(root);
+
+        String checkoutRow = rowFor(rows, "blindbean");
+        String worktreeRow = rowFor(rows, "async-test-lib");
+        String all = String.join(System.lineSeparator(), rows);
+
+        assertTrue(checkoutRow.contains("working tree dirty"),
+            "a consumer swept by checkout must still be refused while it has uncommitted work, "
+                + "because checkout -B would switch the branch under those edits. Row was: "
+                + checkoutRow + System.lineSeparator() + all);
+
+        assertTrue(!worktreeRow.contains("working tree dirty"),
+            "async-test-lib was skipped for having a dirty checkout, but it is swept in a "
+                + "worktree, which cannot touch that checkout at all. A repo is in "
+                + "WORKTREE_REPOS because someone else works in it, so dirty is its normal "
+                + "state and this guard removes it from every sweep (#617). Row was: "
+                + worktreeRow + System.lineSeparator() + all);
+    }
+
+    /** Runs the sweep over a synthetic consumer root, with no build reached by either repo. */
+    private static List<String> runSweep(Path root) throws IOException, InterruptedException {
+        ProcessBuilder pb = new ProcessBuilder(
+            "sh", "tools/consumer-sweep.sh", "9.9.9", "blindbean", "async-test-lib");
+        pb.directory(REPO_ROOT.toFile());
+        pb.redirectErrorStream(true);
+        pb.environment().put("VIBETAGS_CONSUMER_ROOT", root.toAbsolutePath().toString());
+        // Keep the script's scratch directory inside the temp root. It rm -rf's its own worktree
+        // path, and that path is shared with a real sweep run from the same machine.
+        pb.environment().put("TMPDIR", root.toAbsolutePath().toString());
+        Process sweep;
+        try {
+            sweep = pb.start();
+        } catch (IOException noShell) {
+            assumeTrue(false, "no sh on PATH; the Linux CI job runs this");
+            return List.of();
+        }
+        String out = new String(sweep.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        sweep.waitFor();
+        return out.lines().toList();
+    }
+
+    /** The row the sweep printed for one repo, or a message naming what it printed instead. */
+    private static String rowFor(List<String> rows, String repo) {
+        Optional<String> row = rows.stream().filter(l -> l.startsWith(repo + " ")).findFirst();
+        assertTrue(row.isPresent(),
+            "the sweep printed no row at all for " + repo + ". Every consumer named on the "
+                + "command line gets a row, so a missing one means the loop ended early: "
+                + String.join(System.lineSeparator(), rows));
+        return row.get();
+    }
+
+    /** A git repo with one commit and one uncommitted edit on top. */
+    private static void dirtyRepoAt(Path dir) throws IOException, InterruptedException {
+        Files.createDirectories(dir);
+        git(dir, "init", "-q");
+        Files.writeString(dir.resolve("pom.xml"),
+            "<project><properties><vibetags.version>1.0.0</vibetags.version></properties></project>");
+        git(dir, "add", "-A");
+        git(dir, "-c", "user.email=t@example.com", "-c", "user.name=t", "commit", "-q", "-m", "init");
+        // The uncommitted edit that the guard reacts to.
+        Files.writeString(dir.resolve("NOTES.md"), "work in progress");
+    }
+
+    private static void git(Path dir, String... args) throws IOException, InterruptedException {
+        String[] cmd = new String[args.length + 1];
+        cmd[0] = "git";
+        System.arraycopy(args, 0, cmd, 1, args.length);
+        Process p = new ProcessBuilder(cmd).directory(dir.toFile()).redirectErrorStream(true).start();
+        String log = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        assertTrue(p.waitFor() == 0, "git " + String.join(" ", args) + " failed: " + log);
+    }
+}

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseNotesExtractionTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ReleaseNotesExtractionTest.java
@@ -1,0 +1,173 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Release notes are extracted by one script, and that script refuses to emit a truncated file.
+ *
+ * <p>The extraction used to be an inline awk range, in two places. An awk range tests its end
+ * pattern against the record that opened it, and the end pattern here matches the section heading
+ * itself, so the range opened and closed on one line and the command emitted the heading alone.
+ *
+ * <p>What makes it worth a test rather than a comment is the direction it fails in. The output is
+ * not empty and not an error: it is a file containing exactly the right release title with the
+ * entire body missing. {@code gh release create --notes-file} accepts it, and by the time anyone
+ * reads the release page the tag exists and the Maven Central deploy has fired. A tag that
+ * publishes cannot be re-cut.
+ *
+ * <p>It has now happened twice. {@code docs/RELEASING.md} shipped the range form, produced a
+ * one-line release note for 1.2.3, and was corrected with a warning against it. The release skill
+ * kept its own copy of the broken command and produced the same one-line extract again at
+ * the next release cut from it (#619), with that warning sitting unread in the other file.
+ * Two copies of a subtle command was the defect, so the invariant pinned here is that there
+ * is exactly one implementation and no document inlines its own.
+ */
+@DisplayName("Release notes come from one script that refuses to truncate")
+class ReleaseNotesExtractionTest {
+
+    /** {@code vibetags/} is the surefire working directory; its parent is the repo root. */
+    private static final Path REPO_ROOT = Paths.get("").toAbsolutePath().getParent();
+
+    private static final String SCRIPT = "tools/release-notes.sh";
+
+    @Test
+    @DisplayName("no document inlines its own extraction; both call the shared script")
+    void theExtractionIsNotInlinedInAnyRunnableBlock() throws IOException {
+        assertTrue(Files.isRegularFile(REPO_ROOT.resolve(SCRIPT)),
+            SCRIPT + " is missing, so both documents point at a script that does not exist.");
+
+        for (String doc : List.of(".claude/skills/release/SKILL.md", "docs/RELEASING.md")) {
+            Path path = REPO_ROOT.resolve(doc);
+            assertTrue(Files.isRegularFile(path), doc + " is missing");
+            String text = Files.readString(path, StandardCharsets.UTF_8);
+
+            assertTrue(text.contains(SCRIPT),
+                doc + " no longer calls " + SCRIPT + ". If the extraction moved, point this test "
+                    + "and both documents at wherever it went, rather than letting each grow its "
+                    + "own copy again.");
+
+            // Only runnable blocks count. Both documents quote the broken awk range on purpose, in
+            // prose, to explain why it must not be used, and that prose has to stay quotable.
+            for (String block : shellBlocks(text)) {
+                boolean inlinesIt = block.contains("awk") && block.contains("## [");
+                assertTrue(!inlinesIt,
+                    doc + " has a runnable block that extracts the changelog section itself:"
+                        + System.lineSeparator() + block + System.lineSeparator()
+                        + "That is how the same one-line-release-note bug shipped twice. Call "
+                        + SCRIPT + " instead.");
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("the script takes the whole section and stops at the next release")
+    void theWholeSectionIsExtractedAndTheNextOneIsNot() throws Exception {
+        Result run = runScript(syntheticChangelog(), "9.9.9");
+        assertEquals(0, run.exit(), run.err());
+
+        assertTrue(run.out().contains("## [9.9.9]"),
+            "the heading opens the notes, as every release body since 1.2.x does:"
+                + System.lineSeparator() + run.out());
+        assertTrue(run.out().contains("first body line"),
+            "the section body is missing:" + System.lineSeparator() + run.out());
+        assertTrue(run.out().contains("last body line"),
+            "the section body is cut short:" + System.lineSeparator() + run.out());
+        assertTrue(!run.out().contains("9.9.8"),
+            "the next release leaked into these notes:" + System.lineSeparator() + run.out());
+
+        // The bug itself: a heading, and nothing underneath it.
+        assertTrue(run.out().lines().count() > 4,
+            "the extract is one line again, which is the #619 shape exactly:"
+                + System.lineSeparator() + run.out());
+    }
+
+    @Test
+    @DisplayName("a missing or empty section is refused rather than published")
+    void aTruncatedExtractIsRefused() throws Exception {
+        Result absent = runScript(syntheticChangelog(), "7.7.7");
+
+        assertNotEquals(0, absent.exit(),
+            "a version with no section in the changelog produced notes and exit 0. What reads "
+                + "that file next is gh release create, which tags main and fires the Central "
+                + "deploy, so the refusal has to happen here:"
+                + System.lineSeparator() + absent.out());
+        assertTrue(absent.err().contains("Refusing"),
+            "the refusal has to say why, since its caller is one step from publishing: "
+                + absent.err());
+    }
+
+    /** A changelog with one real section, a following section, and nothing else. */
+    private static Path syntheticChangelog() throws IOException {
+        Path file = Files.createTempDirectory("release-notes").resolve("CHANGELOG.md");
+        Files.writeString(file, String.join(System.lineSeparator(),
+            "# Changelog",
+            "",
+            "## [9.9.9] - 2026-01-02",
+            "",
+            "### Fixed",
+            "",
+            "- first body line",
+            "- middle body line",
+            "- last body line",
+            "",
+            "## [9.9.8] - 2026-01-01",
+            "",
+            "### Fixed",
+            "",
+            "- belongs to the previous release",
+            ""), StandardCharsets.UTF_8);
+        return file;
+    }
+
+    private static Result runScript(Path changelog, String version) throws Exception {
+        ProcessBuilder pb = new ProcessBuilder("sh", SCRIPT, version);
+        pb.directory(REPO_ROOT.toFile());
+        pb.environment().put("CHANGELOG", changelog.toAbsolutePath().toString());
+        Process p;
+        try {
+            p = pb.start();
+        } catch (IOException noShell) {
+            assumeTrue(false, "no sh on PATH; the Linux CI job runs this");
+            return new Result(0, "", "");
+        }
+        String out = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        String err = new String(p.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+        return new Result(p.waitFor(), out, err);
+    }
+
+    private record Result(int exit, String out, String err) { }
+
+    /** The contents of every fenced shell block, which are the lines a reader actually runs. */
+    private static List<String> shellBlocks(String text) {
+        List<String> blocks = new ArrayList<>();
+        StringBuilder current = null;
+        for (String line : text.lines().toList()) {
+            String trimmed = line.strip();
+            if (current == null) {
+                if (trimmed.equals("```bash") || trimmed.equals("```sh")) {
+                    current = new StringBuilder();
+                }
+            } else if (trimmed.equals("```")) {
+                blocks.add(current.toString());
+                current = null;
+            } else {
+                current.append(line).append(System.lineSeparator());
+            }
+        }
+        return blocks;
+    }
+}


### PR DESCRIPTION
Fixes #617. Fixes #619.

Two release-tooling bugs, both found while cutting the last release, both of which failed in the
direction that looks like success.

## #617 — the sweep skipped the consumer it can least afford to lose

The dirty-tree guard sat above the `WORKTREE_REPOS` branch, so it also refused `async-test-lib`.

The guard is right for the checkout path: `git checkout -B` switches the branch of the very
checkout someone's edits live in. It is wrong for the worktree path, which builds a separate
directory from `origin/main` and never touches that checkout or its index. And a repo is in
`WORKTREE_REPOS` *precisely because* someone else works in it, so a dirty checkout is its normal
state rather than an exception. The guard therefore removed it from every sweep, permanently.

`async-test-lib` is the row worth losing least: it is the only consumer that commits its
`.vibetags-mod-*` sidecars, which is the file class #590 was found through. And the sweep's footer
prints the same words whether the loop covered five repos or four, so a partial sweep reads exactly
like a complete one.

The fix resolves membership once, before the guard, and reads the flag in both places, so the
`WORKTREE_REPOS` list is matched in exactly one spot instead of two.

## #619 — the release notes extracted the title and dropped the body

The extraction was an inline `awk` range. An awk range tests its end pattern against the record
that opened it, and `/^## \[/` matches the section heading itself, so the range opened and closed
on one line. Output: the correct release title, with the entire body missing.

`gh release create --notes-file` accepts that without complaint, and by the time anyone reads the
release page the tag exists and the Maven Central deploy has fired. A tag that publishes cannot be
re-cut.

**It had already happened, for 1.2.3.** `docs/RELEASING.md` was corrected then and carries an
explicit warning against the range form. The release skill kept its own copy of the broken command,
and the skill is what an agent actually follows, so the warning sat one file away and changed
nothing.

That is why this is not "fix the skill". Correcting it would have restored the same two-copy
arrangement that allowed the drift, with both copies right for a while. The extraction is now
`tools/release-notes.sh`, both documents call it, and it **refuses to emit fewer than five lines**
rather than hand a truncated file to a step that cannot be undone.

## Verification

Both fixes were shown failing first.

| Check | Result |
|---|---|
| #617 before the fix | `async-test-lib  SKIP  working tree dirty` against a synthetic consumer root |
| #617 after | reaches the worktree path; `blindbean` still correctly refused |
| #619 before the fix | test red on the assertion naming the missing script call |
| #619 script vs reality | run against the real changelog, reproduces the notes published for the last release **byte-for-byte** |
| `mvn clean verify -Pe2e` | 2673 tests, 0 failures, 0 errors, 4 skipped; PMD, CPD and SpotBugs all ran |
| pre-commit | gitleaks, end-of-file-fixer, trailing-whitespace passed; `checkstyle` **skipped** (Docker hook, no daemon here), and Checkstyle binds to Maven `validate`, which ran green |

Four tests are added. Three need `sh` and skip on a Windows host, exactly as
`ReleaseScriptCoverageTest` already does; the Linux CI leg is what runs them. The fourth needs no
shell and asserts the invariant that outlives both bugs: no runnable block in either document
extracts the changelog section itself. Prose may still quote the broken `awk` form, which is how
`RELEASING.md` keeps its warning.

## Also in this pass, not in this diff

- The v1.3.3 release body was published without its `## [1.3.3] - 2026-09-10` heading, while every
  release body from 1.2.x on opens with one. The script now prints the heading and the live release
  body has been edited to match.
- #619's own premise was wrong and has been corrected on the issue: `docs/RELEASING.md` did **not**
  carry the broken snippet. It was already right. That made the fix better, not smaller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lp3ZaoNQYPv9NWdXQuLEn
