### PR TITLE
Stop a .clinerules/ directory activating the single-file Cline service

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,7 +39,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a link four lines below said 49. `ProjectFactsConsistencyTest` pinned the first and not the
   second.
 
+### Fixed
+
+- A `.clinerules/` **directory** no longer activates the single-file `cline` service. Cline's
+  current documentation describes `.clinerules/` as a directory of rule files and does not mention
+  the single file VibeTags writes, so a user following those docs created a directory at exactly the
+  path the `cline` service maps to. `ServiceRegistry.resolveActiveServices` opted in on
+  `Files.exists`, which is true for a directory, and the writer was then handed a directory to write
+  a regular file over.
+
+  The fix reads the entry's type: a granular service needs a directory, everything else needs a
+  regular file. A path cannot be both, so its type is an unambiguous signal for which of the two the
+  user meant. The `_granular` suffix was already load-bearing in `PlatformRendererRegistry` and
+  `GuardrailContentBuilder`, so this reads an existing convention rather than inventing one.
+
+  `ClineDirectoryOptInTest` was written first and confirmed red against `main`. VibeTags still does
+  not write the directory form; #642 says what that needs and why it was not folded into a bug fix.
+
 ### Changed
+
+- Four generated outputs are now documented as naming a tool that has moved on, in
+  [PLATFORMS.md](PLATFORMS.md). None is removed and no existing project changes: `gemini_instructions.md`
+  (no Google documentation describes any product reading it), `.cody/config.json` and `.codyignore`
+  (Cody Free and Pro retired 23 July 2025; the successor Amp reads `AGENTS.md`),
+  `.supermavenignore` (standalone product discontinued November 2025; the technology is in Cursor
+  Tab and VibeTags writes `.cursorignore`), and the single-file `.clinerules`.
+
+  Removing a service stops an opted-in consumer's file regenerating, which leaves it looking current
+  while drifting from the annotations -- worse than a file nobody reads. Removal is a breaking
+  change and belongs to a major version; #641 holds the decision and the steps.
+
 
 - `AtomicityValidator` now runs, in a surefire fork of its own (#629). The async detectors were
   switched on earlier, but that one needs bytecode instrumentation and the build attached no

--- a/docs/PLATFORMS.md
+++ b/docs/PLATFORMS.md
@@ -168,3 +168,23 @@ upside. Its `ignore_patterns` key would collide the same way, and unlike aider's
 nothing that `.gemini/styleguide.md` does not already deliver: the style guide is where Gemini Code
 Assist takes its review rules from, and it is Markdown, so the marker merge is clean. Issue #636
 records the decision.
+
+### Four outputs whose tool has moved on
+
+These are still written, and nothing about an existing project changes. They are recorded here
+because the file-presence opt-in model means a path VibeTags names is a path a user may create, and
+three of these four name a tool that no longer reads them. None is removed: removing a service stops
+an opted-in consumer's file regenerating, which is a silent staleness worse than a file nobody
+reads. Removal belongs to a major version, tracked in #641.
+
+| Output | Status | Evidence |
+|---|---|---|
+| `gemini_instructions.md` | **No vendor source found.** Google documents `GEMINI.md` for the Gemini CLI (configurable via `contextFileName`), `.idx/airules.md` for Firebase, and `.gemini/styleguide.md` for the GitHub reviewer. This path appears in none of them. It sits in 55 public repositories, none of them VibeTags consumers, so people do write it -- but no documentation says anything reads it. | [Gemini CLI context docs](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/gemini-md.md) |
+| `.cody/config.json`, `.codyignore` | **Product retired.** Sourcegraph retired Cody Free and Pro on 23 July 2025; the successor, Amp, reads `AGENTS.md`, which VibeTags writes. 4 and 3 public repositories. | [Sourcegraph's announcement](https://sourcegraph.com/blog/changes-to-cody-free-pro-and-enterprise-starter-plans) |
+| `.supermavenignore` | **Product sunset.** Supermaven was acquired by Anysphere in November 2024 and the standalone product was discontinued in November 2025; its technology is inside Cursor Tab, and VibeTags writes `.cursorignore`. 5 public repositories. | [Cursor's announcement](https://cursor.com/blog/supermaven) |
+| `.clinerules` (the single file) | **Legacy shape.** [Cline's current rules documentation](https://docs.cline.bot/features/cline-rules) documents a `.clinerules/` **directory** and does not mention the file. Cline also reads `.cursorrules`, `.windsurfrules` and `AGENTS.md`, all of which VibeTags writes, so no Cline user loses guardrails over this. #642 covers writing the directory form. |
+
+The lesson is the one #611 recorded from the other direction. A platform list is not a thing you
+write once: the tools underneath it are renamed, acquired and retired, and a generated file
+outlives the product it was generated for. Nothing in the build can notice that, which is why it is
+checked by hand and written down here.

--- a/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ServiceRegistry.java
+++ b/vibetags/src/main/java/se/deversity/vibetags/processor/internal/ServiceRegistry.java
@@ -233,7 +233,7 @@ public final class ServiceRegistry {
     public static Set<String> resolveActiveServices(Map<String, Path> allServiceFiles) {
         Set<String> active = new HashSet<>();
         allServiceFiles.forEach((key, path) -> {
-            if (OPT_IN_KEYS.contains(key) && Files.exists(path)) {
+            if (OPT_IN_KEYS.contains(key) && optedIn(key, path)) {
                 active.add(key);
             }
         });
@@ -245,6 +245,27 @@ public final class ServiceRegistry {
             active.remove("codex");
         }
         return active;
+    }
+
+    /**
+     * True when {@code path} is the <em>kind</em> of filesystem entry the service writes.
+     *
+     * <p>This used to be a bare {@code Files.exists}, and the shape of that bug is worth keeping
+     * written down. Two platforms map a single-file service and a directory service to the same
+     * path, because the vendor changed which one it reads: Cline documents {@code .clinerules/} as
+     * a directory of rule files and no longer documents the single {@code .clinerules} file
+     * VibeTags wrote. A user following the current docs creates the directory, {@code exists()} is
+     * true for it, the file service activates, and the writer is handed a directory to write a
+     * regular file over.
+     *
+     * <p>A path cannot be both, so the entry's type is an unambiguous signal for which of the two
+     * the user meant. Granular services write a directory; everything else writes a file. The
+     * {@code _granular} suffix is already load-bearing elsewhere — {@code PlatformRendererRegistry}
+     * routes on it and {@code GuardrailContentBuilder} filters on it — so this reads an existing
+     * convention rather than inventing a second one.
+     */
+    private static boolean optedIn(String key, Path path) {
+        return key.endsWith("_granular") ? Files.isDirectory(path) : Files.isRegularFile(path);
     }
 
     /**

--- a/vibetags/src/test/java/se/deversity/vibetags/processor/ClineDirectoryOptInTest.java
+++ b/vibetags/src/test/java/se/deversity/vibetags/processor/ClineDirectoryOptInTest.java
@@ -1,0 +1,41 @@
+package se.deversity.vibetags.processor;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import se.deversity.vibetags.processor.internal.ServiceRegistry;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Cline's current documentation describes {@code .clinerules/} as a <em>directory</em> of rule
+ * files and does not mention the single file VibeTags writes. A user following those docs creates
+ * a directory at exactly the path VibeTags maps the {@code cline} service to.
+ *
+ * <p>{@code resolveActiveServices} opts a service in on {@link Files#exists}, which is true for a
+ * directory, so the aggregate service activates and the writer is then asked to write a regular
+ * file over a directory.
+ */
+@Tag("e2e")
+class ClineDirectoryOptInTest {
+
+    @Test
+    void aClinerulesDirectoryDoesNotActivateTheSingleFileService(@TempDir Path root) throws IOException {
+        Files.createDirectories(root.resolve(".clinerules"));
+
+        Map<String, Path> serviceFiles = ServiceRegistry.buildServiceFileMap(root);
+        Set<String> active = ServiceRegistry.resolveActiveServices(serviceFiles);
+
+        assertFalse(active.contains("cline"),
+            "a .clinerules/ directory is Cline's current documented shape, not an opt-in to the "
+                + "single .clinerules file. Activating the file service points the writer at a "
+                + "directory.");
+    }
+}


### PR DESCRIPTION
A live defect found while auditing whether VibeTags' own paths are still the paths its tools read.

## The bug

[Cline's current rules documentation](https://docs.cline.bot/features/cline-rules) describes
`.clinerules/` as a **directory** of rule files ("Cline processes all `.md` and `.txt` files inside
`.clinerules/`") and does not mention the single `.clinerules` file VibeTags writes. A user
following those docs creates a directory at exactly the path the `cline` service maps to.

`ServiceRegistry.resolveActiveServices` opted a service in on `Files.exists`, which is true for a
directory. So the single-file service activated and the writer was handed a directory to write a
regular file over.

`ClineDirectoryOptInTest` was written first and confirmed red against `main`:

```
a .clinerules/ directory is Cline's current documented shape, not an opt-in to the single
.clinerules file. Activating the file service points the writer at a directory.
==> expected: <false> but was: <true>
```

## The fix

`optedIn(key, path)` matches the entry's type to what the service writes: a granular service needs a
directory, everything else needs a regular file. A path cannot be both, so which one exists is an
unambiguous signal for which of the two the user meant. The `_granular` suffix was already
load-bearing in `PlatformRendererRegistry` and `GuardrailContentBuilder`, so this reads an existing
convention rather than inventing a second one.

## What this PR deliberately does not do

VibeTags still does not **write** Cline's directory form. The obvious implementation, a
`cline_granular` key mapped to the same path with the entry's type selecting between them, was
implemented and then reverted, because it broke three separate assumptions at once:

1. `ProjectFactsConsistencyTest` derives the config-file count from `ServiceRegistry` and counted
   the shared path once as a file, so the README count could not be stated correctly.
2. `buildServiceFileMap_containsAllExpectedKeys` pins the key set.
3. `testResolveActiveServices_allFilesExist_allServicesActive` creates every mapped path as a
   regular file and threw `FileAlreadyExistsException` on the second key. That helper cannot express
   "these two keys are mutually exclusive" — and it is worth noting it creates a regular file at
   `.cursor/rules` and every other granular path today, and only got away with it because the opt-in
   accepted either type.

Two service keys at one path is a shape this model does not have. Bending three tests to it inside a
bug fix was the wrong trade, so #642 records what it would take. No Cline user is left without
guardrails meanwhile: Cline also reads `.cursorrules`, `.windsurfrules` and `AGENTS.md`, all of
which VibeTags writes.

## Four outputs whose tool has moved on

Documented in [PLATFORMS.md](docs/PLATFORMS.md), **none removed**, no existing project changes:

| Output | Status |
|---|---|
| `gemini_instructions.md` | No Google documentation describes any product reading this path. The three documented Gemini-family files are `GEMINI.md`, `.idx/airules.md` and `.gemini/styleguide.md`, and VibeTags writes all three. 55 public repos carry it, none of them VibeTags consumers, so people write it — nothing is documented as reading it. |
| `.cody/config.json`, `.codyignore` | [Cody Free and Pro retired 23 July 2025](https://sourcegraph.com/blog/changes-to-cody-free-pro-and-enterprise-starter-plans). The successor, Amp, reads `AGENTS.md`. 4 and 3 public repos. |
| `.supermavenignore` | [Standalone product discontinued November 2025](https://cursor.com/blog/supermaven) after the Anysphere acquisition; the technology is inside Cursor Tab and VibeTags writes `.cursorignore`. 5 public repos. |
| `.clinerules` (single file) | Legacy shape, per the docs above. |

Removing a service stops an opted-in consumer's file regenerating, leaving it in their repo looking
current while drifting from the annotations. That is worse than a file nobody reads: silently wrong
beats merely useless the wrong way round. Removal is breaking and belongs to a major version, so
**#641** holds the decision and the steps.

#641 also raises a standing question worth a view: nothing in the build can notice that a vendor
retired a product, so the platform list is only as current as the last manual check. Whether that
check gets a cadence — a step in the release skill, say — is a call for you.

## Verification

| Gate | Result |
|---|---|
| `mvn -B verify -Pe2e` | green, 2677 tests; checkstyle 0 violations, PMD and SpotBugs both ran |
| failing-test-first | `ClineDirectoryOptInTest` confirmed red on `main` before the fix (output above) |
| pre-commit | gitleaks, end-of-file-fixer, trailing-whitespace green. **checkstyle hook skipped** (Docker not running here); covered by the Maven run |
| Architecture Diagram Drift | no new classes, so it should stay green |

No counts change, so this one should not conflict with #637, #638 or #640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrgKxSGLM8reDgs8nfXZ6g
