### PR TITLE
fix: retire a covered ancestor region even when it is the newer sidecar (#621)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- One module's guardrails are no longer written twice when the leftover sidecar is the newer file
+  (issue #621). A repository whose sources live in one subproject below the VibeTags root can end
+  up with two sidecars for what is really one module: the ancestor identity a compilation falls
+  back to when it cannot resolve its module root from the round's sources, and the module's own.
+  The prune that exists to retire the leftover consulted timestamps before containment, so it only
+  let a descendant retire its ancestor when the descendant was the fresher file. Reverse the write
+  order and nothing was retired at all: the ancestor was protected because its descendant was
+  older, and the descendant was protected because the ancestor's smaller element set did not cover
+  it. Both survived, and every element they shared was written twice, byte-identical, wrapped in
+  two `VIBETAGS-MODULE` regions, into every granular rule file and every aggregate, with exit code
+  0 and nothing on the console.
+
+  Containment is now decided first and without timestamps, provided it is strict: the nested
+  modules must between them know at least one element the ancestor never had. Recency is not
+  evidence of correctness here and arguably the reverse, because a nested identity is only ever
+  produced by resolving a real build file while the ancestor identity is the fallback. Equal
+  element sets stay with freshness, because that is also what "the sources moved up out of the
+  subproject" looks like, and there it is the nested sidecar that is the leftover. A reactor root
+  that compiles sources of its own still keeps at least one element no submodule has, fails
+  containment, and keeps its region.
+
+  The symptom is worth recognising, because it points away from the cause: only *some* annotated
+  elements duplicate, and they are exactly the ancestor's smaller set, which reads like a bug
+  specific to certain annotations and is nothing of the kind. `-Avibetags.module` with a stable
+  name remains the way to rule the whole class out, by pinning the identity so the fallback is
+  never produced.
+
 ## [1.3.3] - 2026-09-10
 
 ### Upgrading

--- a/docs/MULTI-MODULE.md
+++ b/docs/MULTI-MODULE.md
@@ -140,6 +140,28 @@ Ties go to the more specific module: on equal timestamps a descendant still reti
 never the reverse. Two sidecars written inside one filesystem tick therefore resolve the same way on
 every build.
 
+Timestamps decide only where they have to. A region whose elements are all claimed by the modules
+nested inside it, where those modules between them also know **at least one element it never had**,
+is retired without consulting timestamps at all. Freshness gated this until #621, and that left a
+build repairing nothing in either direction: the ancestor was the more recently written file, so its
+descendant was not allowed to retire it, and the ancestor's smaller element set could not cover the
+descendant's, so neither went. Both survived and every element they shared was written twice.
+
+Recency is not evidence of correctness in that direction, and arguably the reverse: a nested identity
+is only ever produced by resolving a real build file, while the ancestor identity is the *fallback* a
+compilation takes when it cannot resolve its module root from the round's sources. So the fresher of
+the two is the one more likely to be wrong. The strictness is what keeps the second row of the table
+above working: equal element sets are exactly what "sources moved up" also looks like, and there the
+nested sidecar is the leftover, so equality is still settled by freshness.
+
+The symptom to recognise, because it misleads: only *some* annotated elements duplicate, and they are
+exactly the ancestor's smaller set. That reads like a bug specific to certain annotations, or to
+elements carrying more than one, and it is neither.
+
+If you need to rule this out entirely rather than have it repaired, pass `-Avibetags.module` with a
+stable name alongside `-Avibetags.root`. That pins the identity instead of leaving it to per-round
+resolution, so the fallback identity is never produced in the first place.
+
 The rule is conservative in every other respect. A region is dropped only when the fresher regions
 cover *all* of its elements, so a reactor root that compiles sources of its own keeps at least one
 element no submodule has and keeps its region and its sub-markers. Sibling modules are never in a

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ModuleSidecar.java
@@ -868,15 +868,33 @@ public final class ModuleSidecar {
      * so before this was handled both regions survived and every generated file stated the same
      * guardrails twice. {@link #yieldsOnSamePath} settles that pair, again by freshness.
      *
-     * <p>Ties go to the more specific module, which is the first case's shape and the historical
-     * default: on equal timestamps a descendant still retires its ancestor, never the reverse,
-     * and on one path the named module outlives the root identity.
+     * <p><strong>Strict containment is decided first, and without timestamps.</strong> A region
+     * whose every element is claimed by regions nested inside it, where those regions between them
+     * also know at least one element it never had, is retired on that ground alone. The strictness
+     * matters: equal element sets are exactly what the second case above also looks like, and
+     * there it is the nested sidecar that is the leftover, so equality is left to freshness. Freshness used to gate this, and that left the reported case unrepaired in both
+     * directions at once (#621): the ancestor was the more recently written file, so its
+     * descendant was not allowed to retire it, and the ancestor's smaller element set could
+     * not cover the descendant's, so neither went. Both survived and every element they
+     * shared was written twice, byte-identical, into every generated file.
      *
-     * <p>Conservative in every other respect. A region is dropped only when the fresher regions
-     * cover <em>all</em> of its elements, so a reactor root that compiles sources of its own keeps
-     * at least one element no submodule has and keeps its region. Sibling modules are never in a
-     * path relation. A sidecar recording no element ids says nothing and is left alone, as is one
-     * whose timestamp cannot be read.
+     * <p>Recency is not evidence of correctness here, and arguably the reverse. The ancestor
+     * identity is the <em>fallback</em> a compilation takes when it cannot resolve its module
+     * root from the round's sources, so it is the identity most likely to be simultaneously
+     * wrong and freshly written. A nested identity is only ever produced by resolving a real
+     * build file.
+     *
+     * <p>Freshness still settles the two relations where containment cannot say which identity
+     * is the leftover: a nested region against an ancestor that outlived it, and two regions
+     * on one path. A region already retired by containment takes no part in those decisions,
+     * because two regions holding equal element sets each cover the other and dropping both
+     * would take every guardrail with them. Ties go to the more specific module, as before.
+     *
+     * <p>Conservative in every other respect. A region is dropped only when the surviving
+     * regions cover <em>all</em> of its elements, so a reactor root that compiles sources of
+     * its own keeps at least one element no submodule has and keeps its region. Sibling
+     * modules are never in a path relation. A sidecar recording no element ids says nothing
+     * and is left alone, as is one whose timestamp cannot be read.
      */
     private static void dropSupersededRegions(List<ModuleSidecar> sidecars,
                                               List<Path> files, boolean prune,
@@ -895,19 +913,65 @@ public final class ModuleSidecar {
             writtenAtByRegion.merge(s.regionId, written, Math::max);
         }
 
-        Set<String> superseded = new LinkedHashSet<>();
+        // Pass 1: containment by the modules nested inside a region, decided without
+        // consulting timestamps. A region whose every element is also claimed by regions
+        // below it is the same sources under a less specific identity, and that is true
+        // whenever it is true. Gating it on freshness left the reported case unrepaired in
+        // both directions at once: the ancestor was the newer file so its descendant could
+        // not retire it, and the ancestor's smaller element set could not cover the
+        // descendant's, so neither was dropped and every shared element was written twice
+        // (#621). Recency is no evidence here. The ancestor identity is the *fallback* a
+        // compilation takes when it cannot resolve its module root from the round's sources,
+        // so it is exactly the identity most likely to be both wrong and freshly written.
+        //
+        // The safety is containment itself, unchanged: a reactor root that compiles sources
+        // of its own keeps at least one element no submodule has, fails containment, and
+        // keeps its region.
+        Set<String> supersededByDescendants = new LinkedHashSet<>();
         elementsByRegion.forEach((region, elements) -> {
-            if (elements.isEmpty()) return; // nothing to compare against — keep it
-            long writtenAt = writtenAtByRegion.getOrDefault(region, Long.MAX_VALUE);
-            if (writtenAt == Long.MAX_VALUE) return; // unreadable timestamp — never retire on a guess
+            if (elements.isEmpty()) return; // nothing to compare against - keep it
             String path = pathByRegion.getOrDefault(region, "");
             Set<String> covered = new LinkedHashSet<>();
             elementsByRegion.forEach((other, otherElements) -> {
                 if (other.equals(region)) return;
+                if (isNestedUnder(pathByRegion.getOrDefault(other, ""), path)) {
+                    covered.addAll(otherElements);
+                }
+            });
+            // Strictly more, not merely as much. Equal element sets are genuinely ambiguous:
+            // they are what "the sources moved up out of the subproject" also looks like, and
+            // there it is the nested sidecar that is the leftover and the root that is real.
+            // Only freshness separates those two, so equality is left to pass 2. A descendant
+            // that knows an element the ancestor never had cannot be the stale one.
+            if (covered.containsAll(elements) && !elements.containsAll(covered)) {
+                supersededByDescendants.add(region);
+            }
+        });
+
+        // Pass 2: the relations that genuinely need a tie-break, which are the ones where
+        // containment alone cannot say which identity is the leftover.
+        //
+        // A region already retired above is not allowed to retire anything here. Without that,
+        // two regions holding equal element sets each cover the other and both are dropped,
+        // taking every guardrail with them. Ties go to the more specific module, as before.
+        Set<String> superseded = new LinkedHashSet<>(supersededByDescendants);
+        elementsByRegion.forEach((region, elements) -> {
+            if (superseded.contains(region)) return;
+            if (elements.isEmpty()) return; // nothing to compare against - keep it
+            long writtenAt = writtenAtByRegion.getOrDefault(region, Long.MAX_VALUE);
+            if (writtenAt == Long.MAX_VALUE) return; // unreadable timestamp - never retire on a guess
+            String path = pathByRegion.getOrDefault(region, "");
+            Set<String> covered = new LinkedHashSet<>();
+            elementsByRegion.forEach((other, otherElements) -> {
+                if (other.equals(region)) return;
+                if (supersededByDescendants.contains(other)) return;
                 String otherPath = pathByRegion.getOrDefault(other, "");
                 long otherWrittenAt = writtenAtByRegion.getOrDefault(other, Long.MIN_VALUE);
                 if (isNestedUnder(otherPath, path)) {
                     // A descendant retires its ancestor on equal timestamps too (see javadoc).
+                    // Pass 1 has already taken the cases where the descendants know strictly
+                    // more; what is left here is equal element sets, where only freshness can
+                    // say which identity is the leftover.
                     if (otherWrittenAt >= writtenAt) covered.addAll(otherElements);
                 } else if (isNestedUnder(path, otherPath) && otherWrittenAt > writtenAt) {
                     covered.addAll(otherElements);

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/FresherAncestorRegionDuplicateTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/FresherAncestorRegionDuplicateTest.java
@@ -1,0 +1,211 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An ancestor region whose elements are fully covered by a nested module is retired even when it
+ * is the <em>fresher</em> sidecar of the two.
+ *
+ * <p>{@code AncestorModuleDuplicateRegionTest} covers the case where the nested module compiled
+ * last, and there the ancestor is retired. The prune consults sidecar timestamps before it
+ * consults containment, so it only lets a descendant retire its ancestor when the descendant is at
+ * least as fresh. Reverse the order and nothing is retired at all:
+ *
+ * <ul>
+ *   <li>the ancestor cannot be retired, because its only descendant is older;</li>
+ *   <li>the descendant cannot be retired either, because the ancestor's smaller element set does
+ *       not cover the descendant's.</li>
+ * </ul>
+ *
+ * <p>Both regions therefore survive, and every element they share is written twice: once under
+ * each identity, byte-identical, into every generated rule file and into the aggregate. The give
+ * away in a report is that <em>some</em> elements duplicate and others do not. The ones that
+ * duplicate are exactly the ancestor's smaller set, which reads like an annotation-specific bug
+ * and is nothing of the kind.
+ *
+ * <p>Ordering is not exotic. The ancestor identity is what a compilation falls back to when the
+ * module root cannot be resolved from the round's sources, so any later build that takes the
+ * fallback path writes it fresh, and it then outranks the real module's sidecar for good.
+ *
+ * <p>Timestamps here are set explicitly rather than left to the order of the two compiles.
+ * Filesystem mtime granularity is coarse enough on some hosts to make two writes a second apart
+ * compare equal, and the equal case is already covered elsewhere. This test is about the strictly
+ * newer ancestor.
+ */
+@Tag("e2e")
+@DisplayName("A fresher ancestor region still yields to the module nested inside it")
+class FresherAncestorRegionDuplicateTest {
+
+    private static final String VALIDATOR_SOURCE = """
+        package com.example.billing;
+
+        import se.deversity.vibetags.annotations.AISecure;
+
+        @AISecure(aspect = "input validation")
+        public class InvoiceValidator {
+        }
+        """;
+
+    private static final String WRITER_SOURCE = """
+        package com.example.billing;
+
+        import se.deversity.vibetags.annotations.AIContract;
+
+        @AIContract(invariants = "Ledger entries are append-only")
+        public class LedgerWriter {
+        }
+        """;
+
+    private static final String CALCULATOR_SOURCE = """
+        package com.example.billing;
+
+        import se.deversity.vibetags.annotations.AICore;
+
+        @AICore(sensitivity = "critical")
+        public class TaxCalculator {
+        }
+        """;
+
+    @TempDir
+    Path repoRoot;
+
+    @AfterEach
+    void tearDown() {
+        VibeTagsLogger.shutdown();
+    }
+
+    /**
+     * Builds the reported state: a nested module sidecar holding three elements, and an ancestor
+     * sidecar holding two of them, written afterwards and strictly newer.
+     */
+    private void buildFresherAncestorOverNestedModule() throws IOException {
+        Files.writeString(repoRoot.resolve("settings.gradle"),
+            "rootProject.name = 'app'\ninclude 'app'\n", StandardCharsets.UTF_8);
+        Files.writeString(repoRoot.resolve("build.gradle"),
+            "plugins { id 'java' }\n", StandardCharsets.UTF_8);
+        Files.createDirectories(repoRoot.resolve(".gemini/rules"));
+
+        // The subproject has its own build file, so the module-root walk stops there.
+        Files.createDirectories(repoRoot.resolve("app"));
+        Files.writeString(repoRoot.resolve("app/build.gradle"),
+            "plugins { id 'java' }\n", StandardCharsets.UTF_8);
+
+        ProcessorTestHarness nested = new ProcessorTestHarness(repoRoot, false);
+        nested.writeSourceFile("app/src/main/java/com/example/billing/InvoiceValidator.java",
+            VALIDATOR_SOURCE);
+        nested.writeSourceFile("app/src/main/java/com/example/billing/LedgerWriter.java",
+            WRITER_SOURCE);
+        nested.writeSourceFile("app/src/main/java/com/example/billing/TaxCalculator.java",
+            CALCULATOR_SOURCE);
+        nested.compile();
+
+        // Backdated before the second compile rather than after it. The merge that has to make
+        // the decision runs inside that compile, so the relation has to hold by then, and mtime
+        // granularity is coarse enough on some hosts to make two consecutive writes compare equal.
+        backdateNestedSidecar();
+
+        // Now a build that cannot resolve the subproject: its build file is gone, so the walk
+        // climbs to the repository root and the compilation files itself under the ancestor
+        // identity. It sees two of the three elements, so its set is a strict subset.
+        Files.delete(repoRoot.resolve("app/build.gradle"));
+        Files.delete(repoRoot.resolve(
+            "app/src/main/java/com/example/billing/TaxCalculator.java"));
+
+        ProcessorTestHarness ancestor = new ProcessorTestHarness(repoRoot, false);
+        ancestor.writeSourceFile("app/src/main/java/com/example/billing/InvoiceValidator.java",
+            VALIDATOR_SOURCE);
+        ancestor.writeSourceFile("app/src/main/java/com/example/billing/LedgerWriter.java",
+            WRITER_SOURCE);
+        ancestor.compile();
+    }
+
+    /** Puts the nested module's sidecar strictly in the past, so the ancestor is the fresher. */
+    private void backdateNestedSidecar() throws IOException {
+        Path nested = repoRoot.resolve(".vibetags-mod-app");
+        assertTrue(Files.exists(nested), "precondition: the nested module wrote its sidecar");
+        long now = Files.getLastModifiedTime(nested).toMillis();
+        Files.setLastModifiedTime(nested, FileTime.fromMillis(now - 60_000L));
+    }
+
+    private String ruleFile(String stem) throws IOException {
+        Path p = repoRoot.resolve(".gemini/rules/" + stem + ".md");
+        assertTrue(Files.exists(p), "expected generated rule file " + p);
+        return Files.readString(p, StandardCharsets.UTF_8);
+    }
+
+    private static int countOf(String haystack, String needle) {
+        int count = 0;
+        for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) {
+            count++;
+        }
+        return count;
+    }
+
+    @Test
+    @DisplayName("a shared element is stated once, not once per identity")
+    void sharedElementsAreNotWrittenTwice() throws IOException {
+        buildFresherAncestorOverNestedModule();
+
+        String validator = ruleFile("com-example-billing-InvoiceValidator");
+        assertEquals(1, countOf(validator, "## Security-Critical Code"),
+            "the guardrail is stated once per element, not once per module identity. Two regions "
+                + "claiming the same element write it twice, byte-identical:\n" + validator);
+
+        String writer = ruleFile("com-example-billing-LedgerWriter");
+        assertEquals(1, countOf(writer, "## Contract-Frozen Signature"),
+            "the guardrail is stated once per element, not once per module identity:\n" + writer);
+    }
+
+    @Test
+    @DisplayName("the covered ancestor sidecar is retired even though it is the newer file")
+    void theFresherAncestorSidecarIsPruned() throws IOException {
+        buildFresherAncestorOverNestedModule();
+
+        assertFalse(Files.exists(repoRoot.resolve(".vibetags-mod-_root_")),
+            "the ancestor holds no element the nested module does not, so it is the same sources "
+                + "under a less specific identity and must be retired. Being the more recently "
+                + "written file does not make it right: the ancestor identity is the fallback a "
+                + "compilation takes when it cannot resolve its module root, so it is precisely "
+                + "the one most likely to be both wrong and recent.");
+        assertTrue(Files.exists(repoRoot.resolve(".vibetags-mod-app")),
+            "the real module's sidecar must survive the prune");
+    }
+
+    @Test
+    @DisplayName("one surviving region leaves no module markers behind")
+    void oneRegionMeansNoSubMarkers() throws IOException {
+        buildFresherAncestorOverNestedModule();
+
+        String validator = ruleFile("com-example-billing-InvoiceValidator");
+        assertFalse(validator.contains("VIBETAGS-MODULE"),
+            "one module leaves one region, so no sub-markers belong in the file:\n" + validator);
+    }
+
+    /**
+     * The element only the nested module ever saw must not be collateral damage. It is the
+     * element that distinguishes the two sets, so a fix that retires the wrong region loses it.
+     */
+    @Test
+    @DisplayName("an element the ancestor never saw survives the prune")
+    void theElementOnlyTheNestedModuleSawSurvives() throws IOException {
+        buildFresherAncestorOverNestedModule();
+
+        String calculator = ruleFile("com-example-billing-TaxCalculator");
+        assertEquals(1, countOf(calculator, "critical"),
+            "the nested module's own element must still be rendered:\n" + calculator);
+    }
+}

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/internal/SupersededAncestorRegionTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/internal/SupersededAncestorRegionTest.java
@@ -364,4 +364,46 @@ class SupersededAncestorRegionTest {
             "and the leftover sidecar must be deleted, not merely skipped");
     }
 
+
+    /**
+     * The reported shape in #621: the ancestor is the <em>fresher</em> file, and its element set is
+     * a strict subset of the nested module's.
+     *
+     * <p>Before strict containment was decided ahead of freshness, neither region could go. The
+     * ancestor was protected because its only descendant was older, and the descendant was
+     * protected because the ancestor's smaller set did not cover it. Both survived and every
+     * element they shared was written twice into every generated file.
+     */
+    @Test
+    void aFresherRootIsRetiredWhenTheSubprojectKnowsStrictlyMore(@TempDir Path root) throws IOException {
+        Files.createDirectories(root.resolve("app"));
+        writeSidecar(root, "_root_", "", "com.example.A", "com.example.B");
+        writeSidecar(root, "app", "app", "com.example.A", "com.example.B", "com.example.C");
+        writtenAt(root, "app", 1_000_000L);
+        writtenAt(root, "_root_", 2_000_000L);   // the fallback identity, written last
+
+        assertEquals(List.of("app"), regionIds(ModuleSidecar.readAll(root)),
+            "the ancestor holds nothing the nested module does not, so recency does not save it: "
+                + "the ancestor identity is the fallback taken when a module root cannot be "
+                + "resolved, which makes it the one most likely to be both wrong and recent");
+        assertFalse(Files.exists(root.resolve(".vibetags-mod-_root_")));
+    }
+
+    /**
+     * The safety that makes the rule above sound: containment, not depth. A root that compiles
+     * sources of its own keeps an element no submodule has, and keeps its region however much
+     * more the submodule knows.
+     */
+    @Test
+    void aRootWithAnElementOfItsOwnSurvivesDescendantsThatKnowMore(@TempDir Path root) throws IOException {
+        Files.createDirectories(root.resolve("app"));
+        writeSidecar(root, "_root_", "", "com.example.A", "com.example.RootOnly");
+        writeSidecar(root, "app", "app", "com.example.A", "com.example.B", "com.example.C");
+        writtenAt(root, "app", 2_000_000L);
+        writtenAt(root, "_root_", 1_000_000L);
+
+        assertEquals(List.of("_root_", "app"), regionIds(ModuleSidecar.readAll(root)),
+            "the root owns an element no submodule claims, so it is a real module and keeps its "
+                + "region even though the submodule knows strictly more");
+    }
 }


### PR DESCRIPTION
Fixes #621.

## The bug

A repository whose sources live in one subproject below the VibeTags root can hold two sidecars for
what is really one module:

```
.vibetags-mod-_root_    modulePath=          the fallback identity
.vibetags-mod-<module>  modulePath=<module>  the module's own
```

`dropSupersededRegions` exists to retire the leftover, and it already handles this shape. But it
consulted timestamps *before* containment: a descendant could only retire its ancestor when the
descendant was at least as fresh. Reverse the write order and **nothing** is retired:

- the ancestor is protected, because its only descendant is the older file;
- the descendant is protected, because the ancestor's smaller element set does not cover it.

Both survive. Every element they share is written twice, byte-identical, wrapped in two
`VIBETAGS-MODULE` regions, into every granular rule file and every aggregate. Exit code 0, nothing
on the console, visible only as `region.duplicate ... reason=element-claimed-twice` in
`vibetags.log` or by diffing committed files.

This is not an exotic ordering. The ancestor identity is what a compilation falls back to when it
cannot resolve its module root from the round's sources, so any later build taking the fallback
path writes it fresh, and it then outranks the real module's sidecar permanently.

## The symptom that points away from the cause

Only *some* annotated elements duplicate, and they are exactly the ancestor's smaller set. That
reads like a bug specific to certain annotations, or to elements carrying more than one, and it is
neither. An element with two annotations that is absent from the ancestor's set is untouched, which
makes the annotation theory look disproved from the wrong direction.

`FresherAncestorRegionDuplicateTest` pins that too: its fourth case, asserting the element only the
nested module ever saw still renders, **passed while the other three were red**.

## The fix

Containment is decided first and without timestamps, provided it is **strict**: the nested modules
must between them know at least one element the ancestor never had.

Recency is not evidence of correctness in this direction, and arguably the reverse. A nested
identity is only ever produced by resolving a real build file; the ancestor identity is the
fallback. The fresher of the two is the one *more* likely to be wrong.

**Strictness is load-bearing, and I found that by breaking it.** Deciding plain containment without
timestamps regressed three tests across two classes, because equal element sets are also what
"the sources moved up out of the subproject" looks like, and there the nested sidecar is the
leftover and the root is real. Equality therefore stays with freshness. A region already retired by
containment also takes no part in the freshness pass, or two regions holding equal sets each cover
the other and both are dropped, taking every guardrail with them.

The safety is unchanged and is containment itself: a reactor root that compiles sources of its own
keeps at least one element no submodule has, fails containment, and keeps its region.

## Verification

| Check | Result |
|---|---|
| New e2e test before the fix | red on 3 of 4 cases, including the shared guardrail rendered twice (`expected: <1> but was: <2>`) |
| Re-confirmed red after correcting an assertion needle | still 3 of 4 red |
| `mvn clean verify -Pe2e` | **2679 tests, 0 failures, 0 errors, 4 skipped**; PMD, CPD and SpotBugs all ran |
| Neighbouring region tests | `AncestorModuleDuplicateRegionTest`, `ModuleFlattenedIntoRootTest`, `MultiModuleCaseCollisionTest`, `MultiModuleReactorEndToEndTest`, `MultiModuleGranularRoleMergeTest` all green |
| pre-commit | gitleaks, end-of-file-fixer, trailing-whitespace passed; `checkstyle` **skipped** (Docker hook, no daemon here), and Checkstyle binds to Maven `validate`, which ran green |

Tests added: four end-to-end cases in `FresherAncestorRegionDuplicateTest`, and two unit cases in
`SupersededAncestorRegionTest` (22 → 24) — the regression itself, and the boundary that keeps a root
owning an element of its own.

## Docs

`docs/MULTI-MODULE.md` and the CHANGELOG record the rule, why equality still needs freshness, the
misleading symptom, and `-Avibetags.module` with a stable name as the way to rule the whole class
out by pinning the identity so the fallback is never produced at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lp3ZaoNQYPv9NWdXQuLEn
