### PR TITLE
chore(deps): async-test-lib 1.11.2 -> 1.12.0

### DIFF
--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -88,7 +88,7 @@
         <junit.platform.version>6.1.3</junit.platform.version>
         <mockito.version>5.23.0</mockito.version>
         <archunit.version>1.5.0</archunit.version>
-        <async-test-lib.version>1.11.2</async-test-lib.version>
+        <async-test-lib.version>1.12.0</async-test-lib.version>
         <snakeyaml.version>2.7</snakeyaml.version>
         <jmh.version>1.37</jmh.version>
 


### PR DESCRIPTION
## Why

async-test-lib 1.12.0 was published today. One declaration changes, the
`async-test-lib.version` property in `vibetags-parent/pom.xml`; `vibetags/build.gradle` reads it
back with `pomVersion('async-test-lib.version')`, so there is no second copy to keep in step.

## How it was verified

Both tiers, because the Gradle side has to be shown picking the property up:

```
mvn -B test -Pe2e      Tests run: 2673, Failures: 0, Errors: 0, Skipped: 0    BUILD SUCCESS
./gradlew --no-daemon test -Pe2e                                              BUILD SUCCESSFUL
```

`-Pe2e` is not optional here: most of the `@AsyncTest` classes carry `@Tag("e2e")`, so a plain
`mvn test` would report a green quarter of the async surface. All five classes declaring
`@AsyncTest` ran on the Maven side (EnforcementBaseline, GuardrailFileWriter, ModuleSidecar,
VibeTagsLogger, WriteCache), plus `VibeTagsLoggerConcurrencyTest`, and the Gradle run produced the
same six result files.

The artifact is the published one: the sweep's preflight verified no 1.12.0 jar was cached in
`~/.m2`. That matters more here than elsewhere, because this build puts `mavenLocal()` above
`mavenCentral()` and would silently prefer a local build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbDEg1bgDuPE2HmH8qU1ox
