### PR TITLE
chore: prepare release v1.3.4

### DIFF
--- a/.claude/skills/vibetags-usage/SKILL.md
+++ b/.claude/skills/vibetags-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibetags-usage
 description: This skill should be used when the user asks how to "use VibeTags", "add VibeTags annotations", "set up AI guardrails", "protect code from AI", "configure AI platforms", asks about @AILocked, @AIContext, @AIDraft, @AIAudit, @AIIgnore, @AIPrivacy, @AICore, @AIPerformance, @AIContract, @AITestDriven, @AIThreadSafe, @AIImmutable, @AIDeprecated, @AIObservability, @AIRegulation, @AIArchitecture, @AILegacyBridge, @AIStrictClasspath, @AIInternationalized, @AIPublicAPI, @AISchemaSafe, @AIStrictExceptions, @AIStrictTypes, @AIParallelTests, @AIIdempotent, @AIFeatureFlag, @AISecure, @AICallersOnly, @AISandboxOnly, @AIMemoryBudget, @AIPure, @AIDomainModel, @AIExtensible, @AIInputSanitized, @AISecureLogging, @AIExplain, @AIPrototype, @AISunset, @AITemporary, @AIGenerated, @AILoadBearing, @AIBannedApi, @AIThreadAffinity, @AIKeepInSync annotations, or wants to control how AI tools interact with Java code.
-version: 1.3.3
+version: 1.3.4
 ---
 
 # VibeTags Usage Guide
@@ -27,7 +27,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
     <dependency>
         <groupId>se.deversity.vibetags</groupId>
         <artifactId>vibetags-annotations</artifactId>
-        <version>1.3.3</version>
+        <version>1.3.4</version>
     </dependency>
 </dependencies>
 
@@ -41,7 +41,7 @@ common "VibeTags is broken" report, and neither failure produces a useful error:
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.3.3</version>
+                        <version>1.3.4</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -63,8 +63,8 @@ the whole processor and its SLF4J/Logback dependencies on your compile classpath
 
 ```groovy
 dependencies {
-    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.3.3'
-    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.3'
+    compileOnly         'se.deversity.vibetags:vibetags-annotations:1.3.4'
+    annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.4'
 }
 ```
 
@@ -226,7 +226,7 @@ though the build is green.
 Every way this setup fails is silent, so check rather than assume:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.3.3 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.3.4 doctor
 ```
 
 Or by hand, in the order things go wrong:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.3.3</version>
+            <version>1.3.4</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -76,7 +76,7 @@
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.3.3</version>
+                        <version>1.3.4</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -94,7 +94,7 @@ touch CLAUDE.md .cursorrules AGENTS.md   # Claude, Cursor, Codex CLI — add whi
 Or let the companion CLI do it (and `vibetags doctor` checks your setup afterwards):
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.3.3 init --platforms claude,cursor
+jbang se.deversity.vibetags:vibetags-cli:1.3.4 init --platforms claude,cursor
 ```
 
 **3. Annotate your first class:**
@@ -123,8 +123,8 @@ mvn compile
 
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.4')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.4')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -170,8 +170,8 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.3"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.3"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.4"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.4"))
 
     compileOnly("se.deversity.vibetags:vibetags-annotations")
     kapt("se.deversity.vibetags:vibetags-processor")
@@ -507,8 +507,8 @@ build-tool wiring, active platforms, and `VIBETAGS-START`/`END` marker integrity
 installing anything:
 
 ```bash
-jbang se.deversity.vibetags:vibetags-cli:1.3.3 init --list
-jbang se.deversity.vibetags:vibetags-cli:1.3.3 doctor
+jbang se.deversity.vibetags:vibetags-cli:1.3.4 init --list
+jbang se.deversity.vibetags:vibetags-cli:1.3.4 doctor
 ```
 
 The platform list and marker rules are read from `vibetags-processor` at runtime, so the CLI
@@ -541,7 +541,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
         <dependency>
             <groupId>se.deversity.vibetags</groupId>
             <artifactId>vibetags-bom</artifactId>
-            <version>1.3.3</version>
+            <version>1.3.4</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -566,7 +566,7 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
                     <path>
                         <groupId>se.deversity.vibetags</groupId>
                         <artifactId>vibetags-processor</artifactId>
-                        <version>1.3.3</version>
+                        <version>1.3.4</version>
                     </path>
                 </annotationProcessorPaths>
             </configuration>
@@ -582,8 +582,8 @@ The recommended setup uses the BOM (`vibetags-bom`) to manage both versions in o
 **Gradle:**
 ```groovy
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.4')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.4')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
@@ -597,15 +597,15 @@ dependencies {
 <dependency>
     <groupId>se.deversity.vibetags</groupId>
     <artifactId>vibetags-annotations</artifactId>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
 </dependency>
 <!-- vibetags-processor goes in <annotationProcessorPaths> as shown above -->
 ```
 
 **Gradle:**
 ```groovy
-compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.3'
-annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.3'
+compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.4'
+annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.4'
 ```
 
 > **Backwards compatibility:** Existing 0.5.x setups that depended on `vibetags-processor:<version>` directly continue to work — the processor pulls `vibetags-annotations` transitively. New projects should prefer the split pattern above.

--- a/USAGE.md
+++ b/USAGE.md
@@ -321,7 +321,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - uses: PIsberg/vibetags/action/locked-files@v1.3.3
+      - uses: PIsberg/vibetags/action/locked-files@v1.3.4
 ```
 
 The action touches `.vibetags-locks` itself, rebuilds the PR head (so the report is never stale), and flags three things as inline PR annotations: edits inside a locked line range, removal of an `@AILocked` annotation line, and deletion of a file that contained `@AILocked`. Set `warn-only: true` to report without failing. See [action/locked-files/README.md](action/locked-files/README.md) for all inputs.

--- a/action/locked-files/README.md
+++ b/action/locked-files/README.md
@@ -34,7 +34,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - uses: PIsberg/vibetags/action/locked-files@v1.3.3
+      - uses: PIsberg/vibetags/action/locked-files@v1.3.4
         with:
           build-command: mvn -B -q compile
 ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.4] - 2026-09-10
+
 ### Fixed
 
 - One module's guardrails are no longer written twice when the leftover sidecar is the newer file
@@ -35,6 +37,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   specific to certain annotations and is nothing of the kind. `-Avibetags.module` with a stable
   name remains the way to rule the whole class out, by pinning the identity so the fallback is
   never produced.
+
+- The consumer sweep no longer skips the one downstream repository it can least afford to lose
+  (issue #617). `tools/consumer-sweep.sh` refused any repo with a dirty working tree, and that
+  guard ran before the branch that sweeps a contended repo in a `git worktree`. A worktree sweep
+  builds a separate directory from `origin/main` and never touches the contended checkout, and a
+  repo is on that list precisely because someone else works in it, so a dirty checkout is its
+  normal state. The sweep's footer prints identically either way, so covering four repos of five
+  read exactly like a complete run.
+
+- Release notes are extracted by one script that refuses to emit a truncated file (issue #619).
+  The extraction was an inline `awk` range, and an awk range tests its end pattern against the
+  record that opened it, so `/^## \[/` closed the range on the section heading and the command
+  emitted the correct release title with the whole body missing. `gh release create --notes-file`
+  accepts that without complaint, by which point the tag exists and the deploy has fired.
+  `tools/release-notes.sh` is now the only implementation, both `docs/RELEASING.md` and the
+  release skill call it, and it fails rather than hand fewer than five lines to a step that
+  cannot be undone.
+
+### Changed
+
+- `async-test-lib` moves from 1.11.2 to 1.12.0 (#623). Test scope only; nothing ships to
+  consumers from it.
 
 ## [1.3.3] - 2026-09-10
 
@@ -4108,7 +4132,8 @@ The `writeFileIfChanged_smallWrite` and `writeFileIfChanged_largeWrite` columns 
 - API and generated file formats may change before 1.0.0.
 - Publishes to both GitHub Packages and Maven Central (Sonatype OSSRH).
 
-[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.3.3...HEAD
+[Unreleased]: https://github.com/PIsberg/vibetags/compare/v1.3.4...HEAD
+[1.3.4]: https://github.com/PIsberg/vibetags/compare/v1.3.3...v1.3.4
 [1.3.3]: https://github.com/PIsberg/vibetags/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/PIsberg/vibetags/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/PIsberg/vibetags/compare/v1.3.0...v1.3.1

--- a/examples/all-tiers/pom.xml
+++ b/examples/all-tiers/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.3.3</vibetags.bom.version>
+    <vibetags.bom.version>1.3.4</vibetags.bom.version>
     <!-- Flipped to true by CI so the build verifies the committed guardrail files instead of
          rewriting them. See the README's "Verifying" section. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/basic/build.gradle
+++ b/examples/basic/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and annotation-processor configurations so neither needs an explicit version.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.4')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.4')
 
     // Annotations on compile, processor on the annotation-processor path only —
     // keeps the processor's slf4j/logback off the consumer's compile classpath.

--- a/examples/basic/pom.xml
+++ b/examples/basic/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. Bumping this one
              value rolls the processor and any future vibetags-* artifact in lockstep. -->
-        <vibetags.bom.version>1.3.3</vibetags.bom.version>
+        <vibetags.bom.version>1.3.4</vibetags.bom.version>
         <vibetags.log.path>vibetags.log</vibetags.log.path>
       <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,

--- a/examples/enforcing/pom.xml
+++ b/examples/enforcing/pom.xml
@@ -25,7 +25,7 @@
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- BOM is the single source of truth for vibetags-* versions. -->
-        <vibetags.bom.version>1.3.3</vibetags.bom.version>
+        <vibetags.bom.version>1.3.4</vibetags.bom.version>
         <!-- Enforcement is ON for every build of this example: the three provable families
              must match the committed .vibetags-baseline or compilation fails. That is the
              point of the example, so it is not hidden behind a profile. -->

--- a/examples/gradle-composite/app/build.gradle
+++ b/examples/gradle-composite/app/build.gradle
@@ -16,8 +16,8 @@ repositories {
 
 dependencies {
     implementation 'se.deversity.vibetags.example:vibetags-example-gradle-composite-lib'
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.4')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.4')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-composite/lib/build.gradle
+++ b/examples/gradle-composite/lib/build.gradle
@@ -15,8 +15,8 @@ repositories {
 }
 
 dependencies {
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.4')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.4')
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'
 }

--- a/examples/gradle-flat/app/build.gradle
+++ b/examples/gradle-flat/app/build.gradle
@@ -21,8 +21,8 @@ allprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.4')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.4')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-multimodule/build.gradle
+++ b/examples/gradle-multimodule/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.4')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.4')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/gradle-shared-buildfile/build.gradle
+++ b/examples/gradle-shared-buildfile/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     }
 
     dependencies {
-        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
-        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+        implementation platform('se.deversity.vibetags:vibetags-bom:1.3.4')
+        annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.4')
         compileOnly 'se.deversity.vibetags:vibetags-annotations'
         annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     }

--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.apache.groovy:groovy:5.1.0'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.4')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.4')
 
     // Annotations on compile, processor on the annotation-processor path only.
     compileOnly 'se.deversity.vibetags:vibetags-annotations'

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -18,8 +18,8 @@ repositories {
 dependencies {
     // BOM is the single source of truth for vibetags-* versions. Apply it to both the
     // compile and kapt configurations so neither needs an explicit version.
-    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.3"))
-    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.3"))
+    implementation(platform("se.deversity.vibetags:vibetags-bom:1.3.4"))
+    kapt(platform("se.deversity.vibetags:vibetags-bom:1.3.4"))
 
     // Annotations on compile, processor on the kapt path only — keeps the processor's
     // slf4j/logback off the consumer's compile classpath. compileOnly is enough:

--- a/examples/multimodule-indexed/pom.xml
+++ b/examples/multimodule-indexed/pom.xml
@@ -37,7 +37,7 @@
     <!-- The indexed root (.vibetags-root-index) needs RC6+. The merged-layout sibling
          example pins the last release (RC5); this one pins the in-development version so
          CI resolves it from the freshly-installed reactor build. Bump on release. -->
-    <vibetags.bom.version>1.3.3</vibetags.bom.version>
+    <vibetags.bom.version>1.3.4</vibetags.bom.version>
     <!-- The diagnostic channel. INFO reports what ran; `mvn compile
          -Dvibetags.log.level=DEBUG` adds one structured event per decision to vibetags.log,
          which is how you find out why a file was or was not rewritten. -->

--- a/examples/multimodule/pom.xml
+++ b/examples/multimodule/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vibetags.bom.version>1.3.3</vibetags.bom.version>
+    <vibetags.bom.version>1.3.4</vibetags.bom.version>
     <!-- Flipped to true by CI (and by anyone running `mvn compile -Dvibetags.check=true`) so the
          build verifies the committed guardrail files instead of rewriting them. -->
     <vibetags.check>false</vibetags.check>

--- a/examples/scala/build.gradle
+++ b/examples/scala/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'org.scala-lang:scala-library:2.13.18'
 
     // BOM is the single source of truth for vibetags-* versions.
-    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
-    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+    implementation platform('se.deversity.vibetags:vibetags-bom:1.3.4')
+    annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.4')
 
     compileOnly 'se.deversity.vibetags:vibetags-annotations'
     annotationProcessor 'se.deversity.vibetags:vibetags-processor'

--- a/tools/demo/pom.xml
+++ b/tools/demo/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vibetags.bom.version>1.3.3</vibetags.bom.version>
+        <vibetags.bom.version>1.3.4</vibetags.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/vibetags-annotations/build.gradle
+++ b/vibetags-annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'se.deversity.vibetags'
-version = '1.3.3'
+version = '1.3.4'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -19,7 +19,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-annotations'
-            version = '1.3.3'
+            version = '1.3.4'
             from components.java
 
             pom {

--- a/vibetags-annotations/pom.xml
+++ b/vibetags-annotations/pom.xml
@@ -43,8 +43,8 @@
             &lt;/dependency&gt;
 
         Gradle:
-            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.3'
-            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.3'
+            compileOnly 'se.deversity.vibetags:vibetags-annotations:1.3.4'
+            annotationProcessor 'se.deversity.vibetags:vibetags-processor:1.3.4'
     </description>
 
     <build>

--- a/vibetags-bom/pom.xml
+++ b/vibetags-bom/pom.xml
@@ -44,8 +44,8 @@
             &lt;/dependencyManagement&gt;
 
         Gradle:
-            implementation platform('se.deversity.vibetags:vibetags-bom:1.3.3')
-            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.3')
+            implementation platform('se.deversity.vibetags:vibetags-bom:1.3.4')
+            annotationProcessor platform('se.deversity.vibetags:vibetags-bom:1.3.4')
             compileOnly 'se.deversity.vibetags:vibetags-annotations'
             annotationProcessor 'se.deversity.vibetags:vibetags-processor'
     </description>

--- a/vibetags-cli/pom.xml
+++ b/vibetags-cli/pom.xml
@@ -28,7 +28,7 @@
         reports the project's VibeTags health — build-tool wiring, active platforms,
         marker integrity. Run it without installing anything:
 
-            jbang se.deversity.vibetags:vibetags-cli:1.3.3 init --list
+            jbang se.deversity.vibetags:vibetags-cli:1.3.4 init --list
 
         The platform list and marker rules are read from vibetags-processor, so this
         tool cannot drift from what the processor actually does.

--- a/vibetags-parent/pom.xml
+++ b/vibetags-parent/pom.xml
@@ -69,7 +69,7 @@
         <!-- The VibeTags release version. Bump THIS and nothing else: every module takes its
              own version, its sibling dependencies and its BOM entries from it. Resolved into
              the deployed POMs by flatten-maven-plugin, so consumers never see the property. -->
-        <revision>1.3.3</revision>
+        <revision>1.3.4</revision>
 
         <!-- release, not source/target: on a JDK newer than 21 (CI builds 21, 25 and 26)
              source/target compiles against the *running* JDK's API and javac warns that the

--- a/vibetags/build.gradle
+++ b/vibetags/build.gradle
@@ -35,7 +35,7 @@ def pomVersion = { String property ->
 }
 
 group = 'se.deversity.vibetags'
-version = '1.3.3'
+version = '1.3.4'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -49,7 +49,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'se.deversity.vibetags'
             artifactId = 'vibetags-processor'
-            version = '1.3.3'
+            version = '1.3.4'
             from components.java
 
             pom {
@@ -107,7 +107,7 @@ repositories {
 dependencies {
     // Annotation classes the processor scans for; backwards-compatible transitive
     // dep so existing consumers still get the annotations via vibetags-processor.
-    api 'se.deversity.vibetags:vibetags-annotations:1.3.3'
+    api 'se.deversity.vibetags:vibetags-annotations:1.3.4'
 
     // JSpecify null annotations (@NullMarked, @Nullable, @NonNull)
     implementation "org.jspecify:jspecify:${pomVersion('jspecify.version')}"


### PR DESCRIPTION
Bumps `<revision>` from 1.3.3 to 1.3.4 and closes the `[Unreleased]` section as
`[1.3.4] - 2026-09-10`.

A patch release, and this time uncontroversially so: everything in it is a fix.

## What is in it

- **#621** — the one that matters to consumers. A repository whose sources live in one subproject
  below the VibeTags root could hold two sidecars for what is really one module, and the prune
  meant to retire the leftover consulted timestamps before containment. With the leftover the
  fresher file, nothing was retired in either direction, and every element the two regions shared
  was written twice, byte-identical, into every granular rule file and every aggregate. Exit code
  0, nothing on the console.
- **#617** — the consumer sweep no longer skips the one downstream repository that commits its
  sidecars. Its dirty-tree guard ran ahead of the worktree branch, so the repo whose sweep cannot
  touch its checkout was the one refused for having a dirty checkout.
- **#619** — release notes come from one script that refuses to emit a truncated file. The
  extraction was an inline `awk` range that returned the correct release title with the whole body
  missing, which `gh release create --notes-file` accepts without complaint.
- **#623** — `async-test-lib` 1.11.2 → 1.12.0, test scope only.

Both tooling fixes were exercised by this release rather than merely shipped in it.

## Verification

Everything below ran before the bump was committed. A skipped gate is listed as skipped.

| Gate | Result |
|---|---|
| `vibetags` `mvn clean install -Pe2e` | **2679 tests, 0 failures, 0 errors, 4 skipped** — also covers the inherited #623 bump |
| `vibetags-annotations`, `vibetags-bom`, `vibetags-cli` | BUILD SUCCESS |
| `examples/basic` `compile`, `examples/multimodule` `test-compile`, `examples/multimodule-indexed` `compile` | BUILD SUCCESS, no generated file moved |
| `.github/actions/verify-generated-files`, run locally from `examples/basic` | exit 0 |
| `tools/release-notes.sh 1.3.4` | 52 lines, opens on the heading, no bleed into the previous entry |
| `pre-commit` | gitleaks, end-of-file-fixer, trailing-whitespace passed; `checkstyle` **skipped** (Docker hook, no daemon on this host). Checkstyle binds to Maven `validate` and ran green above. |

### Consumer sweep

`tools/consumer-sweep.sh 1.3.4` against a locally installed 1.3.4. Five rows for five entries in
`CONSUMERS`, counted rather than taken from the footer.

| repo | build | result | guardrail drift |
|---|---|---|---|
| blindbean | Maven `verify` | pass | none |
| codekarta | Maven `verify` + Gradle `build` | pass | none |
| common-license-lib | Maven `verify` + Gradle `build` | pass | none |
| skill3 | Gradle `build` | pass | none |
| async-test-lib | Maven `verify` + Gradle `build` | pass | none |

Drift is counted from `git diff --numstat`, never from `git status`, which on Windows lists a file
whose line endings moved even when its text did not.

**#621 moves no consumer's committed output**, because none of the five was in the duplicated-region
state. That is worth saying explicitly: the fix repairs a state you have to already be in, so an
upgrade is not expected to produce a diff. If your repository *is* in that state, the first build
after upgrading will delete the duplicate region, and the resulting diff is the fix landing.

Two rows needed the usual hand-finishing, neither about VibeTags:

- **async-test-lib** was **swept rather than skipped** — the #617 fix working in the exact situation
  it was written for, on its first release since. Its three committed `.vibetags-mod-*` sidecars come
  back byte-identical to `HEAD` once CRLF is stripped, which is the strongest single drift signal
  available, since it is the only consumer that commits them.
- **codekarta** reported FAIL on this host: its enforcer requires JDK 21–25 and `JAVA_HOME` here is
  JDK 26, so it dies in `validate` before the compiler runs. Rerun on the installed JDK 21: Maven
  exit 0, Gradle exit 0, no drift.

## Next

Merging this and cutting the release were both explicitly requested; the release notes are already
extracted and will be published from `tools/release-notes.sh` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lp3ZaoNQYPv9NWdXQuLEn
